### PR TITLE
docs: sync 07-adapters PostgresSink + roadmap/README status to as-built (#12, #11.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 
 `harness-pi` 现在处在 **v0.1 readiness** 阶段：core loop、hook dispatcher、standard plugins、controllers、first-party tools、dogfood coding agent、offline examples 和测试都已经落地，足够做 spike/review。
 
-判断成熟度时区分四个层级，别把它们混为一谈：
+判断成熟度时区分三个层级，别把它们混为一谈：
 
 1. **机制已实现**（mechanism implemented，代码 + 本地测试通过）：包括 streaming `message_update` / thinking parity、完整 auto-compaction、PG sink——这些**都已经落地并有本地测试覆盖**，不再是迁移 blocker。
 2. **provider 已验证**（provider-verified）：用真实 provider 跑 streaming / error / overflow 的 smoke。**尚未完成。**

--- a/README.md
+++ b/README.md
@@ -43,7 +43,13 @@
 
 `harness-pi` 现在处在 **v0.1 readiness** 阶段：core loop、hook dispatcher、standard plugins、controllers、first-party tools、dogfood coding agent、offline examples 和测试都已经落地，足够做 spike/review。
 
-还不应直接全量替换 `bidding-agent`：这个框架尚未经过第三方 production 验证，streaming `message_update`/thinking parity、完整 auto-compaction、PG sink 仍是迁移 blocker。当前建议是先把 `bidding-agent` 内部接口形状对齐，再用 worktree 做最小 happy-path spike。
+判断成熟度时区分四个层级，别把它们混为一谈：
+
+1. **机制已实现**（mechanism implemented，代码 + 本地测试通过）：包括 streaming `message_update` / thinking parity、完整 auto-compaction、PG sink——这些**都已经落地并有本地测试覆盖**，不再是迁移 blocker。
+2. **provider 已验证**（provider-verified）：用真实 provider 跑 streaming / error / overflow 的 smoke。**尚未完成。**
+3. **bidding-migration 已验证**（bidding-migration-validated）：用真实 `bidding-agent` 做一次 spike 跑通。**尚未完成。**
+
+结论：harness-pi 已经 **spike-ready**，但**还不是 `bidding-agent` 的生产替代品**。剩下的差距是「真实 provider 在规模下的验证」+「一次 bidding-agent 迁移 spike」，**不是缺机制**。当前建议仍是先把 `bidding-agent` 内部接口形状对齐，再用 worktree 做最小 happy-path spike。
 
 ## Dogfood Agent
 

--- a/docs/07-adapters.md
+++ b/docs/07-adapters.md
@@ -225,72 +225,56 @@ export class NdjsonFileSink extends BatchingSink {
 
 **用途**：本地开发、容器化部署到带挂载 volume 的环境。
 
-### 4.3 PostgresSink（peerDep on `pg`）
+### 4.3 PostgresSink（零 `pg` 依赖，注入 `PgClient`）
+
+实现见 `packages/plugins/src/metrics/sinks/postgres.ts`。与 `PostgresSessionStore` 同构：**本包零 `pg` 依赖**，通过最小 `PgClient` 接口注入查询能力，node-postgres 的 `Pool` / `Client` 天然满足它。继承 `BatchingSink`，复用批量 / 重试 / overflow 语义，只实现 `write(batch)`。
 
 ```ts
-// 假设用户自己装了 pg
-import type { Pool } from "pg";
-import { BatchingSink } from "./batching-sink.js";
+import { PostgresSink } from "@harness-pi/plugins/metrics/sinks/postgres";
+import { Pool } from "pg";  // 调用方自带 pg；本包不依赖
 
-export interface PostgresSinkOptions {
-  pool: Pool;          // 用户传入已建好的连接池
-  table?: string;      // 默认 "metrics_events"
-  batchSize?: number;
-  flushIntervalMs?: number;
+const client = new Pool({ connectionString: process.env.DATABASE_URL });
+const sink = new PostgresSink({ client });  // 注入 PgClient，Pool / Client 都满足
+await sink.migrate();                       // 幂等建表，首次使用前调一次
+```
+
+构造参数 `PostgresSinkOptions extends BatchingSinkOptions`，只多一个 `client: PgClient`：
+
+```ts
+/** node-postgres 的 Pool/Client 满足的最小查询接口。 */
+export interface PgClient {
+  query(
+    text: string,
+    params?: unknown[],
+  ): Promise<{ rows: Array<Record<string, unknown>> }>;
 }
 
-export class PostgresSink extends BatchingSink {
-  constructor(private pgOpts: PostgresSinkOptions) {
-    super(pgOpts);
-  }
-
-  protected async write(batch: MetricEvent[]): Promise<void> {
-    const table = this.pgOpts.table ?? "metrics_events";
-    // 简化的 bulk insert（实际要用 unnest 或 pg-format 防 SQL 注入）
-    const values = batch.map((e, i) => {
-      const offset = i * 5;
-      return `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5})`;
-    }).join(", ");
-    const params = batch.flatMap(e => [
-      e.kind,
-      e.sessionId ?? null,
-      e.turnIdx ?? null,
-      new Date(e.ts),
-      JSON.stringify(e),
-    ]);
-    await this.pgOpts.pool.query(
-      `INSERT INTO ${table} (kind, session_id, turn_idx, ts, payload) VALUES ${values}`,
-      params,
-    );
-  }
+export interface PostgresSinkOptions extends BatchingSinkOptions {
+  client: PgClient;
 }
 ```
+
+`write(batch)` 的要点（不必逐行复述，照源码即可）：
+
+- 表名固定为 `metrics_events`，**无 `table` 选项**。
+- 把 `kind / session_id / turn_idx / work_item_id / ts` 提升为可索引列，其余字段进 `payload` jsonb（这些被提升的列从 `payload` 里 `...rest` 剥掉，不重复存）。
+- `payload` 用永不抛错的 `safeStringify` 序列化：`BigInt → 字符串`、循环引用 → `"[Circular]"`，再 catch 兜底成 `{_unserializable:true}`——避免一条坏 payload 把整个 sink 毒死（否则 `write()` 抛错会被无限重排队、最终 overflow 丢整批）。
+- 单条 `INSERT` 按 `MAX_ROWS_PER_INSERT = 10000` 分块，避免触到 Postgres 65535 bind-param 上限（6 binds/row）。
 
 **用途**：production agent 后台，dashboard 查询。
 
-**peerDep 声明**（`packages/plugins/package.json`）：
-
-```json
-{
-  "peerDependencies": {
-    "pg": "^8.0.0"
-  },
-  "peerDependenciesMeta": {
-    "pg": { "optional": true }
-  }
-}
-```
-
-用户：
+**安装与导入**（本包不声明 `pg` peerDep，因为运行时根本不 import 它；调用方自带 `pg` 或任何满足 `PgClient` 的 driver）：
 
 ```bash
 npm install @harness-pi/plugins pg
-# 然后才能 import { PostgresSink } from "@harness-pi/plugins/metrics/sinks/postgres"
+# PostgresSink / POSTGRES_METRICS_SINK_DDL 既从包根导出，也从子路径导出：
+# import { PostgresSink } from "@harness-pi/plugins";
+# import { PostgresSink } from "@harness-pi/plugins/metrics/sinks/postgres";
 ```
 
 **Schema（包内提供 DDL）**：
 
-PostgresSink 导出幂等的 `POSTGRES_METRICS_SINK_DDL` 并提供 `migrate()`（按 `;` 拆条执行）——与 `PostgresSessionStore` 同构，**本包零 `pg` 依赖**（注入 `PgClient`，node-postgres 的 `Pool`/`Client` 满足）。首次使用前 `await sink.migrate()` 建表即可；也可以把这段 DDL 接进你自己的 migration 工具（drizzle/prisma/raw SQL）。
+PostgresSink 导出幂等的 `POSTGRES_METRICS_SINK_DDL` 并提供 `migrate()`（按 `;` 拆条执行，兼容只支持单语句的 driver）。首次使用前 `await sink.migrate()` 建表即可；也可以把这段 DDL 接进你自己的 migration 工具（drizzle/prisma/raw SQL）。
 
 DDL（`ts` 用 `bigint` = epoch 毫秒，对齐 `MetricEvent.ts: number`；索引按「等值过滤列 + 时间」复合，服务「按 kind + 时间窗 + session/work-item 聚合」的典型查询）：
 
@@ -363,7 +347,7 @@ export class OtelSink extends BatchingSink {
 Controller 跑多 session 时，**一个 sink 实例服务所有 session**：
 
 ```ts
-const sharedSink = new PostgresSink({ pool, table: "metrics_events" });
+const sharedSink = new PostgresSink({ client });
 
 // workPool / leaseQueue 里每个 worker 的 session 都注入这个 sink
 workerFactory: async (...) => {

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,12 +25,14 @@ pnpm --filter @harness-pi-example/02-with-plugins start
 pnpm --filter @harness-pi-example/03-tools start
 ```
 
-明确不做：
+明确不做（v0.1 当时的范围划定 —— 历史口径，部分已超出）：
 
-- 不做 `bidding-agent` 全量迁移。
-- 不引入 PG sink。
-- 不实现完整 auto-compaction。
-- 不把 streaming `message_update` / thinking parity 塞进 tools scope。
+- 不做 `bidding-agent` 全量迁移。（仍然成立。）
+- ~~不引入 PG sink。~~ —— 已实现，见下「Adapter 候选」`PostgresSink [x]`。
+- ~~不实现完整 auto-compaction。~~ —— 已实现，见下「下一轮 core parity」`autoCompaction [x]`。
+- ~~不把 streaming `message_update` / thinking parity 塞进 tools scope。~~ —— 已实现（独立于 tools scope），见下「下一轮 core parity」`message_update [x]`。
+
+> 注：上面三条删除线是 v0.1 当时画的范围线；这些机制后来都已落地（见下文 `[x]` 项），此处保留作为历史记录，不代表当前状态。
 
 ## v0.1 gate
 


### PR DESCRIPTION
Docs-only sync to the as-built implementation. Tri-review gate: code-review(docs accuracy) **9.5/9 PASS, 0 inaccuracies**; linus **"Looks reasonable."**; test-review N/A (no code/tests). The one nit linus flagged (README "四个层级" but 3 listed) is fixed.

### #12 — `docs/07-adapters.md` PostgresSink section → as-built
The old pre-implementation sketch (`{ pool: Pool }` + `table?` option + `new Date(ts)` timestamptz + a hand-written `JSON.stringify(e)` write() + a false `pg` peerDep) is replaced with the shipped reality, verified line-by-line against `packages/plugins/src/metrics/sinks/postgres.ts`:
- `{ client: PgClient }` injection, **zero `pg` dependency**; fixed table `metrics_events` (no `table` option).
- Ships idempotent `POSTGRES_METRICS_SINK_DDL` + `migrate()`; `bigint` ts, `work_item_id` column, promoted-columns-stripped `payload` via never-throwing `safeStringify`; `MAX_ROWS_PER_INSERT` chunking; composite indexes; root + subpath exports.
- §6 multi-session example `{ pool, table }` → `{ client }`.

### #11.5 — roadmap/README status no longer lists implemented mechanisms as blockers
- `roadmap.md`: the "v0.1 明确不做" items (PG sink / auto-compaction / message_update) are struck through and cross-referenced to the `[x]` core-parity entries, marked as historical scope.
- `README.md` 当前状态: a 3-tier maturity model (mechanism-implemented / provider-verified / bidding-migration-validated). harness-pi is **spike-ready** but **not yet a production `bidding-agent` replacement** — the gap is real-provider verification + a migration spike, not missing mechanisms.

Closes #12. Addresses #11 (item 5, docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
