### PR TITLE
fix(plugins): PostgresSink follow-ups — harden write(), export parity, composite indexes (#5 #6 #7)

### DIFF
--- a/docs/07-adapters.md
+++ b/docs/07-adapters.md
@@ -288,23 +288,25 @@ npm install @harness-pi/plugins pg
 # 然后才能 import { PostgresSink } from "@harness-pi/plugins/metrics/sinks/postgres"
 ```
 
-**Schema 不打包**：
+**Schema（包内提供 DDL）**：
 
-我们**不**在 plugins 包里 ship migration / DDL。用户自己建表（DDL 在文档示例里给）。理由：DDL 跟用户的 migration 工具（drizzle/prisma/raw SQL）耦合，强行给反而困扰。
+PostgresSink 导出幂等的 `POSTGRES_METRICS_SINK_DDL` 并提供 `migrate()`（按 `;` 拆条执行）——与 `PostgresSessionStore` 同构，**本包零 `pg` 依赖**（注入 `PgClient`，node-postgres 的 `Pool`/`Client` 满足）。首次使用前 `await sink.migrate()` 建表即可；也可以把这段 DDL 接进你自己的 migration 工具（drizzle/prisma/raw SQL）。
 
-参考 DDL（在 README 或本 doc 给示例）：
+DDL（`ts` 用 `bigint` = epoch 毫秒，对齐 `MetricEvent.ts: number`；索引按「等值过滤列 + 时间」复合，服务「按 kind + 时间窗 + session/work-item 聚合」的典型查询）：
 
 ```sql
-CREATE TABLE metrics_events (
-  id BIGSERIAL PRIMARY KEY,
-  kind TEXT NOT NULL,
-  session_id TEXT,
-  turn_idx INTEGER,
-  ts TIMESTAMPTZ NOT NULL,
-  payload JSONB NOT NULL
+CREATE TABLE IF NOT EXISTS metrics_events (
+  id           BIGSERIAL PRIMARY KEY,
+  kind         TEXT   NOT NULL,
+  session_id   TEXT,
+  turn_idx     INTEGER,
+  work_item_id TEXT,
+  ts           BIGINT NOT NULL,
+  payload      JSONB  NOT NULL DEFAULT '{}'::jsonb
 );
-CREATE INDEX idx_metrics_session_ts ON metrics_events (session_id, ts);
-CREATE INDEX idx_metrics_kind_ts ON metrics_events (kind, ts);
+CREATE INDEX IF NOT EXISTS idx_metrics_events_kind_ts ON metrics_events (kind, ts);
+CREATE INDEX IF NOT EXISTS idx_metrics_events_session_kind_ts ON metrics_events (session_id, kind, ts);
+CREATE INDEX IF NOT EXISTS idx_metrics_events_work_item_kind_ts ON metrics_events (work_item_id, kind, ts);
 ```
 
 ### 4.4 OtelSink（peerDep on `@opentelemetry/api` + 一个 exporter，v0.x 候选）

--- a/packages/plugins/src/__tests__/postgres-sink.test.ts
+++ b/packages/plugins/src/__tests__/postgres-sink.test.ts
@@ -101,4 +101,60 @@ describe("PostgresSink", () => {
     const res = await inner.query("SELECT kind FROM metrics_events");
     expect(res.rows).toHaveLength(1);
   });
+
+  it("never loses events with non-serializable payloads (BigInt / circular)", async () => {
+    const client = makePgMemClient();
+    const sink = new PostgresSink({ client });
+    await sink.migrate();
+    const circular: Record<string, unknown> = { name: "c" };
+    circular.self = circular;
+    sink.enqueue({ kind: "custom", ts: 1, big: BigInt(42), circular });
+    await sink.flush();
+    expect(sink.stats().pending).toBe(0); // not stuck in an infinite requeue loop
+    expect(sink.stats().flushed).toBe(1);
+    const res = await client.query("SELECT payload FROM metrics_events");
+    expect(res.rows).toHaveLength(1);
+    const payload =
+      typeof res.rows[0]!.payload === "string"
+        ? JSON.parse(res.rows[0]!.payload as string)
+        : res.rows[0]!.payload;
+    expect(payload.big).toBe("42"); // BigInt coerced to string
+    expect(payload.circular).toEqual({ name: "c", self: "[Circular]" });
+  });
+
+  it("chunks large batches so no INSERT exceeds Postgres' bind-parameter cap", async () => {
+    const insertParamCounts: number[] = [];
+    const client: PgClient = {
+      async query(text, params) {
+        if (text.startsWith("INSERT")) insertParamCounts.push((params ?? []).length);
+        return { rows: [] };
+      },
+    };
+    // batchSize/bufferOverflow high enough that enqueue neither auto-flushes nor drops before flush()
+    const sink = new PostgresSink({ client, batchSize: 100_000, bufferOverflow: 100_000 });
+    const N = 10_001; // one past MAX_ROWS_PER_INSERT (10_000) -> forces a second chunk
+    for (let i = 0; i < N; i++) sink.enqueue({ kind: "x", ts: i });
+    await sink.flush();
+    expect(insertParamCounts).toHaveLength(2);
+    expect(Math.max(...insertParamCounts)).toBeLessThanOrEqual(65535);
+    // every row written, 6 binds each (no rows dropped, no chunk over the cap)
+    expect(insertParamCounts.reduce((a, b) => a + b, 0)).toBe(N * 6);
+  });
+
+  it("DDL builds composite indexes matching the kind + time-window + session/work-item pattern", () => {
+    expect(POSTGRES_METRICS_SINK_DDL).toContain("(kind, ts)");
+    expect(POSTGRES_METRICS_SINK_DDL).toContain("(session_id, kind, ts)");
+    expect(POSTGRES_METRICS_SINK_DDL).toContain("(work_item_id, kind, ts)");
+  });
+});
+
+describe("PostgresSink export parity", () => {
+  it("is re-exported from the metrics barrel and the package root (like MemorySink/NdjsonFileSink)", async () => {
+    const metricsBarrel = await import("../metrics/index.js");
+    const rootBarrel = await import("../index.js");
+    expect(typeof metricsBarrel.PostgresSink).toBe("function");
+    expect(typeof metricsBarrel.POSTGRES_METRICS_SINK_DDL).toBe("string");
+    expect(typeof rootBarrel.PostgresSink).toBe("function");
+    expect(typeof rootBarrel.POSTGRES_METRICS_SINK_DDL).toBe("string");
+  });
 });

--- a/packages/plugins/src/metrics/all.ts
+++ b/packages/plugins/src/metrics/all.ts
@@ -16,3 +16,4 @@ export type {
   WorkItemRollup,
   WorkItemAggregatorOptions,
 } from "./sinks/work-item-aggregator.js";
+export type { PostgresSinkOptions, PgClient } from "./sinks/postgres.js";

--- a/packages/plugins/src/metrics/index.ts
+++ b/packages/plugins/src/metrics/index.ts
@@ -142,6 +142,8 @@ export function emitMetric(ctx: HookContext, event: MetricEvent): void {
 
 export { MemorySink } from "./sinks/memory.js";
 export { NdjsonFileSink } from "./sinks/ndjson-file.js";
+export { PostgresSink, POSTGRES_METRICS_SINK_DDL } from "./sinks/postgres.js";
+export type { PostgresSinkOptions, PgClient } from "./sinks/postgres.js";
 export { WorkItemAggregator } from "./sinks/work-item-aggregator.js";
 export type {
   WorkItemRollup,

--- a/packages/plugins/src/metrics/sinks/postgres.ts
+++ b/packages/plugins/src/metrics/sinks/postgres.ts
@@ -23,7 +23,13 @@ export interface PgClient {
 
 /**
  * 建表 DDL（幂等，分号分隔多条语句）。`migrate()` 按分号拆开逐条执行（兼容只支持单语句的 driver）。
- * 索引列服务于「按 kind + 时间窗 + session/work-item 聚合」这一典型 dashboard / 恒温器查询。
+ *
+ * 索引按「先等值过滤列、后时间」的复合形式建，直接服务典型查询（恒温器 / dashboard）：
+ *   WHERE kind = $1 [AND session_id = $2 | AND work_item_id = $2] AND ts >= $a AND ts < $b
+ * 复合索引比四个单列索引更高效（无需 bitmap-AND / 内存过滤），也少一份写放大。可按真实 EXPLAIN 再调。
+ *
+ * `ts` 用 bigint = epoch 毫秒（对齐 `MetricEvent.ts: number`）；`ts BETWEEN a AND b` 范围过滤直接可用，
+ * 需要 timestamptz 视图时在查询里 `to_timestamp(ts / 1000.0)` 即可，故不在存储层强转。
  */
 export const POSTGRES_METRICS_SINK_DDL = `
 CREATE TABLE IF NOT EXISTS metrics_events (
@@ -35,11 +41,38 @@ CREATE TABLE IF NOT EXISTS metrics_events (
   ts           bigint NOT NULL,
   payload      jsonb  NOT NULL DEFAULT '{}'::jsonb
 );
-CREATE INDEX IF NOT EXISTS idx_metrics_events_kind ON metrics_events (kind);
-CREATE INDEX IF NOT EXISTS idx_metrics_events_session ON metrics_events (session_id);
-CREATE INDEX IF NOT EXISTS idx_metrics_events_work_item ON metrics_events (work_item_id);
-CREATE INDEX IF NOT EXISTS idx_metrics_events_ts ON metrics_events (ts);
+CREATE INDEX IF NOT EXISTS idx_metrics_events_kind_ts ON metrics_events (kind, ts);
+CREATE INDEX IF NOT EXISTS idx_metrics_events_session_kind_ts ON metrics_events (session_id, kind, ts);
+CREATE INDEX IF NOT EXISTS idx_metrics_events_work_item_kind_ts ON metrics_events (work_item_id, kind, ts);
 `;
+
+/** 65535 bind-param 上限 / 6 binds-per-row ≈ 10922；取 10000 留余量。超过则 write() 拆成多条 INSERT。 */
+const MAX_ROWS_PER_INSERT = 10000;
+
+/**
+ * 只对「序列化错误」永不抛错的 JSON.stringify，避免一条坏 payload 毒死整个 sink：BigInt → 字符串、
+ * 循环引用 → "[Circular]" 在 replacer 里处理；其它仍会抛的（如 toJSON() 自身抛错）由外层 try/catch
+ * 兜底，退化成 {_unserializable:true}。（client.query() 的 I/O 错误是另一回事——照常抛出由 BatchingSink 重试。）
+ * 没有它的话，一条不可序列化事件会让 write() 抛错、被 BatchingSink 无限重排队、最终 overflow 丢掉整批。
+ *
+ * 注意（JSON.stringify 固有语义）：Symbol 键与 undefined 值被静默丢弃；共享（非循环）引用会被保守标成
+ * "[Circular]"。payload 预期是普通 JSON 数据——所有 core metric kind 都满足。
+ */
+function safeStringify(value: unknown): string {
+  const seen = new WeakSet<object>();
+  try {
+    return JSON.stringify(value, (_key, val) => {
+      if (typeof val === "bigint") return val.toString();
+      if (typeof val === "object" && val !== null) {
+        if (seen.has(val)) return "[Circular]";
+        seen.add(val);
+      }
+      return val as unknown;
+    });
+  } catch {
+    return JSON.stringify({ _unserializable: true });
+  }
+}
 
 export interface PostgresSinkOptions extends BatchingSinkOptions {
   client: PgClient;
@@ -62,6 +95,14 @@ export class PostgresSink extends BatchingSink {
   }
 
   protected async write(batch: MetricEvent[]): Promise<void> {
+    // Chunk so a single INSERT never exceeds Postgres' 65535 bind-parameter cap (6 binds/row).
+    // BatchingSink hands the whole buffer (up to bufferOverflow) in one call, so this is load-bearing.
+    for (let i = 0; i < batch.length; i += MAX_ROWS_PER_INSERT) {
+      await this.writeChunk(batch.slice(i, i + MAX_ROWS_PER_INSERT));
+    }
+  }
+
+  private async writeChunk(batch: MetricEvent[]): Promise<void> {
     if (batch.length === 0) return;
     const tuples: string[] = [];
     const params: unknown[] = [];
@@ -77,7 +118,7 @@ export class PostgresSink extends BatchingSink {
         turnIdx ?? null,
         workItemId == null ? null : String(workItemId),
         ts,
-        JSON.stringify(payload),
+        safeStringify(payload),
       );
     }
     await this.client.query(


### PR DESCRIPTION
Post-merge follow-ups from the review of #4 (PostgresSink for metrics) — the three issues it surfaced.

### #5 — `write()` hardening (bug)
- **`safeStringify()`**: BigInt → string, cycles → `"[Circular]"`, and never throws on a *serialization* error (a throwing `toJSON()` is caught by the outer try/catch → `{_unserializable:true}`). Before this, one non-serializable payload threw in `write()`, got requeued forever by `BatchingSink`, and was eventually dropped on overflow — a stalled sink + silent data loss.
- **Chunking**: the multi-row INSERT is split at `MAX_ROWS_PER_INSERT=10000` (×6 binds = 60 000 < Postgres' 65 535 cap). `BatchingSink` hands the whole buffer (up to `bufferOverflow`) in one call, so this bites once the buffer is reconfigured / burst-filled.

### #6 — export parity (enhancement)
`PostgresSink` / `POSTGRES_METRICS_SINK_DDL` + types `PostgresSinkOptions` / `PgClient` are now re-exported from the metrics barrel **and** the package root, matching `MemorySink` / `NdjsonFileSink` (was subpath-only). The root value-export already landed incidentally via #8; this adds the metrics barrel + types + a parity test.

### #7 — DDL design (enhancement)
Replaced the four single-column indexes with composites — `(kind, ts)`, `(session_id, kind, ts)`, `(work_item_id, kind, ts)` — matching the documented query pattern (`WHERE kind=$1 [AND session_id|work_item_id=$2] AND ts >= $a AND ts < $b`); documented why `ts` stays `bigint` (ms epoch, aligns with `MetricEvent.ts`). Synced `docs/07-adapters.md` to the as-built schema (it had stale `TIMESTAMPTZ`, single-column indexes, a missing `work_item_id` column, and a "we don't ship DDL" note the impl reversed).

### Verify
- +4 tests (BigInt/circular no-loss, chunking → 2 INSERTs under the cap, composite-index DDL, barrel+root export parity). Plugins **208 tests green**; full-repo typecheck/build/test green.
- Adversarial pre-PR review: no critical bugs; the two minor findings (comment clarity, doc drift) are applied.

Closes #5
Closes #6
Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
