### PR TITLE
fix(core,plugins): preserve tool-order barriers + ref'd retry timer (#11.1, #11.4)

### DIFF
--- a/packages/core/src/__tests__/edge-cases.test.ts
+++ b/packages/core/src/__tests__/edge-cases.test.ts
@@ -421,7 +421,7 @@ describe("AgentSession edge cases", () => {
     expect(isErrors).toEqual([false, true, false]);
   });
 
-  it("safe + unsafe mixed: unsafe runs sequentially after safe batch", async () => {
+  it("safe + unsafe mixed: an unsafe call is a barrier — preserves model order (#11.1)", async () => {
     const events: string[] = [];
     const safeTool: HarnessTool = {
       name: "safe",
@@ -462,19 +462,18 @@ describe("AgentSession edge cases", () => {
       tools: [safeTool, unsafeTool],
     });
     await session.run("go");
-    // Safe 批两个并发执行（start-start-end-end 交错）
-    const safeStarts = events.filter((e) => e.startsWith("safe-") && e.endsWith("-start"));
-    expect(safeStarts).toHaveLength(2);
-    // 两个 safe start 应该相邻（中间没 end）
-    const s1StartIdx = events.indexOf("safe-s1-start");
-    const s2StartIdx = events.indexOf("safe-s2-start");
-    // 在 s1 结束前 s2 应该已经 start
-    const s1EndIdx = events.indexOf("safe-s1-end");
-    expect(s2StartIdx).toBeLessThan(s1EndIdx);
-    // Unsafe 严格顺序
-    const u1End = events.indexOf("unsafe-u1-end");
-    const u2Start = events.indexOf("unsafe-u2-start");
-    expect(u2Start).toBeGreaterThan(u1End);
+    // [safe, unsafe, safe, unsafe]：每个 safe 都被 unsafe barrier 隔开、互不相邻 → 不并发，
+    // 严格按模型顺序执行。修复前 s1/s2 会被提到一批并发、u1 抢在 s2 前跑（#11.1）。
+    expect(events).toEqual([
+      "safe-s1-start",
+      "safe-s1-end",
+      "unsafe-u1-start",
+      "unsafe-u1-end",
+      "safe-s2-start",
+      "safe-s2-end",
+      "unsafe-u2-start",
+      "unsafe-u2-end",
+    ]);
   });
 
   it("aborting in middle of session: onSessionEnd still fires once with reason=aborted", async () => {

--- a/packages/core/src/__tests__/edge-cases.test.ts
+++ b/packages/core/src/__tests__/edge-cases.test.ts
@@ -430,7 +430,6 @@ describe("AgentSession edge cases", () => {
       isConcurrencySafe: () => true,
       async execute(args) {
         events.push(`safe-${args["id"]}-start`);
-        await new Promise((r) => setTimeout(r, 30));
         events.push(`safe-${args["id"]}-end`);
         return { content: [{ type: "text", text: String(args["id"]) }] };
       },
@@ -441,7 +440,6 @@ describe("AgentSession edge cases", () => {
       parameters: Type.Object({ id: Type.String() }),
       async execute(args) {
         events.push(`unsafe-${args["id"]}-start`);
-        await new Promise((r) => setTimeout(r, 10));
         events.push(`unsafe-${args["id"]}-end`);
         return { content: [{ type: "text", text: String(args["id"]) }] };
       },

--- a/packages/core/src/__tests__/integration.test.ts
+++ b/packages/core/src/__tests__/integration.test.ts
@@ -17,6 +17,44 @@ function resultText(m: { content: unknown }): string {
   return "";
 }
 
+/**
+ * Deterministic concurrency latch: `n` callers rendezvous and are ALL released only once `n`
+ * have arrived. If fewer than `n` ever run concurrently, the arrivals block forever → the test
+ * times out. So concurrency is proven without any dependence on wall-clock timing: a truly
+ * concurrent run releases immediately; a serialized run deadlocks. `n=1` releases at once.
+ */
+function rendezvous(n: number): () => Promise<void> {
+  let arrived = 0;
+  let release!: () => void;
+  const gate = new Promise<void>((r) => (release = r));
+  return async () => {
+    if (++arrived >= n) release();
+    await gate;
+  };
+}
+
+/** A tool that records `start-<name>`/`end-<name>` into `ev`; an optional `arrive` gates the
+ *  body on a {@link rendezvous} so concurrency can be asserted deterministically. */
+function probeTool(
+  ev: string[],
+  name: string,
+  safe: boolean,
+  arrive?: () => Promise<void>,
+): HarnessTool {
+  return {
+    name,
+    description: name,
+    parameters: Type.Object({}),
+    isConcurrencySafe: () => safe,
+    async execute() {
+      ev.push(`start-${name}`);
+      if (arrive) await arrive();
+      ev.push(`end-${name}`);
+      return { content: [{ type: "text", text: name }] };
+    },
+  };
+}
+
 const echoTool: HarnessTool = {
   name: "echo",
   description: "echo back",
@@ -452,7 +490,6 @@ describe("Integration: Parallel tool execution (isConcurrencySafe)", () => {
       parameters: Type.Object({}),
       isConcurrencySafe: () => false,
       async execute() {
-        await new Promise<void>((r) => setTimeout(r, 30));
         state = "new";
         return { content: [{ type: "text", text: "wrote" }] };
       },
@@ -480,24 +517,15 @@ describe("Integration: Parallel tool execution (isConcurrencySafe)", () => {
     const r = session.messages.find(
       (m) => m.role === "toolResult" && m.toolCallId === "r",
     );
-    // read ran AFTER the write barrier completed — must see "new", not stale "old"
+    // Deterministic: the barrier runs the write strictly before the read → read sees "new".
+    // Pre-fix, read sat in the all-safe batch that ran before the unsafe write → "old".
     expect(r ? resultText(r) : "").toBe("new");
   });
 
   it("only contiguous safe runs parallelize; unsafe calls are barriers (#11.1)", async () => {
     const ev: string[] = [];
-    const mk = (id: string, safe: boolean, ms: number): HarnessTool => ({
-      name: id,
-      description: id,
-      parameters: Type.Object({}),
-      isConcurrencySafe: () => safe,
-      async execute() {
-        ev.push(`start-${id}`);
-        await new Promise<void>((r) => setTimeout(r, ms));
-        ev.push(`end-${id}`);
-        return { content: [{ type: "text", text: id }] };
-      },
-    });
+    const ab = rendezvous(2); // A,B must run concurrently (else this deadlocks → timeout)
+    const cd = rendezvous(2); // C,D must run concurrently after the W barrier
     const model = createFakeModel([
       {
         content: [
@@ -513,24 +541,176 @@ describe("Integration: Parallel tool execution (isConcurrencySafe)", () => {
     const session = new AgentSession({
       model,
       tools: [
-        mk("A", true, 30),
-        mk("B", true, 30),
-        mk("W", false, 10),
-        mk("C", true, 30),
-        mk("D", true, 30),
+        probeTool(ev, "A", true, ab),
+        probeTool(ev, "B", true, ab),
+        probeTool(ev, "W", false),
+        probeTool(ev, "C", true, cd),
+        probeTool(ev, "D", true, cd),
       ],
     });
     await session.run("go");
+    // No deadlock ⇒ A,B ran concurrently and C,D ran concurrently (rendezvous(2) released).
+    expect(ev).toHaveLength(10);
     const at = (e: string): number => ev.indexOf(e);
-    // A,B are a concurrent run: B starts before A ends
-    expect(at("start-B")).toBeLessThan(at("end-A"));
-    // W is a barrier: starts only after A and B both finished
+    // W is a barrier: it runs only after the A,B segment fully finished…
     expect(at("start-W")).toBeGreaterThan(at("end-A"));
     expect(at("start-W")).toBeGreaterThan(at("end-B"));
-    // C,D resume concurrency only after W finished
+    // …and the C,D segment runs only after W finished (the bug ran C/D before W).
     expect(at("start-C")).toBeGreaterThan(at("end-W"));
     expect(at("start-D")).toBeGreaterThan(at("end-W"));
-    expect(at("start-D")).toBeLessThan(at("end-C"));
+  });
+
+  it("barrier at the head of the batch: [unsafe, safe, safe] (#11.1)", async () => {
+    const ev: string[] = [];
+    const ab = rendezvous(2);
+    const model = createFakeModel([
+      {
+        content: [
+          { type: "toolCall", id: "W", name: "W", arguments: {} },
+          { type: "toolCall", id: "A", name: "A", arguments: {} },
+          { type: "toolCall", id: "B", name: "B", arguments: {} },
+        ],
+      },
+      { content: [{ type: "text", text: "done" }] },
+    ]);
+    const session = new AgentSession({
+      model,
+      tools: [probeTool(ev, "W", false), probeTool(ev, "A", true, ab), probeTool(ev, "B", true, ab)],
+    });
+    await session.run("go");
+    expect(ev).toHaveLength(6); // no deadlock ⇒ the trailing safe run (A,B) flushed concurrently
+    const at = (e: string): number => ev.indexOf(e);
+    expect(at("start-A")).toBeGreaterThan(at("end-W"));
+    expect(at("start-B")).toBeGreaterThan(at("end-W"));
+  });
+
+  it("barrier at the tail of the batch: [safe, safe, unsafe] (#11.1)", async () => {
+    const ev: string[] = [];
+    const ab = rendezvous(2);
+    const model = createFakeModel([
+      {
+        content: [
+          { type: "toolCall", id: "A", name: "A", arguments: {} },
+          { type: "toolCall", id: "B", name: "B", arguments: {} },
+          { type: "toolCall", id: "W", name: "W", arguments: {} },
+        ],
+      },
+      { content: [{ type: "text", text: "done" }] },
+    ]);
+    const session = new AgentSession({
+      model,
+      tools: [probeTool(ev, "A", true, ab), probeTool(ev, "B", true, ab), probeTool(ev, "W", false)],
+    });
+    await session.run("go");
+    expect(ev).toHaveLength(6);
+    const at = (e: string): number => ev.indexOf(e);
+    // leading safe run flushed (A,B concurrent), then the trailing unsafe ran after them
+    expect(at("start-W")).toBeGreaterThan(at("end-A"));
+    expect(at("start-W")).toBeGreaterThan(at("end-B"));
+    expect(session.messages.filter((m) => m.role === "toolResult")).toHaveLength(3);
+  });
+
+  it("all-unsafe batch runs in strict sequential order (#11.1)", async () => {
+    const ev: string[] = [];
+    const model = createFakeModel([
+      {
+        content: [
+          { type: "toolCall", id: "X", name: "X", arguments: {} },
+          { type: "toolCall", id: "Y", name: "Y", arguments: {} },
+          { type: "toolCall", id: "Z", name: "Z", arguments: {} },
+        ],
+      },
+      { content: [{ type: "text", text: "done" }] },
+    ]);
+    const session = new AgentSession({
+      model,
+      tools: [probeTool(ev, "X", false), probeTool(ev, "Y", false), probeTool(ev, "Z", false)],
+    });
+    await session.run("go");
+    expect(ev).toEqual(["start-X", "end-X", "start-Y", "end-Y", "start-Z", "end-Z"]);
+  });
+
+  it("a throwing isConcurrencySafe is fail-closed to an unsafe barrier + reported via onError (#11.1)", async () => {
+    const ev: string[] = [];
+    const errors: string[] = [];
+    const thrower: HarnessTool = {
+      name: "T",
+      description: "isConcurrencySafe throws",
+      parameters: Type.Object({}),
+      isConcurrencySafe: () => {
+        throw new Error("safety check boom");
+      },
+      async execute() {
+        ev.push("start-T");
+        ev.push("end-T");
+        return { content: [{ type: "text", text: "T" }] };
+      },
+    };
+    const errHook: Hook = {
+      name: "err-spy",
+      onError(input) {
+        if (input.phase === "tool") errors.push(input.err.message);
+      },
+    };
+    const model = createFakeModel([
+      {
+        content: [
+          { type: "toolCall", id: "A", name: "A", arguments: {} },
+          { type: "toolCall", id: "T", name: "T", arguments: {} },
+          { type: "toolCall", id: "B", name: "B", arguments: {} },
+        ],
+      },
+      { content: [{ type: "text", text: "done" }] },
+    ]);
+    const session = new AgentSession({
+      model,
+      hooks: [errHook],
+      tools: [probeTool(ev, "A", true), thrower, probeTool(ev, "B", true)],
+    });
+    await session.run("go");
+    // fail-closed: T is treated as unsafe → acts as a barrier between A and B (strict order)
+    expect(ev).toEqual(["start-A", "end-A", "start-T", "end-T", "start-B", "end-B"]);
+    // and the isConcurrencySafe throw was surfaced, not swallowed
+    expect(errors).toContain("safety check boom");
+  });
+
+  it("abort during the batch skips the remaining trailing safe run (#11.1)", async () => {
+    const ev: string[] = [];
+    const aborter: HarnessTool = {
+      name: "boom",
+      description: "aborts mid-batch",
+      parameters: Type.Object({}),
+      isConcurrencySafe: () => false,
+      async execute(_args, ctx) {
+        ev.push("boom");
+        ctx.abort("manual mid-batch");
+        return { content: [{ type: "text", text: "x" }], isError: true };
+      },
+    };
+    const later: HarnessTool = {
+      name: "later",
+      description: "safe — must be skipped after abort",
+      parameters: Type.Object({}),
+      isConcurrencySafe: () => true,
+      async execute() {
+        ev.push("later-ran");
+        return { content: [{ type: "text", text: "late" }] };
+      },
+    };
+    const model = createFakeModel([
+      {
+        content: [
+          { type: "toolCall", id: "boom", name: "boom", arguments: {} },
+          { type: "toolCall", id: "later", name: "later", arguments: {} },
+        ],
+      },
+      { content: [{ type: "text", text: "done" }] },
+    ]);
+    const session = new AgentSession({ model, tools: [aborter, later] });
+    const summary = await session.run("go");
+    expect(summary.reason).toBe("aborted");
+    // the trailing safe run after the aborting barrier must NOT execute
+    expect(ev).toEqual(["boom"]);
   });
 });
 

--- a/packages/core/src/__tests__/integration.test.ts
+++ b/packages/core/src/__tests__/integration.test.ts
@@ -8,6 +8,15 @@ import { AgentSession } from "../session.js";
 import type { HarnessTool, Hook, HookContext } from "../index.js";
 import { createFakeModel } from "../testing.js";
 
+/** Read the first text block of a toolResult message. */
+function resultText(m: { content: unknown }): string {
+  const c = m.content;
+  if (Array.isArray(c) && c[0] && typeof c[0] === "object" && "text" in c[0]) {
+    return String((c[0] as { text: unknown }).text);
+  }
+  return "";
+}
+
 const echoTool: HarnessTool = {
   name: "echo",
   description: "echo back",
@@ -433,6 +442,95 @@ describe("Integration: Parallel tool execution (isConcurrencySafe)", () => {
     if (toolResults[1]?.role === "toolResult") {
       expect(toolResults[1].toolCallId).toBe("tc-2");
     }
+  });
+
+  it("an unsafe write is a barrier: a later safe read observes the write (#11.1)", async () => {
+    let state = "old";
+    const write: HarnessTool = {
+      name: "write_state",
+      description: "unsafe write",
+      parameters: Type.Object({}),
+      isConcurrencySafe: () => false,
+      async execute() {
+        await new Promise<void>((r) => setTimeout(r, 30));
+        state = "new";
+        return { content: [{ type: "text", text: "wrote" }] };
+      },
+    };
+    const read: HarnessTool = {
+      name: "read_state",
+      description: "safe read",
+      parameters: Type.Object({}),
+      isConcurrencySafe: () => true,
+      async execute() {
+        return { content: [{ type: "text", text: state }] };
+      },
+    };
+    const model = createFakeModel([
+      {
+        content: [
+          { type: "toolCall", id: "w", name: "write_state", arguments: {} },
+          { type: "toolCall", id: "r", name: "read_state", arguments: {} },
+        ],
+      },
+      { content: [{ type: "text", text: "done" }] },
+    ]);
+    const session = new AgentSession({ model, tools: [write, read] });
+    await session.run("go");
+    const r = session.messages.find(
+      (m) => m.role === "toolResult" && m.toolCallId === "r",
+    );
+    // read ran AFTER the write barrier completed — must see "new", not stale "old"
+    expect(r ? resultText(r) : "").toBe("new");
+  });
+
+  it("only contiguous safe runs parallelize; unsafe calls are barriers (#11.1)", async () => {
+    const ev: string[] = [];
+    const mk = (id: string, safe: boolean, ms: number): HarnessTool => ({
+      name: id,
+      description: id,
+      parameters: Type.Object({}),
+      isConcurrencySafe: () => safe,
+      async execute() {
+        ev.push(`start-${id}`);
+        await new Promise<void>((r) => setTimeout(r, ms));
+        ev.push(`end-${id}`);
+        return { content: [{ type: "text", text: id }] };
+      },
+    });
+    const model = createFakeModel([
+      {
+        content: [
+          { type: "toolCall", id: "A", name: "A", arguments: {} },
+          { type: "toolCall", id: "B", name: "B", arguments: {} },
+          { type: "toolCall", id: "W", name: "W", arguments: {} },
+          { type: "toolCall", id: "C", name: "C", arguments: {} },
+          { type: "toolCall", id: "D", name: "D", arguments: {} },
+        ],
+      },
+      { content: [{ type: "text", text: "done" }] },
+    ]);
+    const session = new AgentSession({
+      model,
+      tools: [
+        mk("A", true, 30),
+        mk("B", true, 30),
+        mk("W", false, 10),
+        mk("C", true, 30),
+        mk("D", true, 30),
+      ],
+    });
+    await session.run("go");
+    const at = (e: string): number => ev.indexOf(e);
+    // A,B are a concurrent run: B starts before A ends
+    expect(at("start-B")).toBeLessThan(at("end-A"));
+    // W is a barrier: starts only after A and B both finished
+    expect(at("start-W")).toBeGreaterThan(at("end-A"));
+    expect(at("start-W")).toBeGreaterThan(at("end-B"));
+    // C,D resume concurrency only after W finished
+    expect(at("start-C")).toBeGreaterThan(at("end-W"));
+    expect(at("start-D")).toBeGreaterThan(at("end-W"));
+    expect(at("start-D")).toBeLessThan(at("end-C"));
   });
 });
 

--- a/packages/core/src/tool-executor.ts
+++ b/packages/core/src/tool-executor.ts
@@ -44,14 +44,16 @@ export class ToolExecutor {
 
   /**
    * 跑一批 toolCall。返回 Map<toolCallId, result>。
-   * 按 `isConcurrencySafe` 分批：safe 批 Promise.all 并发，unsafe 批 await 顺序。
+   *
+   * 执行顺序保持模型在 assistant message 里写下的相对顺序：unsafe 调用是 **barrier**，只把
+   * **连续的** safe 段用 Promise.all 并发跑。否则 `[edit, read]` 里的 read 可能抢在 edit 完成前
+   * 执行、读到旧状态（最终 toolResult 顺序仍按原 toolCalls 排，会掩盖执行乱序）。见 #11.1。
    */
   async executeBatch(
     toolCalls: ToolCall[],
   ): Promise<Map<string, ToolExecResult>> {
-    const safeBatch: ToolCall[] = [];
-    const sequential: ToolCall[] = [];
-
+    // 先分类（保留 isConcurrencySafe 抛错的上报），不动顺序。
+    const classified: Array<{ call: ToolCall; safe: boolean }> = [];
     for (const call of toolCalls) {
       const tool = findToolByName(this.deps.tools, call.name);
       let safe = false;
@@ -76,7 +78,7 @@ export class ToolExecutor {
           error: err instanceof Error ? err.message : String(err),
         });
       }
-      (safe ? safeBatch : sequential).push(call);
+      classified.push({ call, safe });
     }
 
     const results = new Map<string, ToolExecResult>();
@@ -85,11 +87,25 @@ export class ToolExecutor {
         results.set(call.id, res);
       });
 
-    await Promise.all(safeBatch.map(executeOne));
-    for (const call of sequential) {
+    // unsafe = barrier；只并行**连续的** safe 段，保持模型顺序（#11.1）。
+    let safeRun: ToolCall[] = [];
+    const flushSafeRun = async (): Promise<void> => {
+      if (safeRun.length === 0) return;
+      const run = safeRun;
+      safeRun = [];
+      await Promise.all(run.map(executeOne));
+    };
+
+    for (const { call, safe } of classified) {
+      if (safe) {
+        safeRun.push(call);
+        continue;
+      }
+      await flushSafeRun(); // barrier：先把前面连续的 safe 段跑完
       if (this.deps.abortCtrl.signal.aborted) break;
       await executeOne(call);
     }
+    if (!this.deps.abortCtrl.signal.aborted) await flushSafeRun();
 
     return results;
   }

--- a/packages/plugins/src/__tests__/controllers.test.ts
+++ b/packages/plugins/src/__tests__/controllers.test.ts
@@ -76,6 +76,40 @@ describe("LifecycleRestart", () => {
     expect(initialMessagesSeen[0]?.length).toBeGreaterThan(0);
   });
 
+  it("abort during the retry delay exits promptly, not after the full delay (#11.4)", async () => {
+    const slowTool: HarnessTool = {
+      name: "slow",
+      description: "slow",
+      parameters: Type.Object({}),
+      async execute() {
+        await new Promise<void>((r) => setTimeout(r, 100));
+        return { content: [{ type: "text", text: "ok" }] };
+      },
+    };
+    const model = createFakeModel([
+      { content: [{ type: "toolCall", name: "slow", arguments: {} }] },
+    ]);
+    const ctrl = new LifecycleRestart({
+      maxRetries: 1,
+      retryDelayMs: 10_000, // huge: if abort doesn't wake the sleep, the run would block ~10s
+      sessionFactory: (im) =>
+        new AgentSession({
+          model,
+          tools: [slowTool],
+          hooks: [watchdog({ turnTimeoutMs: 20 })],
+          ...(im ? { initialMessages: im } : {}),
+        }),
+    });
+    const ac = new AbortController();
+    const t0 = Date.now();
+    // first run watchdog-aborts (~20ms) → enters the 10s retry delay → abort during it
+    setTimeout(() => ac.abort(), 200);
+    const res = await ctrl.run("hi", { signal: ac.signal });
+    const elapsed = Date.now() - t0;
+    expect(elapsed).toBeLessThan(3_000); // promptly, NOT ~10s
+    expect(res.reason).toBe("aborted");
+  });
+
   it("non-retryable abortReason stops immediately", async () => {
     const model = createFakeModel([
       { content: [{ type: "text", text: "ok" }] },

--- a/packages/plugins/src/__tests__/controllers.test.ts
+++ b/packages/plugins/src/__tests__/controllers.test.ts
@@ -76,7 +76,7 @@ describe("LifecycleRestart", () => {
     expect(initialMessagesSeen[0]?.length).toBeGreaterThan(0);
   });
 
-  it("abort during the retry delay exits promptly, not after the full delay (#11.4)", async () => {
+  it("abort during the retry delay wakes the sleep and exits promptly (#11.4)", async () => {
     const slowTool: HarnessTool = {
       name: "slow",
       description: "slow",
@@ -91,23 +91,56 @@ describe("LifecycleRestart", () => {
     ]);
     const ctrl = new LifecycleRestart({
       maxRetries: 1,
-      retryDelayMs: 10_000, // huge: if abort doesn't wake the sleep, the run would block ~10s
+      // 5s delay vs a 2s assertion: if abort does NOT wake the sleep the run blocks ~5s and the
+      // assertion fails cleanly — well under vitest's 10s timeout, so it's a clean fail, not a hang.
+      retryDelayMs: 5_000,
       sessionFactory: (im) =>
         new AgentSession({
           model,
           tools: [slowTool],
-          hooks: [watchdog({ turnTimeoutMs: 20 })],
+          hooks: [watchdog({ turnTimeoutMs: 10 })],
           ...(im ? { initialMessages: im } : {}),
         }),
     });
     const ac = new AbortController();
     const t0 = Date.now();
-    // first run watchdog-aborts (~20ms) → enters the 10s retry delay → abort during it
-    setTimeout(() => ac.abort(), 200);
+    // first run watchdog-aborts (~10ms) → enters the 5s retry delay → abort lands during it
+    setTimeout(() => ac.abort(), 100);
     const res = await ctrl.run("hi", { signal: ac.signal });
-    const elapsed = Date.now() - t0;
-    expect(elapsed).toBeLessThan(3_000); // promptly, NOT ~10s
+    expect(Date.now() - t0).toBeLessThan(2_000); // woke promptly, did NOT wait the full 5s
     expect(res.reason).toBe("aborted");
+  });
+
+  it("a pre-aborted signal performs no retry and returns promptly (#11.4)", async () => {
+    const slowTool: HarnessTool = {
+      name: "slow",
+      description: "slow",
+      parameters: Type.Object({}),
+      async execute() {
+        await new Promise<void>((r) => setTimeout(r, 100));
+        return { content: [{ type: "text", text: "ok" }] };
+      },
+    };
+    const model = createFakeModel([
+      { content: [{ type: "toolCall", name: "slow", arguments: {} }] },
+    ]);
+    const ctrl = new LifecycleRestart({
+      maxRetries: 3,
+      retryDelayMs: 10_000, // must never be entered
+      sessionFactory: (im) =>
+        new AgentSession({
+          model,
+          tools: [slowTool],
+          hooks: [watchdog({ turnTimeoutMs: 10 })],
+          ...(im ? { initialMessages: im } : {}),
+        }),
+    });
+    const ac = new AbortController();
+    ac.abort(); // already aborted before the run starts
+    const t0 = Date.now();
+    const res = await ctrl.run("hi", { signal: ac.signal });
+    expect(Date.now() - t0).toBeLessThan(1_000); // no 10s retry delay
+    expect(res.retries).toBe(0); // the while-guard `!signal.aborted` prevents any retry
   });
 
   it("non-retryable abortReason stops immediately", async () => {

--- a/packages/plugins/src/controllers/lifecycle-restart.ts
+++ b/packages/plugins/src/controllers/lifecycle-restart.ts
@@ -101,11 +101,20 @@ export class LifecycleRestart {
       // 内存模式在 delay 前先抓历史快照；resume 模式无需快照（历史在 store 里）。
       const carriedMessages = this.opts.resume ? undefined : [...session.messages];
       if (delay > 0) {
+        // 不要 unref：这个 timer 是被 await 的控制流，unref 后独立 worker 的事件循环可能在重试
+        // 触发前就退出（#11.4）。abort 时立即唤醒，让取消能及时退出循环。
         await new Promise<void>((resolve) => {
-          const t = setTimeout(resolve, delay);
-          if (typeof (t as { unref?: () => void }).unref === "function") {
-            (t as { unref: () => void }).unref();
-          }
+          const signal = opts?.signal;
+          if (signal?.aborted) return resolve();
+          const onAbort = (): void => {
+            clearTimeout(t);
+            resolve();
+          };
+          const t = setTimeout(() => {
+            signal?.removeEventListener("abort", onAbort);
+            resolve();
+          }, delay);
+          signal?.addEventListener("abort", onAbort, { once: true });
         });
       }
       if (opts?.signal?.aborted) break;


### PR DESCRIPTION
Addresses the first two (correctness) findings of the #11 hardening review.

## #11.1 — mixed safe/unsafe tool calls executed out of order (P0/P1)
`ToolExecutor.executeBatch` partitioned a turn's calls into *all safe* then *all unsafe*, running every `isConcurrencySafe` call (via `Promise.all`) before any unsafe one. A model turn like `[edit, read]` could therefore run the **read before the edit finished** (stale state), while the final `toolResult` order still looked correct — masking the bug.

**Fix:** unsafe calls are now **barriers**; only *contiguous* runs of safe calls parallelize, preserving the model-authored order. Repro from the issue now returns `read="new"`.

- +2 regression tests (`[unsafe write, safe read]` observes the write; `[A,B,unsafe,C,D]` barrier + contiguous concurrency).
- Updated `edge-cases.test.ts` "safe + unsafe mixed" — it had **encoded the buggy ordering** (asserted two non-adjacent safe calls ran concurrently across an unsafe barrier); now asserts strict model order.

## #11.4 — LifecycleRestart awaited an `unref`'d retry timer (P2)
An `unref`'d timer doesn't keep the event loop alive, so a standalone worker could exit before the retry fired. **Fix:** dropped `unref` (the timer is awaited control flow) and made the sleep abort-aware (abort wakes it promptly).

- +1 test (abort during a 10s retry delay exits in <3s).
- Note: the `unref`-exit only manifests in a standalone process (the test runner keeps the loop alive), so it isn't unit-testable in vitest; validated via the Node repro in #11.

## Verify
Full-repo typecheck/build/test green — core **226**, plugins **209**.

Addresses #11 (items 1 & 4). Items 2 (log redaction), 3 (strict persistence), 5 (docs) are separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
