### PR TITLE
feat(plugins): PostgresSink for metrics (closes #1)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -56,7 +56,7 @@ v0.1 之前必须满足：
 
 ## Adapter 候选
 
-- [ ] `PostgresSink`（metrics）：peerDep on `pg`，提供 DDL 示例。
+- [x] `PostgresSink`（metrics）：通过最小 `PgClient` 注入（零 `pg` 依赖，与 `PostgresSessionStore` 同构），导出 `POSTGRES_METRICS_SINK_DDL`，子路径 `@harness-pi/plugins/metrics/sinks/postgres`。
 - [ ] `OtelSink`（metrics）：peerDep on `@opentelemetry/api`。
 
 触发条件：真实部署需要 dashboard 查询或统一 observability stack。

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -29,6 +29,10 @@
     "./metrics/sinks/ndjson-file": {
       "types": "./dist/metrics/sinks/ndjson-file.d.ts",
       "default": "./dist/metrics/sinks/ndjson-file.js"
+    },
+    "./metrics/sinks/postgres": {
+      "types": "./dist/metrics/sinks/postgres.d.ts",
+      "default": "./dist/metrics/sinks/postgres.js"
     }
   },
   "files": ["dist", "src", "README.md", "!**/__tests__/**", "!**/*.test.*"],
@@ -46,6 +50,7 @@
   "devDependencies": {
     "typescript": "^5.6.0",
     "vitest": "^2.1.0",
-    "@types/node": "^22.0.0"
+    "@types/node": "^22.0.0",
+    "pg-mem": "^3.0.14"
   }
 }

--- a/packages/plugins/src/__tests__/postgres-sink.test.ts
+++ b/packages/plugins/src/__tests__/postgres-sink.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { newDb } from "pg-mem";
+import {
+  PostgresSink,
+  POSTGRES_METRICS_SINK_DDL,
+  type PgClient,
+} from "../metrics/sinks/postgres.js";
+
+/**
+ * 用 pg-mem（内存 Postgres 模拟器，真解析+执行 SQL）跑 PostgresSink 的真实 SQL 覆盖——
+ * 与 PostgresSessionStore 的测试同构，不手搓 fake DB。失败/重排队路径用一个 fail-once 包装
+ * client（pg-mem 不便模拟瞬时写失败），底层仍委托给 pg-mem。
+ */
+function makePgMemClient(): PgClient {
+  const db = newDb();
+  const pg = db.adapters.createPg();
+  return new pg.Pool() as unknown as PgClient;
+}
+
+describe("PostgresSink", () => {
+  it("migrate runs each DDL statement once", async () => {
+    const calls: string[] = [];
+    const client: PgClient = {
+      async query(text) {
+        calls.push(text);
+        return { rows: [] };
+      },
+    };
+    await new PostgresSink({ client }).migrate();
+    const stmts = POSTGRES_METRICS_SINK_DDL.split(";")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    expect(calls).toHaveLength(stmts.length);
+    expect(calls[0]).toContain("CREATE TABLE IF NOT EXISTS metrics_events");
+  });
+
+  it("flush batch-inserts events with promoted columns + jsonb payload", async () => {
+    const client = makePgMemClient();
+    const sink = new PostgresSink({ client });
+    await sink.migrate();
+
+    sink.enqueue({
+      kind: "llm.called",
+      ts: 1,
+      sessionId: "s1",
+      turnIdx: 2,
+      workItemId: "w1",
+      durationMs: 42,
+    });
+    sink.enqueue({ kind: "tool.called", ts: 2, sessionId: "s1", toolName: "read" });
+    await sink.flush();
+
+    const res = await client.query(
+      "SELECT kind, session_id, turn_idx, work_item_id, ts, payload FROM metrics_events ORDER BY ts",
+    );
+    expect(res.rows).toHaveLength(2);
+    expect(res.rows[0]).toMatchObject({
+      kind: "llm.called",
+      session_id: "s1",
+      turn_idx: 2,
+      work_item_id: "w1",
+    });
+    const payload0 =
+      typeof res.rows[0]!.payload === "string"
+        ? JSON.parse(res.rows[0]!.payload as string)
+        : res.rows[0]!.payload;
+    // promoted columns are stripped out of the payload (no duplication)
+    expect(payload0).toEqual({ durationMs: 42 });
+    expect(res.rows[1]).toMatchObject({
+      kind: "tool.called",
+      session_id: "s1",
+      turn_idx: null,
+      work_item_id: null,
+    });
+  });
+
+  it("requeues the batch on write failure, then recovers", async () => {
+    const inner = makePgMemClient();
+    let failOnce = true;
+    const flaky: PgClient = {
+      async query(text, params) {
+        if (failOnce && text.startsWith("INSERT")) {
+          failOnce = false;
+          throw new Error("transient write failure");
+        }
+        return inner.query(text, params);
+      },
+    };
+    const sink = new PostgresSink({ client: flaky });
+    await sink.migrate();
+
+    sink.enqueue({ kind: "session.started", ts: 1, sessionId: "s2" });
+    await sink.flush(); // INSERT throws once -> batch requeued at head
+    expect(sink.stats().failed).toBeGreaterThan(0);
+    expect(sink.stats().pending).toBe(1);
+
+    await sink.flush(); // retry succeeds
+    expect(sink.stats().pending).toBe(0);
+    expect(sink.stats().flushed).toBe(1);
+
+    const res = await inner.query("SELECT kind FROM metrics_events");
+    expect(res.rows).toHaveLength(1);
+  });
+});

--- a/packages/plugins/src/metrics/sinks/postgres.ts
+++ b/packages/plugins/src/metrics/sinks/postgres.ts
@@ -1,0 +1,88 @@
+/**
+ * PostgresSink —— 把 metric events 批写进 Postgres，供 dashboard / 跨会话聚合查询。
+ *
+ * 与 `PostgresSessionStore` 同构：**本包零 `pg` 依赖**，通过最小 `PgClient` 接口注入查询能力，
+ * node-postgres 的 `Pool` / `Client` 天然满足它（`query(text, params) -> { rows }`）。调用方自带 `pg`。
+ * 继承 `BatchingSink`，复用批量 / 重试 / overflow 语义，只实现 `write(batch)`。
+ *
+ * 把 `kind / session_id / turn_idx / work_item_id / ts` 提升为可索引列（恒温器 / dashboard 按
+ * kind + 时间窗 + work-item 聚合），其余字段进 `payload` jsonb。DDL 见导出的
+ * `POSTGRES_METRICS_SINK_DDL`；`migrate()` 幂等执行它。详见 docs/07-adapters.md §3。
+ */
+
+import { BatchingSink, type BatchingSinkOptions } from "../batching-sink.js";
+import type { MetricEvent } from "../types.js";
+
+/** node-postgres 的 Pool/Client 满足的最小查询接口（与 PostgresSessionStore 同形）。 */
+export interface PgClient {
+  query(
+    text: string,
+    params?: unknown[],
+  ): Promise<{ rows: Array<Record<string, unknown>> }>;
+}
+
+/**
+ * 建表 DDL（幂等，分号分隔多条语句）。`migrate()` 按分号拆开逐条执行（兼容只支持单语句的 driver）。
+ * 索引列服务于「按 kind + 时间窗 + session/work-item 聚合」这一典型 dashboard / 恒温器查询。
+ */
+export const POSTGRES_METRICS_SINK_DDL = `
+CREATE TABLE IF NOT EXISTS metrics_events (
+  id           bigserial PRIMARY KEY,
+  kind         text   NOT NULL,
+  session_id   text,
+  turn_idx     integer,
+  work_item_id text,
+  ts           bigint NOT NULL,
+  payload      jsonb  NOT NULL DEFAULT '{}'::jsonb
+);
+CREATE INDEX IF NOT EXISTS idx_metrics_events_kind ON metrics_events (kind);
+CREATE INDEX IF NOT EXISTS idx_metrics_events_session ON metrics_events (session_id);
+CREATE INDEX IF NOT EXISTS idx_metrics_events_work_item ON metrics_events (work_item_id);
+CREATE INDEX IF NOT EXISTS idx_metrics_events_ts ON metrics_events (ts);
+`;
+
+export interface PostgresSinkOptions extends BatchingSinkOptions {
+  client: PgClient;
+}
+
+export class PostgresSink extends BatchingSink {
+  private readonly client: PgClient;
+
+  constructor(opts: PostgresSinkOptions) {
+    super(opts);
+    this.client = opts.client;
+  }
+
+  /** 执行建表 DDL（幂等）。首次使用前调一次。按分号拆成单条语句逐条执行。 */
+  async migrate(): Promise<void> {
+    for (const stmt of POSTGRES_METRICS_SINK_DDL.split(";")) {
+      const sql = stmt.trim();
+      if (sql.length > 0) await this.client.query(sql);
+    }
+  }
+
+  protected async write(batch: MetricEvent[]): Promise<void> {
+    if (batch.length === 0) return;
+    const tuples: string[] = [];
+    const params: unknown[] = [];
+    let p = 0;
+    for (const event of batch) {
+      const { kind, sessionId, turnIdx, ts, workItemId, ...payload } = event;
+      tuples.push(
+        `($${++p}, $${++p}, $${++p}, $${++p}, $${++p}, $${++p}::jsonb)`,
+      );
+      params.push(
+        kind,
+        sessionId ?? null,
+        turnIdx ?? null,
+        workItemId == null ? null : String(workItemId),
+        ts,
+        JSON.stringify(payload),
+      );
+    }
+    await this.client.query(
+      `INSERT INTO metrics_events (kind, session_id, turn_idx, work_item_id, ts, payload) VALUES ${tuples.join(", ")}`,
+      params,
+    );
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.19
+      pg-mem:
+        specifier: ^3.0.14
+        version: 3.0.14
       typescript:
         specifier: ^5.6.0
         version: 5.9.3


### PR DESCRIPTION
## What

Implements `PostgresSink` (metrics) — closes #1.

`PostgresSink extends BatchingSink`; `write(batch)` does a single multi-row INSERT with `kind / session_id / turn_idx / work_item_id / ts` promoted to indexed columns (the typical dashboard / 恒温器 query is "aggregate by kind over a time window per session / work-item") and the remaining event fields in a `jsonb` payload.

Follows `PostgresSessionStore` exactly: **zero `pg` dependency** — a minimal injected `PgClient` interface (node-postgres `Pool`/`Client` satisfies it), an exported idempotent `POSTGRES_METRICS_SINK_DDL`, and a `migrate()` that splits on `;`. New subpath export `@harness-pi/plugins/metrics/sinks/postgres`.

## Why

Driven by the first non-bidding-agent, production-like consumer (Engram): its `GovernanceController` (恒温器) reads five operational metrics over time windows, which needs metric events queryable in PG and aggregatable by `workItemId`. This is the `PostgresSink (metrics)` roadmap candidate — its trigger condition ("real deployment needs dashboard queries / unified observability") is now met.

## Tests

- **pg-mem** (real in-memory PG) for migrate + batch insert + read-back of promoted columns and jsonb payload — same approach as the `PostgresSessionStore` tests.
- a fail-once `PgClient` wrapper for the `BatchingSink` requeue-on-failure path.
- `pnpm -r build` + `pnpm -r typecheck` (all packages) + `pnpm --filter @harness-pi/plugins test` (197 tests) green.

## Notes

- Real-PG integration test (à la `postgres-session-store.integration.test.ts`) left as a follow-up.
- Docs: ticked the `roadmap.md` checkbox; a `docs/07-adapters.md` blurb can follow.

Closes #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
