### PR TITLE
plugins(autoCompaction): token-estimate hardening + fail-open test + view-only docs (#13 #14 #16)

### DIFF
--- a/packages/plugins/src/__tests__/auto-compaction.test.ts
+++ b/packages/plugins/src/__tests__/auto-compaction.test.ts
@@ -67,6 +67,34 @@ describe("autoCompaction", () => {
     expect(view!.length).toBe(3);
   });
 
+  it("default estimator counts CJK codepoints as ~1 token each (much higher than chars/4)", () => {
+    // 50 个 CJK 字（无 ASCII）：新公式 ≈ 50 token；旧的 chars/4 只会给 ≈ 13，4× 低估（issue #14 的安全 bug）。
+    const cjk = "你好世界，这是一段中文。".repeat(5); // 12 字/段 * 5 = 60 码点（含全角逗号/句号）
+    const est = estimateTokensByChars([m(cjk)]);
+    const charsOver4 = Math.ceil(cjk.length / 4);
+    expect(est).toBe(cjk.length); // 每个 CJK 码点 ≈ 1 token
+    expect(est).toBeGreaterThan(charsOver4 * 3); // 远高于 chars/4
+  });
+
+  it("default estimator counts an image block as a flat conservative estimate (not tiny ref nor huge base64)", () => {
+    // 短 ref 风格的 image 块（data 很短）：按字符数会被严重低估；扁平估值兜底 ≈ 1000。
+    const imageMsg: Message = {
+      role: "user",
+      content: [{ type: "image", data: "abc", mimeType: "image/png" }],
+      timestamp: 0,
+    };
+    const est = estimateTokensByChars([imageMsg]);
+    expect(est).toBe(1000); // 扁平、保守
+
+    // 内联 base64（data 极长）：若按 data 字符数会疯狂高估；仍是扁平 1000，不随 data 长度膨胀。
+    const inlineMsg: Message = {
+      role: "user",
+      content: [{ type: "image", data: "A".repeat(50_000), mimeType: "image/png" }],
+      timestamp: 0,
+    };
+    expect(estimateTokensByChars([inlineMsg])).toBe(1000);
+  });
+
   it("caches the summary by covered prefix until it grows by resummarizeEvery", async () => {
     let calls = 0;
     const compact = autoCompaction({
@@ -139,6 +167,39 @@ describe("autoCompaction", () => {
     expect(textOf(view[0]!)).toContain("RECAP");
     expect(textOf(view[2]!)).toBe("go");
     expect(session.messages.length).toBe(8); // full history intact (6 + "go" + assistant)
+    fake.teardown();
+  });
+
+  it("end-to-end: a summarize() failure degrades to NO compaction (kernel pipe fail-open), run still completes", async () => {
+    // #13: summarize 抛错 → transform 被内核 fail-open 吞掉 → 模型收到未压缩全量、run 不中断、history 不变。
+    const initial = [m("h1"), m("a1"), m("h2"), m("a2"), m("h3"), m("a3")]; // 6
+    const fake = createFakeModel([
+      { content: [{ type: "text", text: "ok" }], stopReason: "stop" },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [],
+      initialMessages: initial,
+      hooks: [
+        autoCompaction({
+          maxContextTokens: 100,
+          triggerRatio: 0.8, // threshold 80
+          keepRecent: 2,
+          estimateTokens: (msgs) => msgs.length * 50, // 7 msgs * 50 = 350 > 80 → 会尝试压缩
+          summarize: () => {
+            throw new Error("summary backend down");
+          },
+        }),
+      ],
+    });
+    const summary = await session.run("go");
+
+    expect(summary.reason).toBe("done"); // 压缩失败不杀 run（不是 "error"）
+    // fail-open：模型收到未压缩全量（6 初始 + "go" = 7），而不是压缩后的视图。
+    expect(fake.getCalls()[0]!.messages.length).toBe(7);
+    expect(textOf(fake.getCalls()[0]!.messages[6]!)).toBe("go");
+    // 完整历史未被破坏：6 初始 + "go" + assistant = 8。
+    expect(session.messages.length).toBe(8);
     fake.teardown();
   });
 });

--- a/packages/plugins/src/__tests__/auto-compaction.test.ts
+++ b/packages/plugins/src/__tests__/auto-compaction.test.ts
@@ -95,6 +95,87 @@ describe("autoCompaction", () => {
     expect(estimateTokensByChars([inlineMsg])).toBe(1000);
   });
 
+  it("counts astral (surrogate-pair) CJK as ~1 token/codepoint, not 2 ASCII chars", () => {
+    // 𠀀 = U+20000 (CJK Ext B): .length === 2 (a surrogate pair). Iterating by code POINT must
+    // count it as one CJK token; the pre-fix .length/regex path counted it as 2 ASCII → undercount.
+    const astral = "\u{20000}".repeat(10);
+    expect(astral.length).toBe(20); // 20 UTF-16 code units…
+    expect([...astral].length).toBe(10); // …but 10 code points
+    expect(estimateTokensByChars([m(astral)])).toBe(10); // 10 CJK code points ≈ 10 tokens
+  });
+
+  it("counts CJK + ASCII mixed in one text with consistent code-point units", () => {
+    // 你好(2 CJK) + " hello "(7 non-CJK) + 世界(2 CJK) + " world"(6 non-CJK)
+    // = 4 CJK + ceil(13/4)=4  → 8
+    expect(estimateTokensByChars([m("你好 hello 世界 world")])).toBe(8);
+  });
+
+  it("adds an image block and a text block in the same message", () => {
+    const msg: Message = {
+      role: "user",
+      content: [
+        { type: "image", data: "abc", mimeType: "image/png" },
+        { type: "text", text: "caption" }, // 7 ASCII → ceil(7/4) = 2
+      ],
+      timestamp: 0,
+    };
+    expect(estimateTokensByChars([msg])).toBe(1002); // 1000 (image) + 2 (text)
+  });
+
+  it("counts multiple images per-image (not per-message)", () => {
+    const msg: Message = {
+      role: "user",
+      content: [
+        { type: "image", data: "a", mimeType: "image/png" },
+        { type: "image", data: "b", mimeType: "image/png" },
+        { type: "image", data: "c", mimeType: "image/png" },
+      ],
+      timestamp: 0,
+    };
+    expect(estimateTokensByChars([msg])).toBe(3000); // 3 × IMAGE_TOKENS
+  });
+
+  it("counts non-text / non-image blocks (e.g. toolCall) via their JSON length", () => {
+    const big = {
+      role: "assistant",
+      content: [{ type: "toolCall", id: "t1", name: "foo", arguments: { x: "y".repeat(40) } }],
+      timestamp: 0,
+    } as unknown as Message;
+    const small = {
+      role: "assistant",
+      content: [{ type: "toolCall", id: "t1", name: "foo", arguments: { x: "y" } }],
+      timestamp: 0,
+    } as unknown as Message;
+    // the block IS counted (not skipped) and scales with its serialized size
+    expect(estimateTokensByChars([small])).toBeGreaterThan(0);
+    expect(estimateTokensByChars([big])).toBeGreaterThan(estimateTokensByChars([small]));
+  });
+
+  it("handles empty / whitespace / empty-content messages deterministically (no throw)", () => {
+    expect(estimateTokensByChars([m("")])).toBe(0);
+    expect(estimateTokensByChars([m("   ")])).toBe(1); // ceil(3/4)
+    const emptyContent: Message = { role: "user", content: [], timestamp: 0 };
+    expect(estimateTokensByChars([emptyContent])).toBe(0);
+  });
+
+  it("does not compact when messages.length === keepRecent (nothing to compress, no summarize)", async () => {
+    let calls = 0;
+    const compact = autoCompaction({
+      maxContextTokens: 1,
+      triggerRatio: 1,
+      keepRecent: 3,
+      estimateTokens: () => 999, // over threshold → would compact if it could
+      summarize: () => {
+        calls++;
+        return "S";
+      },
+    });
+    const { ctx } = createTestContext();
+    // exactly keepRecent messages: the tail IS everything → nothing to summarize
+    expect(await compact.transformMessagesBeforeLlm!(grow(3), ctx)).toBeUndefined();
+    expect(calls).toBe(0);
+  });
+
   it("caches the summary by covered prefix until it grows by resummarizeEvery", async () => {
     let calls = 0;
     const compact = autoCompaction({

--- a/packages/plugins/src/auto-compaction.ts
+++ b/packages/plugins/src/auto-compaction.ts
@@ -12,6 +12,14 @@
  * 与 `compactSummarize` 的关系：两者互补、可二选一。条数阈值直观；token 阈值贴近真实窗口压力，
  * 是 Claude Code 式 auto-compaction 的「自动」所在。summary 后端仍由调用方 `summarize` 提供（与
  * `compactSummarize` 同契约）；本插件负责的是「何时压缩」这条标准策略，不再要业务侧手搓触发逻辑。
+ *
+ * **语义：view-only（#16 的结论）。** 本插件是**只读、非破坏**的——`transformMessagesBeforeLlm` 只压缩
+ * 「本 turn 发给 LLM 的 view」，**绝不改写 `session.messages`**，故完整原始历史**天然**留在 store 里
+ * （by construction 满足 #2「原始历史保留在 store」）。这与 `compactSummarize` 同款。
+ * 因此 resume 时会重放全量历史、模型每 turn 看到的是重新总结的 view，本插件**不写** `compaction_boundary`
+ * store 条目——那是另一条路径（**persistent boundary**）的职责：由 `compactRestartFresh` 控制器把 summary
+ * 持久化进 store、resume 从 summary 起算、丢弃边界前缀，经 `abortOnOverflow` 抵达。两条路径分工明确，
+ * 本插件刻意不再叠加写 store 的机制（会与 `compactRestartFresh` 冗余、并破坏内核 _flushToStore 不变量）。
  */
 
 import type { Hook, HookContext } from "@harness-pi/core";
@@ -30,7 +38,10 @@ export interface AutoCompactionOptions {
     earlyMessages: Message[],
     ctx: HookContext,
   ) => string | Promise<string>;
-  /** token 估算器。默认按消息文本字符数 / 4 粗估（保守、零依赖；接入真 tokenizer 可覆盖）。 */
+  /**
+   * token 估算器。默认 {@link estimateTokensByChars}：CJK 感知（≈ 1 token/字）+ 图片感知（每图扁平估值），
+   * 整体偏**保守高估**（低估会漏触发压缩→窗口溢出，是安全 bug）；零依赖。接入真 tokenizer 可覆盖。
+   */
   estimateTokens?: (messages: Message[]) => number;
   /**
    * 「想覆盖的前缀」比上次缓存增长达到这么多条才重算 summary；默认 = keepRecent。
@@ -46,20 +57,71 @@ export interface AutoCompactionOptions {
   abortOnOverflow?: boolean;
 }
 
-function messageText(m: Message): string {
-  if (typeof m.content === "string") return m.content;
-  return m.content
-    .map((b) => ("text" in b && typeof b.text === "string" ? b.text : JSON.stringify(b)))
-    .join("");
+/**
+ * CJK 码点（含统一表意文字 + 常见 CJK 标点 / 全角字符）。这些码点在主流 tokenizer 里普遍 ≈ 1 token/字，
+ * 远稠密于 ASCII 的 ≈ 4 char/token，故单独计数。范围按码点匹配（用 /u flag）：
+ * 　-〿 CJK 符号与标点、㐀-䶿 扩展 A、一-鿿 统一表意文字、豈-﫿 兼容表意文字、＀-￯ 全角/半角形式。
+ */
+const CJK_RE = /[　-〿㐀-䶿一-鿿豈-﫿＀-￯]/gu;
+
+/** 单张图片的保守、扁平 token 估算（issue #14）：宁可高估、不可低估，避免漏触发→窗口溢出。 */
+const IMAGE_TOKENS = 1000;
+
+/**
+ * 估算单条文本的 token：CJK 码点按 ≈ 1 token/字计，其余字符按 ≈ 1/4 token 计（向上取整）。
+ * 偏向**高估**——本数用于压缩触发判据，低估的代价是漏触发后 context 溢出（安全 bug，见 #14）。
+ */
+function estimateText(text: string): number {
+  const cjk = (text.match(CJK_RE) ?? []).length;
+  const rest = text.length - cjk;
+  return cjk + Math.ceil(rest / 4);
 }
 
-/** 默认 token 估算：所有消息文本字符数 / 4 向上取整。粗但单调、零依赖。 */
+/**
+ * 默认 token 估算：CJK 感知 + 图片感知，整体偏保守（高估）。粗但单调、确定、零依赖。
+ *
+ * - **CJK**：每个 CJK 码点 ≈ 1 token（不是 chars/4）。`你好世界` → ≈ 4 token，不再被 4× 低估。
+ * - **图片**：image content block（pi-ai 判别式 `type === "image"`）贡献**扁平** {@link IMAGE_TOKENS} token，
+ *   既不按短 ref 的字符数低估、也不按内联 base64 `data` 的字符数疯狂高估。
+ * - **其余文本**（ASCII 等）：≈ 1/4 token/字符（向上取整），故纯英文仍 ≈ chars/4。
+ *
+ * 想接真 tokenizer：覆盖 `estimateTokens` 选项即可。
+ */
 export function estimateTokensByChars(messages: Message[]): number {
-  let chars = 0;
-  for (const m of messages) chars += messageText(m).length;
-  return Math.ceil(chars / 4);
+  let tokens = 0;
+  for (const m of messages) {
+    if (typeof m.content === "string") {
+      tokens += estimateText(m.content);
+      continue;
+    }
+    for (const b of m.content) {
+      if (b.type === "image") {
+        tokens += IMAGE_TOKENS;
+      } else if ("text" in b && typeof b.text === "string") {
+        tokens += estimateText(b.text);
+      } else {
+        // 其余块（thinking / toolCall 等）按其 JSON 序列化长度粗估，仍走 1/4 规则。
+        tokens += estimateText(JSON.stringify(b));
+      }
+    }
+  }
+  return tokens;
 }
 
+/**
+ * 构造一个 autoCompaction hook。三条**使用须知**（issue #13，违反会得到悄无声息的错误压缩）：
+ *
+ * 1. **Hook 顺序**：本插件从 `transformMessagesBeforeLlm` 收到的 `messages`（≈ `session.messages`）估算
+ *    token，故它必须排在 `trimHistory` 这类**内容裁剪型** transform **之前**。若 `trimHistory` 先跑、把
+ *    旧 toolResult 换成了占位符，autoCompaction 读到的体积就是裁剪**后**的、与真实 context 不符的**陈旧值**，
+ *    可能漏触发。准则：压缩型 hook 排在裁剪型 hook 前面。
+ * 2. **与 compactSummarize 共存**：两者是**二选一**（pick one）。同一 session 的 hook 链里**同时**挂两个，
+ *    会顺序各跑、各自维护**独立缓存**，产生**未定义的压缩边界**（谁先压、压到哪、summary 互相覆盖均无保证）。
+ *    选一个用。
+ * 3. **每 session 一个实例**：闭包缓存（`coveredCount` + summary 文本）假设**一个 hook 实例只服务一个 session**。
+ *    把同一个实例**跨 session 复用**会让 `coveredCount` 被另一个 session 的前缀长度污染，导致 view 错位。
+ *    每个 session 各 `autoCompaction(...)` 一次。
+ */
 export function autoCompaction(opts: AutoCompactionOptions): Hook {
   if (!(opts.maxContextTokens > 0)) {
     throw new Error("autoCompaction: maxContextTokens must be > 0");

--- a/packages/plugins/src/auto-compaction.ts
+++ b/packages/plugins/src/auto-compaction.ts
@@ -58,11 +58,12 @@ export interface AutoCompactionOptions {
 }
 
 /**
- * CJK 码点（含统一表意文字 + 常见 CJK 标点 / 全角字符）。这些码点在主流 tokenizer 里普遍 ≈ 1 token/字，
- * 远稠密于 ASCII 的 ≈ 4 char/token，故单独计数。范围按码点匹配（用 /u flag）：
- * 　-〿 CJK 符号与标点、㐀-䶿 扩展 A、一-鿿 统一表意文字、豈-﫿 兼容表意文字、＀-￯ 全角/半角形式。
+ * 单个 CJK 码点判定（含统一表意文字 + 常见 CJK 标点 / 全角字符）。这些码点在主流 tokenizer 里普遍
+ * ≈ 1 token/字，远稠密于 ASCII 的 ≈ 4 char/token，故单独计数。**非 global**，用于逐码点 `.test`：
+ * 　-〿 CJK 符号与标点、㐀-䶿 扩展 A、一-鿿 统一表意文字、豈-﫿 兼容表意文字、＀-￯ 全角/半角形式，
+ * 以及 \u{20000}-\u{2ffff} 扩展 B–F（代理对，需 /u flag + 按码点迭代才能正确命中，否则被当 2 个 ASCII）。
  */
-const CJK_RE = /[　-〿㐀-䶿一-鿿豈-﫿＀-￯]/gu;
+const CJK_CP = /[　-〿㐀-䶿一-鿿豈-﫿＀-￯]|[\u{20000}-\u{2ffff}]/u;
 
 /** 单张图片的保守、扁平 token 估算（issue #14）：宁可高估、不可低估，避免漏触发→窗口溢出。 */
 const IMAGE_TOKENS = 1000;
@@ -70,10 +71,17 @@ const IMAGE_TOKENS = 1000;
 /**
  * 估算单条文本的 token：CJK 码点按 ≈ 1 token/字计，其余字符按 ≈ 1/4 token 计（向上取整）。
  * 偏向**高估**——本数用于压缩触发判据，低估的代价是漏触发后 context 溢出（安全 bug，见 #14）。
+ *
+ * **按码点迭代**（`for...of`）而非按 `.length`（UTF-16 码元）：这样扩展 B+ 的代理对 CJK（如 𠀀）算 1 个
+ * 码点 = 1 token（否则 `.length===2` 会被当 2 个 ASCII 字符），且 CJK/ASCII 混排时 `rest` 计数单位一致。
  */
 function estimateText(text: string): number {
-  const cjk = (text.match(CJK_RE) ?? []).length;
-  const rest = text.length - cjk;
+  let cjk = 0;
+  let rest = 0;
+  for (const ch of text) {
+    if (CJK_CP.test(ch)) cjk++;
+    else rest++;
+  }
   return cjk + Math.ceil(rest / 4);
 }
 


### PR DESCRIPTION
autoCompaction hardening. Tri-review: code **8.2**, test **8.4** (all dims ≥7.5), linus **"Applied."** — all pass.

### #14 — token estimate undercount (SAFETY: under-estimate → no trigger → context overflow)
`estimateTokensByChars` rewritten to bias toward over-estimating:
- **CJK** counts as ≈1 token/codepoint (was chars/4 → 4× undercount for Chinese). Iterates by **code point** (`for...of`) and the CJK class includes the astral range `\u{20000}-\u{2ffff}`, so Ext-B+ surrogate-pair CJK (e.g. 𠀀) counts as 1, not 2 ASCII chars; CJK+ASCII mixed uses consistent code-point units.
- **Images** → flat conservative `IMAGE_TOKENS` (1000), not a char-derived under/over count.
- `estimateTokens` stays overridable for a real tokenizer.

### #13 — fail-open test + caveat docs
- Real-session fail-open regression test (summarize throws → kernel pipe fail-open → run `done`, history intact, model sees uncompacted view).
- JSDoc caveats: hook ordering (before `trimHistory`), coexistence with `compactSummarize` is 二选一, per-session-instance cache.

### #16 — view-only semantics (resolved by documentation)
Documented that `autoCompaction` is intentionally **view-only** (non-destructive; full history retained in store by construction — satisfies #2). The persistent-boundary path (`compaction_boundary`) is `compactRestartFresh`'s job via `abortOnOverflow`. No redundant new mechanism.

Tests: +10 (astral CJK, CJK+ASCII mixed, image+text, multi-image, toolCall JSON branch, empty/whitespace, keepRecent boundary, fail-open, …). plugins 220 green, typecheck clean.

Closes #13
Closes #14
Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)
