### PR TITLE
test(core): harden message_update LiveEvent contract (#15)

### DIFF
--- a/packages/core/src/__tests__/event-bus.test.ts
+++ b/packages/core/src/__tests__/event-bus.test.ts
@@ -266,19 +266,26 @@ describe("Event Bus · live token deltas via on()", () => {
     ]);
     const session = new AgentSession({ model: fake, tools: [] });
     const seq: string[] = [];
-    let snapshot: unknown;
+    let snapshot: AssistantMessage | undefined;
+    let final: AssistantMessage | undefined;
     session.on("message_start", () => seq.push("start"));
     session.on("text_delta", () => seq.push("delta"));
     session.on("message_update", (e) => {
       seq.push("update");
       snapshot = e.message;
     });
-    session.on("message_end", () => seq.push("end"));
+    session.on("message_end", (e) => {
+      seq.push("end");
+      final = e.message as AssistantMessage;
+    });
     await session.run("hi");
     // one snapshot, fired at text_end — after the deltas, before message_end
     expect(seq).toEqual(["start", "delta", "delta", "update", "end"]);
-    // the snapshot is the assembled assistant message (same object that lands in history)
-    expect(snapshot).toBe(session.messages.at(-1));
+    // 契约：message_update 携带的是「中间态、逐块 partial 快照」——一个**独立对象**，**不是**落进 history 的
+    // 权威终态对象（即便单块回合下二者内容恰好相等，对象身份也不同）。要终态对象/终态判定请用 message_end。
+    expect(final).toBe(session.messages.at(-1)); // message_end 才是落 history 的权威终态对象
+    expect(snapshot).not.toBe(final); // update 是独立 partial 快照，绝非终态对象（不能 ===）
+    expect(snapshot!.content).toEqual(final!.content); // 单块回合：该块收尾后 partial 内容 == 终态内容
     fake.teardown();
   });
 
@@ -396,6 +403,158 @@ describe("LiveEvent · 契约硬化", () => {
     expect(updates).toBe(1); // 整个回合只为 toolcall 块发了一次 update
     // 快照里确有 toolCall 块（即 update 携带的是这条 toolcall-only 消息的 partial）。
     expect(snapshot?.content.some((b) => b.type === "toolCall")).toBe(true);
+    fake.teardown();
+  });
+
+  // 头号契约（test-review #2/#3）：一帧 message_update 的 content 是「截至此刻已收尾块」的 partial，
+  // 早期帧**严格少于**终态——把早期 update 当终态会丢块。这里用 [text, toolCall] 两块回合直接证伪
+  // 「update == 终态」：text_end 那帧只有 1 块（text），而 message_end 终态有 2 块（text+toolCall）。
+  it("an early message_update snapshot has FEWER blocks than the final (update ⊊ message_end)", async () => {
+    const fake = createFakeModel([
+      {
+        content: [
+          { type: "text", text: "ans" },
+          { type: "toolCall", name: "noop", arguments: { a: 1 } },
+        ],
+        textDeltas: ["an", "s"],
+        toolcallDeltas: ['{"a":', "1}"],
+      },
+      { content: [{ type: "text", text: "done" }] },
+    ]);
+    const session = new AgentSession({ model: fake, tools: [noopTool] });
+    const frames: AssistantMessage[] = [];
+    let final: AssistantMessage | undefined;
+    session.on("message_update", (e) => frames.push(e.message as AssistantMessage));
+    session.on("message_end", (e) => {
+      if (e.message && !final) final = e.message as AssistantMessage; // 抓第一回合终态
+    });
+    await session.run("hi");
+
+    // 第一回合两块 → 两帧 update：第 1 帧（text_end）只含 text，第 2 帧（toolcall_end）含 text+toolCall。
+    const first = frames[0]!;
+    const second = frames[1]!;
+    expect(first.content.map((b) => b.type)).toEqual(["text"]); // 早期帧：1 块
+    expect(second.content.map((b) => b.type)).toEqual(["text", "toolCall"]); // 后续帧：2 块
+    // 终态（message_end）有 2 块；早期 update 帧块数 < 终态 → 拿早期帧当终态会丢 toolCall 块。
+    expect(final!.content.length).toBe(2);
+    expect(first.content.length).toBeLessThan(final!.content.length);
+    // 且每帧 update 都是独立 partial 对象，不是落 history 的终态对象。
+    expect(first).not.toBe(final);
+    expect(second).not.toBe(final);
+    fake.teardown();
+  });
+
+  // 状态组合（test-review #3）：跨块快照内容**单调增长**——thinking 帧只含 thinking，text 帧含 thinking+text。
+  // 锁住「partial 逐块累积」而非「每帧都是同一份终态」。
+  it("message_update snapshots grow monotonically across blocks (thinking → thinking+text)", async () => {
+    const fake = createFakeModel([
+      {
+        content: [{ type: "text", text: "answer" }],
+        thinkingDeltas: ["mull"],
+        textDeltas: ["ans", "wer"],
+      },
+    ]);
+    const session = new AgentSession({ model: fake, tools: [] });
+    const frames: AssistantMessage[] = [];
+    session.on("message_update", (e) => frames.push(e.message as AssistantMessage));
+    await session.run("hi");
+
+    expect(frames).toHaveLength(2);
+    expect(frames[0]!.content.map((b) => b.type)).toEqual(["thinking"]); // 第 1 帧（thinking_end）
+    expect(frames[1]!.content.map((b) => b.type)).toEqual(["thinking", "text"]); // 第 2 帧（text_end）
+    // 第 1 帧是独立快照，不会被后续 push 回填成 2 块（证明每帧 content 是当时的拷贝、互不别名）。
+    expect(frames[0]!.content).toHaveLength(1);
+    expect(frames[0]).not.toBe(frames[1]);
+    fake.teardown();
+  });
+
+  // 头号契约 mid-abort（test-review #1）：流被中途打断时，最后一帧 message_update 只含**已收尾块**、
+  // 缺尚未流出的块；终态（含 stopReason:"aborted"）只能由 message_end 得知，绝不能拿最后一帧 update 当终态。
+  it("on mid-stream abort, the last message_update lacks the unstreamed block; message_end carries the aborted final", async () => {
+    const fake = createFakeModel([
+      {
+        // 脚本本想发 thinking + text 两块，但在 thinking 收尾后 abort：text 永不流出。
+        content: [{ type: "text", text: "never streamed" }],
+        thinkingDeltas: ["reason"],
+        textDeltas: ["wont", "happen"],
+        abortAfterBlock: "thinking",
+      },
+    ]);
+    const session = new AgentSession({ model: fake, tools: [], consoleSink: () => {} });
+    const frames: AssistantMessage[] = [];
+    let final: AssistantMessage | undefined;
+    session.on("message_update", (e) => frames.push(e.message as AssistantMessage));
+    session.on("message_end", (e) => (final = e.message as AssistantMessage | undefined));
+    await session.run("hi");
+
+    // 只为已收尾的 thinking 块发了一帧 update；text 块从未收尾 → 内核绝不为它臆造 update。
+    expect(frames).toHaveLength(1);
+    expect(frames[0]!.content.map((b) => b.type)).toEqual(["thinking"]); // 最后一帧缺 text 块
+    // 终态由 message_end 携带，且 stopReason 标记 aborted——这是「中途打断」的唯一权威信号，
+    // message_update 不带 stopReason，拿它当终态既缺块也判不出 aborted。
+    expect(final).toBeDefined();
+    expect(final!.stopReason).toBe("aborted");
+    fake.teardown();
+  });
+
+  // 隔离（test-review #4）：message_update 是块边界单独 emit 的代码路径，不能假设它和 delta 共享隔离行为。
+  // 一个 message_update listener 抛错：loop 仍跑完、其他 message_update listener 仍收快照、错误经 consoleSink 记 [event-bus]。
+  it("isolates a throwing message_update listener: loop completes, other update listeners still fire, error logged", async () => {
+    const fake = createFakeModel([
+      { content: [{ type: "text", text: "hi" }], textDeltas: ["h", "i"] },
+    ]);
+    const logs: string[] = [];
+    const session = new AgentSession({ model: fake, tools: [], consoleSink: (m) => logs.push(m) });
+    const good: AssistantMessage[] = [];
+    session.on("message_update", () => {
+      throw new Error("boom in update");
+    });
+    session.on("message_update", (e) => good.push(e.message as AssistantMessage));
+    const summary = await session.run("hi");
+    expect(summary.reason).toBe("done"); // 抛错的 update listener 没拖垮 run
+    expect(good).toHaveLength(1); // 另一个 update listener 仍拿到那帧快照
+    expect(good[0]!.content.map((b) => b.type)).toEqual(["text"]);
+    expect(logs.some((m) => m.includes("[event-bus]"))).toBe(true); // 抛错被记
+    fake.teardown();
+  });
+
+  // 错误路径（test-review #5）：错误回合没有任何块收尾 → 不应有任何 message_update。
+  // 覆盖两条 provider 失败路径：sync-throw（建流即抛）与 runtime error 事件（result resolve 出 error 终态）。
+  it("emits no message_update on an error turn (no block ever completes) — both sync-throw and error-event paths", async () => {
+    // 路径 A：stream() 同步抛。
+    const fa = createFakeModel([{ content: [], streamThrows: new Error("boom") }]);
+    const sa = new AgentSession({ model: fa, tools: [], consoleSink: () => {} });
+    let ua = 0;
+    sa.on("message_update", () => ua++);
+    const ra = await sa.run("hi");
+    expect(ra.reason).toBe("error");
+    expect(ua).toBe(0); // 无块收尾 → 无 update
+    fa.teardown();
+
+    // 路径 B：runtime error 事件 → result() resolve 出 stopReason:"error" 终态（不 reject）。
+    const fb = createFakeModel([{ content: [], throwError: new Error("api 500") }]);
+    const sb = new AgentSession({ model: fb, tools: [], consoleSink: () => {} });
+    let ub = 0;
+    sb.on("message_update", () => ub++);
+    await sb.run("hi");
+    expect(ub).toBe(0); // 同样无块收尾 → 无 update
+    fb.teardown();
+  });
+
+  // 多回合归属（test-review #6）：toolcall 回合 + text 回合，每回合各发一次 update，整轮共 2 次、不串块。
+  it("attributes message_update per turn across a multi-turn run (one per turn, no cross-turn leakage)", async () => {
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }], toolcallDeltas: ["{}"] },
+      { content: [{ type: "text", text: "done" }], textDeltas: ["do", "ne"] },
+    ]);
+    const session = new AgentSession({ model: fake, tools: [noopTool] });
+    const frames: AssistantMessage[] = [];
+    session.on("message_update", (e) => frames.push(e.message as AssistantMessage));
+    await session.run("hi");
+
+    expect(frames).toHaveLength(2); // 整轮共两帧：每回合各一帧
+    expect(frames[0]!.content.map((b) => b.type)).toEqual(["toolCall"]); // 第 1 回合：toolcall 块
+    expect(frames[1]!.content.map((b) => b.type)).toEqual(["text"]); // 第 2 回合：text 块（不含上一回合的 toolCall）
     fake.teardown();
   });
 });

--- a/packages/core/src/__tests__/event-bus.test.ts
+++ b/packages/core/src/__tests__/event-bus.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { AgentSession } from "../session.js";
+import type { LiveEvent } from "../session.js";
 import { createFakeModel } from "../testing.js";
 import type { HarnessTool } from "../types.js";
+import type { AssistantMessage } from "@mariozechner/pi-ai";
 
 const noopTool: HarnessTool = {
   name: "noop",
@@ -293,6 +295,107 @@ describe("Event Bus · live token deltas via on()", () => {
     session.on("message_update", () => updates++);
     await session.run("hi");
     expect(updates).toBe(2); // thinking_end + text_end
+    fake.teardown();
+  });
+});
+
+/* ──────────────── LiveEvent 契约：穷尽 switch + 负向/边界行为 ──────────────── */
+
+describe("LiveEvent · 契约硬化", () => {
+  // 编译期穷尽 switch：镜像 phase3-capabilities.test.ts 里对 SessionEvent 的 smoke。
+  // 将来给 LiveEvent 加 arm 而不更新这里，`const _: never = e` 会让 tsc 报错。
+  it("compile-time exhaustive switch (smoke) —— 也真跑一遍每个 arm", () => {
+    const handle = (e: LiveEvent): string => {
+      switch (e.type) {
+        case "message_start":
+          return "ms";
+        case "text_delta":
+          return "td";
+        case "thinking_delta":
+          return "kd";
+        case "toolcall_delta":
+          return "cd";
+        case "message_update":
+          return "mu";
+        case "message_end":
+          return "me";
+        default: {
+          const _: never = e;
+          void _;
+          return "?";
+        }
+      }
+    };
+
+    // 不只编译，喂每个 arm 真跑，确保 handle 是 total 的、且各分支可达。
+    const msg = { role: "assistant", content: [] } as unknown as AssistantMessage;
+    const all: LiveEvent[] = [
+      { type: "message_start" },
+      { type: "text_delta", contentIndex: 0, delta: "x" },
+      { type: "thinking_delta", contentIndex: 0, delta: "x" },
+      { type: "toolcall_delta", contentIndex: 0, delta: "x" },
+      { type: "message_update", message: msg },
+      { type: "message_end", message: msg },
+    ];
+    expect(all.map(handle)).toEqual(["ms", "td", "kd", "cd", "mu", "me"]);
+  });
+
+  // 负向：message_update 绝不在同一块的 *_delta 之间穿插；它只在块边界（*_end）发一次，
+  // 即每块的所有 delta 都排在该块那条 update 之前。
+  it("never fires message_update interleaved between deltas of the same block (only at *_end)", async () => {
+    const fake = createFakeModel([
+      {
+        content: [{ type: "text", text: "answer" }],
+        thinkingDeltas: ["mu", "ll"],
+        textDeltas: ["ans", "wer"],
+      },
+    ]);
+    const session = new AgentSession({ model: fake, tools: [] });
+    const seq: string[] = [];
+    session.on("thinking_delta", () => seq.push("kd"));
+    session.on("text_delta", () => seq.push("td"));
+    session.on("message_update", () => seq.push("mu"));
+    await session.run("hi");
+
+    // thinking 块：两条 kd 后才有一条 mu；text 块同理。绝无 kd→mu→kd 或 td→mu→td 穿插。
+    expect(seq).toEqual(["kd", "kd", "mu", "td", "td", "mu"]);
+    // 显式断言：任意 mu 之前不会再出现「与它同块、本该排在它前面」的 delta 被它隔开——
+    // 即每条 mu 都紧跟在其块全部 delta 之后。
+    const firstMu = seq.indexOf("mu");
+    expect(seq.slice(0, firstMu).every((t) => t === "kd")).toBe(true); // 第一块（thinking）的 delta 全在第一条 mu 之前
+    fake.teardown();
+  });
+
+  // 边界：仅含 toolCall 的回合（无 text/thinking）。message_update 在 toolcall_end 发一次。
+  it("toolcall-only turn: message_update fires once for the toolcall block, between start and end", async () => {
+    const fake = createFakeModel([
+      {
+        content: [{ type: "toolCall", name: "noop", arguments: { a: 1 } }],
+        toolcallDeltas: ['{"a":', "1}"],
+      },
+      { content: [{ type: "text", text: "done" }] },
+    ]);
+    const session = new AgentSession({ model: fake, tools: [noopTool] });
+    const seq: string[] = [];
+    let updates = 0;
+    let snapshot: AssistantMessage | undefined;
+    session.on("message_start", () => seq.push("start"));
+    session.on("toolcall_delta", () => seq.push("cd"));
+    session.on("message_update", (e) => {
+      seq.push("update");
+      updates++;
+      snapshot = e.message;
+    });
+    session.on("message_end", () => seq.push("end"));
+    await session.run("hi");
+
+    // 第一回合（toolcall-only）的子序列：start → cd* → update（toolcall_end）→ end。
+    // 取到第一个 end 为止即第一回合。
+    const firstTurn = seq.slice(0, seq.indexOf("end") + 1);
+    expect(firstTurn).toEqual(["start", "cd", "cd", "update", "end"]);
+    expect(updates).toBe(1); // 整个回合只为 toolcall 块发了一次 update
+    // 快照里确有 toolCall 块（即 update 携带的是这条 toolcall-only 消息的 partial）。
+    expect(snapshot?.content.some((b) => b.type === "toolCall")).toBe(true);
     fake.teardown();
   });
 });

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -64,16 +64,26 @@ export type SessionEvent =
  * 这里是回合**进行中**的细粒度 token/thinking/toolcall delta，经 `session.on(type, cb)` 订阅。
  * 它们**可丢**（UI 丢几帧无所谓），不进 transcript；listener 抛错被内核隔离，绝不影响 loop
  * （借鉴 kimi LoopEventDispatcher 的 durable/live 双轨 + live listener 容错）。
+ *
+ * 这个 union 显式列出，让消费者用 discriminated switch 处理。新加 arm 时记得
+ * 同步更新 event-bus.test.ts 的 LiveEvent exhaustive-switch 测试。
  */
 export type LiveEvent =
   | { type: "message_start" }
   | { type: "text_delta"; contentIndex: number; delta: string }
   | { type: "thinking_delta"; contentIndex: number; delta: string }
   | { type: "toolcall_delta"; contentIndex: number; delta: string }
-  // `message_update`：内容块边界（text / thinking / toolcall 各自 `*_end`）发一次的「已拼好的整条
-  // 消息」快照，携带 pi-ai 的 `partial`。比逐 token delta **低频**（每块一次，非每 token，避免 O(n²)
-  // 流量），给偏好渲染整条快照而非自己累积 delta 的前端用；要 token 流的仍订阅 `*_delta`。
-  // 终态以 `message_end` 为准。
+  // `message_update`：**回合进行中**的「中间态、逐块快照」。在每个内容块边界（text / thinking /
+  // toolcall 各自 `*_end`）各发一次，携带 pi-ai 截至此刻**已拼好的 `partial`**。比逐 token delta
+  // **低频**（每块一次，非每 token，避免 O(n²) 流量）。
+  //
+  // **契约（务必看清）**：
+  //   - 它是**中间快照**，不是终态。`message.content` 只含「已收尾的块」，回合还没结束。
+  //   - **终态、权威**的整条消息以 `message_end`（源自 `stream().result()`）为准。
+  //   - 需要终态的消费者**必须**用 `message_end`；把 `message_update.message` 当终态（例如在 mid-abort
+  //     时拿最后一帧 update 当成最终结果）是**错的**——它可能缺少尚未收尾的块。
+  //   - 偏好「渲染整条快照」的 UI **主动**订阅 `message_update`；偏好「自己累积 delta」的 UI **忽略**它、
+  //     只订阅 `*_delta`。两类消费者互不依赖。
   | { type: "message_update"; message: AssistantMessage }
   // `message_start` 与 `message_end` **严格成对**：成功路径在 try 后 emit 一次（带 message），
   // catch 路径 emit 一次（不带 message）且必 rethrow —— 两路恰好各一次，不重复、不悬空。

--- a/packages/core/src/testing.ts
+++ b/packages/core/src/testing.ts
@@ -64,6 +64,14 @@ export interface FakeAssistantResponse {
    * 用于测试 message_start/message_end 在异常下仍严格配对。
    */
   streamThrows?: Error;
+  /**
+   * 在指定内容块的 `*_end` 之后**注入一次 mid-stream abort**：fake 不再发后续块，直接以
+   * 「截至此刻的 partial」为内容 push 一个 `stopReason:"aborted"` 终态（对齐 pi-ai faux provider 的
+   * `createAbortedMessage(partial)` 语义）。用于测 `message_update` 契约——证明流被中途打断时，最后一帧
+   * `message_update` 只含**已收尾的块**、缺尚未流出的块，且终态须由 `message_end`（携 `stopReason:"aborted"`）
+   * 判定，而非把最后一帧 update 当终态。确定性、无时序竞争（abort 由 fake 在块边界自行注入，不靠外部 signal 抢跑）。
+   */
+  abortAfterBlock?: "thinking" | "text" | "toolcall";
 }
 
 /**
@@ -201,28 +209,49 @@ export function createFakeModel(
             timestamp: Date.now(),
           };
           // 可选：push 流式 delta 事件（供 Event Bus 测试）。在 end() 之前。
+          //
+          // **忠实复刻 pi-ai 的 `partial` 语义**（对齐 providers/faux.js + anthropic/google 等真实 provider）：
+          // `partial` 是「截至当前已收尾块」的**渐进式快照**，每条事件携带一份**独立拷贝**（content 数组逐块增长），
+          // 而非全程复用最终 `assistant`。kernel 只在 `*_end` 转发 `partial` 作 `message_update`，故只有 `*_end`
+          // 上的 partial 会被消费——但 start/delta 也照发独立快照，避免「假 partial」给测试错误的安全感。
+          // 最终 `result()` 仍是完整 `assistant`（done 事件携带），与 partial 是不同对象、内容是其超集。
+          const built: AssistantMessage["content"] = [];
+          const snap = (): AssistantMessage => ({ ...assistant, content: built.slice() });
+          // 在某块 `*_end` 后注入 mid-stream abort：以「截至此刻 partial」为内容 finish 成 aborted 终态，不再发后续块。
+          const abortHere = (block: NonNullable<FakeAssistantResponse["abortAfterBlock"]>): boolean => {
+            if (next.abortAfterBlock !== block) return false;
+            finish({ ...assistant, content: built.slice(), stopReason: "aborted", errorMessage: "aborted mid-stream" });
+            return true;
+          };
+
           if (next.thinkingDeltas?.length) {
-            stream.push({ type: "thinking_start", contentIndex: 0, partial: assistant } as never);
+            stream.push({ type: "thinking_start", contentIndex: 0, partial: snap() } as never);
             for (const d of next.thinkingDeltas)
-              stream.push({ type: "thinking_delta", contentIndex: 0, delta: d, partial: assistant } as never);
-            stream.push({ type: "thinking_end", contentIndex: 0, content: next.thinkingDeltas.join(""), partial: assistant } as never);
+              stream.push({ type: "thinking_delta", contentIndex: 0, delta: d, partial: snap() } as never);
+            built.push({ type: "thinking", thinking: next.thinkingDeltas.join("") } as never);
+            stream.push({ type: "thinking_end", contentIndex: 0, content: next.thinkingDeltas.join(""), partial: snap() } as never);
+            if (abortHere("thinking")) return;
           }
           if (next.textDeltas?.length) {
             const ci = content.findIndex((b) => b.type === "text");
             if (ci < 0) throw new Error("createFakeModel: textDeltas set but no text block in content");
-            stream.push({ type: "text_start", contentIndex: ci, partial: assistant } as never);
+            stream.push({ type: "text_start", contentIndex: ci, partial: snap() } as never);
             for (const d of next.textDeltas)
-              stream.push({ type: "text_delta", contentIndex: ci, delta: d, partial: assistant } as never);
-            stream.push({ type: "text_end", contentIndex: ci, content: next.textDeltas.join(""), partial: assistant } as never);
+              stream.push({ type: "text_delta", contentIndex: ci, delta: d, partial: snap() } as never);
+            built.push(content[ci]!); // ci>=0 已校验
+            stream.push({ type: "text_end", contentIndex: ci, content: next.textDeltas.join(""), partial: snap() } as never);
+            if (abortHere("text")) return;
           }
           if (next.toolcallDeltas?.length) {
             const ci = content.findIndex((b) => b.type === "toolCall");
             if (ci < 0) throw new Error("createFakeModel: toolcallDeltas set but no toolCall block in content");
-            const tc = content[ci];
-            stream.push({ type: "toolcall_start", contentIndex: ci, partial: assistant } as never);
+            const tc = content[ci]!; // ci>=0 已校验
+            stream.push({ type: "toolcall_start", contentIndex: ci, partial: snap() } as never);
             for (const d of next.toolcallDeltas)
-              stream.push({ type: "toolcall_delta", contentIndex: ci, delta: d, partial: assistant } as never);
-            stream.push({ type: "toolcall_end", contentIndex: ci, toolCall: tc, partial: assistant } as never);
+              stream.push({ type: "toolcall_delta", contentIndex: ci, delta: d, partial: snap() } as never);
+            built.push(tc);
+            stream.push({ type: "toolcall_end", contentIndex: ci, toolCall: tc, partial: snap() } as never);
+            if (abortHere("toolcall")) return;
           }
           finish(assistant);
         })();


### PR DESCRIPTION
Closes #15.

锁定 `message_update` LiveEvent 的「中间态、逐块 partial 快照」契约——它**不是**权威终态,终态须由 `message_end` 判定。

## 改动
- **`packages/core/src/session.ts`**(纯注释,零行为变更):重写 `message_update` LiveEvent arm 的契约说明 + exhaustive-switch 维护提示。
- **`packages/core/src/testing.ts`**(根因修复):`createFakeModel` 此前全程复用最终 `assistant` 当 `partial`——撒谎的「假 partial」让契约无法被测试锁住。现改为忠实复刻 pi-ai faux/真实 provider 的渐进式 partial:每个 `*_start/*_delta/*_end` 携带**独立快照**(`{ ...assistant, content: built.slice() }`),content 逐块增长;`result()` 仍返回完整终态(独立对象、内容超集)。新增 opt-in `abortAfterBlock` 注入**确定性** mid-stream abort(无时序竞争)。
- **`packages/core/src/__tests__/event-bus.test.ts`**:收紧既有边界断言(update 是独立 partial 快照,`not.toBe(final)`)+ 新增 6 个契约测试:early update ⊊ final(块数更少)、跨块单调增长、mid-stream abort(最后一帧缺未流出块、aborted 终态经 message_end)、message_update listener 抛错隔离、错误回合零 update(sync-throw + error-event 双路径)、多回合逐回合归属。

## 验证
- core 240 测试绿(原 234,event-bus 26);`pnpm -r test` 全仓绿;`pnpm -r typecheck` 全 9 项目绿。
- 三审:code-review 8.97 ✅ / test-review 8.63 ✅ / linus "Looks reasonable." ✅。

🤖 Generated with [Claude Code](https://claude.com/claude-code)