### PR TITLE
feat(core): message_update LiveEvent (closes #3)

### DIFF
--- a/apps/coding-agent/src/tui/live-stream.ts
+++ b/apps/coding-agent/src/tui/live-stream.ts
@@ -37,6 +37,8 @@ export class LiveStreamAccumulator {
         return [{ kind: "thinking", text: this.thinking }];
       case "toolcall_delta":
         return []; // P1 不渲染 live toolcall 增量；最终 toolCalls 在 message_end 权威取
+      case "message_update":
+        return []; // 快照轨：本累积器靠 delta 打字机 + message_end 定稿，不消费 message_update 快照
       case "message_end": {
         const text = event.message ? assistantText(event.message) : this.text;
         const thinking = event.message ? assistantThinking(event.message) : this.thinking;

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -49,7 +49,7 @@ v0.1 之前必须满足：
 
 这些是 `bidding-agent` 迁移前的真实 blocker：
 
-- [ ] streaming `message_update` / thinking parity：补可观察的 LLM chunk/update event，不破坏 hook 控制面。
+- [x] streaming `message_update` / thinking parity：thinking delta 本已在 live 轨；新增 `message_update` LiveEvent（内容块边界 `*_end` 发「已拼好整条消息」快照，携带 pi-ai `partial`，低频）+ EventPump 默认转发。
 - [x] auto-compaction parity：`autoCompaction` plugin（`transformMessagesBeforeLlm`，估算 token 体积触发 + 可选 `onContextOverflow`→`compactRestartFresh` 兜底），不再要业务侧手搓触发逻辑。
 - [ ] follow-up / steering parity：明确 `ask_user` 回复插队当前 turn 的模型，避免业务层绕开 kernel。
 - [ ] `ctx.state` hardening：当前 typed registry 已可用，但跨 plugin key 仍需更强约束或 slot API。

--- a/packages/adapters/src/__tests__/event-pump.test.ts
+++ b/packages/adapters/src/__tests__/event-pump.test.ts
@@ -25,6 +25,10 @@ describe("EventPump", () => {
     expect(types).toContain("message_start");
     expect(types.filter((t) => t === "text_delta").length).toBe(2);
     expect(types).toContain("message_end");
+    // message_update snapshot is forwarded by default (at the text block boundary)
+    expect(types).toContain("message_update");
+    const upd = sink.sent.find((e) => e.event.type === "message_update");
+    expect((upd!.event as { message?: { role?: string } }).message?.role).toBe("assistant");
     expect(sink.sent.every((e) => e.track === "live")).toBe(true);
     expect(sink.sent.every((e) => e.sessionId === "S1")).toBe(true);
     expect(sink.sent.every((e) => e.tag === "q1")).toBe(true);
@@ -255,9 +259,9 @@ describe("EventPump", () => {
     await session.run("hi");
     detach();
 
-    // message_start(seq0), text_delta(1,丢), text_delta(2,丢), message_end(3)
-    // → 投递到的是 [0,3]，seq 1/2 缺失 = 消费端可见的跳号（丢失检测）。
-    expect(delivered).toEqual([0, 3]);
+    // message_start(0), text_delta(1,丢), text_delta(2,丢), message_update(3), message_end(4)
+    // → 投递到的是 [0,3,4]，seq 1/2 缺失 = 消费端可见的跳号（丢失检测）。
+    expect(delivered).toEqual([0, 3, 4]);
     fake.teardown();
   });
 

--- a/packages/adapters/src/event-pump.ts
+++ b/packages/adapters/src/event-pump.ts
@@ -54,6 +54,7 @@ const ALL_LIVE = [
   "text_delta",
   "thinking_delta",
   "toolcall_delta",
+  "message_update",
   "message_end",
 ] as const satisfies ReadonlyArray<LiveEvent["type"]>;
 

--- a/packages/core/src/__tests__/event-bus.test.ts
+++ b/packages/core/src/__tests__/event-bus.test.ts
@@ -257,4 +257,42 @@ describe("Event Bus · live token deltas via on()", () => {
     expect(logs.some((m) => m.includes("[event-bus]"))).toBe(true); // throwers were logged
     fake.teardown();
   });
+
+  it("emits message_update at a content-block boundary carrying the assembled message", async () => {
+    const fake = createFakeModel([
+      { content: [{ type: "text", text: "hi" }], textDeltas: ["h", "i"] },
+    ]);
+    const session = new AgentSession({ model: fake, tools: [] });
+    const seq: string[] = [];
+    let snapshot: unknown;
+    session.on("message_start", () => seq.push("start"));
+    session.on("text_delta", () => seq.push("delta"));
+    session.on("message_update", (e) => {
+      seq.push("update");
+      snapshot = e.message;
+    });
+    session.on("message_end", () => seq.push("end"));
+    await session.run("hi");
+    // one snapshot, fired at text_end — after the deltas, before message_end
+    expect(seq).toEqual(["start", "delta", "delta", "update", "end"]);
+    // the snapshot is the assembled assistant message (same object that lands in history)
+    expect(snapshot).toBe(session.messages.at(-1));
+    fake.teardown();
+  });
+
+  it("emits one message_update per content block (thinking + text => two snapshots)", async () => {
+    const fake = createFakeModel([
+      {
+        content: [{ type: "text", text: "answer" }],
+        thinkingDeltas: ["mull"],
+        textDeltas: ["ans", "wer"],
+      },
+    ]);
+    const session = new AgentSession({ model: fake, tools: [] });
+    let updates = 0;
+    session.on("message_update", () => updates++);
+    await session.run("hi");
+    expect(updates).toBe(2); // thinking_end + text_end
+    fake.teardown();
+  });
 });

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -70,6 +70,11 @@ export type LiveEvent =
   | { type: "text_delta"; contentIndex: number; delta: string }
   | { type: "thinking_delta"; contentIndex: number; delta: string }
   | { type: "toolcall_delta"; contentIndex: number; delta: string }
+  // `message_update`：内容块边界（text / thinking / toolcall 各自 `*_end`）发一次的「已拼好的整条
+  // 消息」快照，携带 pi-ai 的 `partial`。比逐 token delta **低频**（每块一次，非每 token，避免 O(n²)
+  // 流量），给偏好渲染整条快照而非自己累积 delta 的前端用；要 token 流的仍订阅 `*_delta`。
+  // 终态以 `message_end` 为准。
+  | { type: "message_update"; message: AssistantMessage }
   // `message_start` 与 `message_end` **严格成对**：成功路径在 try 后 emit 一次（带 message），
   // catch 路径 emit 一次（不带 message）且必 rethrow —— 两路恰好各一次，不重复、不悬空。
   // （注意：不是 try/finally；若把成功路径那次挪进 finally 会与 catch 那次造成 double-emit。）
@@ -1155,6 +1160,13 @@ export class AgentSession {
           ev.type === "toolcall_delta"
         ) {
           this._emitLive({ type: ev.type, contentIndex: ev.contentIndex, delta: ev.delta });
+        } else if (
+          ev.type === "text_end" ||
+          ev.type === "thinking_end" ||
+          ev.type === "toolcall_end"
+        ) {
+          // 内容块收尾：发一次「已拼好的整条消息」快照（pi-ai 的 partial）。低频、给快照式前端。
+          this._emitLive({ type: "message_update", message: ev.partial });
         }
       }
       assistant = await s.result();


### PR DESCRIPTION
## What

Adds a `message_update` LiveEvent — closes #3.

`thinking_delta` + the full message lifecycle were **already** on the live track; the missing piece for streaming UIs was an *assembled-message snapshot*. `message_update` carries pi-ai's `partial` (the message assembled so far) and fires at **content-block boundaries** (`text_end` / `thinking_end` / `toolcall_end`) — **one per block, not per token**, so it avoids O(n²) snapshot traffic. Token-stream consumers keep using `*_delta`; snapshot-rendering UIs use `message_update`; the authoritative final is still `message_end`.

`EventPump` forwards it by default (added to `ALL_LIVE`, exhaustiveness guard satisfied). The TUI delta-accumulator ignores it (it composes deltas + `message_end`).

## Why

roadmap「下一轮 core parity」: *streaming `message_update` / thinking parity*. Driven by Engram's editor Studio + eval dashboard, which want an assembled snapshot to render without re-accumulating deltas. (Investigation note: `thinking_delta` was already emitted + pumped, so the real residual gap was just the snapshot event — this PR is deliberately small.)

## Tests

- core `event-bus`: `message_update` fires at the block boundary carrying the assembled assistant (same object that lands in history), ordered `start → delta → delta → update → end`; one update per block (thinking + text → 2).
- adapters `event-pump`: forwarded by default; the seq-gap test updated for the extra event.
- `pnpm -r build` + `pnpm -r typecheck` (all packages) + full suite green (core 224 / adapters 59 / plugins 208 / tools 51 / example 3).

Closes #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
