### PR TITLE
fix(coding-agent,plugins): redact tool args in session log by default (#11 item 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ pnpm --filter @harness-pi/coding-agent start -- --cwd . --model dashscope:qwen-p
 - 默认 full mode 挂 `read/bash/edit/write/grep/find/ls`；`--read-only` 只挂 `read/grep/find/ls`。
 - `--disable bash,write` 可以关闭指定基础 tool。
 - 默认 log 目录是 `.harness-pi/logs`；`--metrics-file path.ndjson` 可写 metrics。
+- 默认对 session log 里的高危 tool args 脱敏（`write` 内容、`edit` 文本、`bash` 命令仅记长度，不落原文，避免密钥/源码静默写进 `.harness-pi/logs`）；`--log-args full` 记原始 args（仅本地调试）；`--log-args none` 完全不记 args；`--no-log` 关闭整个 session log。
 - **安全边界**：`bash` 是 host shell，不是 sandbox。full mode 只应在你明确允许修改的 workspace 里运行。
 
 ## Layout

--- a/apps/coding-agent/src/__tests__/cli-args.test.ts
+++ b/apps/coding-agent/src/__tests__/cli-args.test.ts
@@ -63,6 +63,20 @@ describe("parseArgs — v0.1.0 flags", () => {
     expect(() => parseArgs(["--log-args", "bogus"])).toThrow(/Invalid --log-args/);
   });
 
+  it("--log-args is case-sensitive (大写非法值抛错，避免大小写漏脱敏)", () => {
+    expect(() => parseArgs(["--log-args", "Redacted"])).toThrow(/Invalid --log-args/);
+    expect(() => parseArgs(["--log-args", "FULL"])).toThrow(/Invalid --log-args/);
+  });
+
+  it("--log-args with empty string throws", () => {
+    // requireValue 把 "" 当缺值（空串 falsy）→ 报 requires a value，而非进 parseLogArgs。
+    expect(() => parseArgs(["--log-args", ""])).toThrow(/requires a value/);
+  });
+
+  it("--log-args with no value throws", () => {
+    expect(() => parseArgs(["--log-args"])).toThrow(/requires a value/);
+  });
+
   it("rejects unknown options", () => {
     expect(() => parseArgs(["--nope"])).toThrow(/Unknown option/);
   });

--- a/apps/coding-agent/src/__tests__/cli-args.test.ts
+++ b/apps/coding-agent/src/__tests__/cli-args.test.ts
@@ -45,6 +45,24 @@ describe("parseArgs — v0.1.0 flags", () => {
     expect(a.task).toBe("do a thing");
   });
 
+  it("--no-log sets noLog", () => {
+    expect(parseArgs(["--no-log"]).noLog).toBe(true);
+  });
+
+  it("--log-args parses redacted | full | none", () => {
+    expect(parseArgs(["--log-args", "redacted"]).logArgs).toBe("redacted");
+    expect(parseArgs(["--log-args", "full"]).logArgs).toBe("full");
+    expect(parseArgs(["--log-args", "none"]).logArgs).toBe("none");
+  });
+
+  it("--log-args defaults to undefined (agent applies the default)", () => {
+    expect(parseArgs([]).logArgs).toBeUndefined();
+  });
+
+  it("--log-args with an invalid value throws", () => {
+    expect(() => parseArgs(["--log-args", "bogus"])).toThrow(/Invalid --log-args/);
+  });
+
   it("rejects unknown options", () => {
     expect(() => parseArgs(["--nope"])).toThrow(/Unknown option/);
   });

--- a/apps/coding-agent/src/__tests__/log-redaction.test.ts
+++ b/apps/coding-agent/src/__tests__/log-redaction.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createFakeModel } from "@harness-pi/core/testing";
 import { redactCodingToolArgs } from "../log-redaction.js";
+import { createCodingAgent, runAgentPrompt } from "../agent.js";
 
 describe("redactCodingToolArgs", () => {
   it("write.content → 仅记长度", () => {
@@ -51,5 +57,143 @@ describe("redactCodingToolArgs", () => {
       glob: "*.ts",
     });
     expect(out).toEqual({ pattern: "TODO", path: "src", glob: "*.ts" });
+  });
+
+  it("空字符串 content → 0 chars（零值边界）", () => {
+    expect(redactCodingToolArgs("write", { path: "a", content: "" })).toEqual({
+      path: "a",
+      content: "[redacted content, 0 chars]",
+    });
+    expect(redactCodingToolArgs("edit", { path: "a", oldText: "", newText: "x" })).toEqual({
+      path: "a",
+      oldText: "[redacted text, 0 chars]",
+      newText: "[redacted text, 1 chars]",
+    });
+  });
+
+  it("非字符串高危字段也脱敏（堵住对象/数组内容泄漏，不靠 schema 校验）", () => {
+    // 模型发来错误类型的 content：若只对 string 脱敏，对象内容会原文落盘——必须照样脱敏。
+    expect(
+      redactCodingToolArgs("write", { path: "a", content: { secret: "leak" } }),
+    ).toEqual({ path: "a", content: "[redacted content]" });
+    expect(
+      redactCodingToolArgs("bash", { command: ["echo", "$TOKEN"] }),
+    ).toEqual({ command: "[redacted command]" });
+  });
+
+  it("edit 只给单边 → 只脱敏存在的字段，不引入 undefined", () => {
+    const onlyOld = redactCodingToolArgs("edit", { path: "a", oldText: "abc" });
+    expect(onlyOld).toEqual({ path: "a", oldText: "[redacted text, 3 chars]" });
+    expect("newText" in (onlyOld as object)).toBe(false); // 不凭空加 newText
+
+    const onlyNew = redactCodingToolArgs("edit", { path: "a", newText: "abcd" });
+    expect(onlyNew).toEqual({ path: "a", newText: "[redacted text, 4 chars]" });
+    expect("oldText" in (onlyNew as object)).toBe(false);
+  });
+
+  it("长度按 .length（UTF-16 code unit）计：emoji/中文是 surrogate/多码元", () => {
+    // 🔑 是 UTF-16 代理对 → .length === 2；中文每字 1 个码元。钉住语义，避免误以为是字节/字符数。
+    expect(redactCodingToolArgs("write", { content: "🔑" })).toEqual({
+      content: "[redacted content, 2 chars]",
+    });
+    expect(redactCodingToolArgs("write", { content: "你好" })).toEqual({
+      content: "[redacted content, 2 chars]",
+    });
+  });
+
+  it("数组 args 原样返回（不被浅拷成丢失数组性的对象）", () => {
+    const arr = ["a", "b"];
+    expect(redactCodingToolArgs("write", arr)).toBe(arr); // 同一引用、仍是数组
+  });
+
+  it("工具名精确匹配（大小写敏感）——真实第一方工具名均小写", () => {
+    // 'Write'（大写）不是已注册工具名，故不脱敏、原样透传。真实工具名是小写 write/edit/bash。
+    expect(redactCodingToolArgs("Write", { content: "x" })).toEqual({ content: "x" });
+  });
+
+  it("无副作用：不原地 mutate 传入的 args", () => {
+    const input = { path: "a", content: "secret" };
+    const out = redactCodingToolArgs("write", input);
+    expect(input.content).toBe("secret"); // 原对象未被改
+    expect(out).not.toBe(input); // 返回的是副本
+    expect((out as { content: string }).content).toBe("[redacted content, 6 chars]");
+  });
+});
+
+/* ─────────── 端到端：createCodingAgent 各 logArgs/log 分支真正落盘行为 ─────────── */
+
+describe("coding-agent session-log 脱敏（端到端，走真 redactCodingToolArgs）", () => {
+  const dirs: string[] = [];
+  afterEach(async () => {
+    while (dirs.length) {
+      const d = dirs.pop();
+      if (d) await rm(d, { recursive: true, force: true });
+    }
+  });
+  async function tempRepo(): Promise<string> {
+    const d = await mkdtemp(join(tmpdir(), "harness-pi-logredact-"));
+    dirs.push(d);
+    return d;
+  }
+
+  const SECRET = "SUPER-SECRET-PAYLOAD-9f3a-do-not-leak";
+  // 一次 write（写入 secret 内容）+ 一句收尾文本。write 真执行（落到临时 cwd），与日志无关。
+  const makeFake = () =>
+    createFakeModel([
+      { content: [{ type: "toolCall", name: "write", arguments: { path: "out.txt", content: SECRET } }] },
+      { content: [{ type: "text", text: "done" }] },
+    ]);
+  const findPre = (log: string, tool: string): { args: unknown } =>
+    log
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l))
+      .find((e) => e.event === "preToolUse" && e.tool === tool);
+  // session log 是异步 WriteStream，onSessionEnd 里 end() 后给一拍让数据落盘。
+  const settle = () => new Promise((r) => setTimeout(r, 50));
+
+  it("默认（不传 logArgs）：write.content 在 .ndjson 被脱敏，原文不落盘", async () => {
+    const cwd = await tempRepo();
+    const report = await runAgentPrompt(createCodingAgent({ cwd, model: makeFake() }), "go");
+    await settle();
+    const log = readFileSync(report.logPath, "utf-8");
+    expect(log).not.toContain(SECRET); // 核心安全契约：默认就不落原文
+    expect((findPre(log, "write").args as { content: string }).content).toMatch(
+      /^\[redacted content, \d+ chars\]$/,
+    );
+  });
+
+  it('logArgs="none"：args 记为 [args omitted]，原文不落盘', async () => {
+    const cwd = await tempRepo();
+    const report = await runAgentPrompt(
+      createCodingAgent({ cwd, model: makeFake(), logArgs: "none" }),
+      "go",
+    );
+    await settle();
+    const log = readFileSync(report.logPath, "utf-8");
+    expect(log).not.toContain(SECRET);
+    expect(findPre(log, "write").args).toBe("[args omitted]");
+  });
+
+  it('logArgs="full"：原始 args 原样落盘（显式 opt-in，与默认成对照）', async () => {
+    const cwd = await tempRepo();
+    const report = await runAgentPrompt(
+      createCodingAgent({ cwd, model: makeFake(), logArgs: "full" }),
+      "go",
+    );
+    await settle();
+    const log = readFileSync(report.logPath, "utf-8");
+    expect(log).toContain(SECRET); // full 模式确实记原文
+    expect(findPre(log, "write").args).toEqual({ path: "out.txt", content: SECRET });
+  });
+
+  it("log:false：sessionLog 完全不挂，不产生任何 .ndjson 文件", async () => {
+    const cwd = await tempRepo();
+    const report = await runAgentPrompt(
+      createCodingAgent({ cwd, model: makeFake(), log: false }),
+      "go",
+    );
+    await settle();
+    expect(existsSync(report.logPath)).toBe(false); // --no-log 的核心契约：根本不落盘
   });
 });

--- a/apps/coding-agent/src/__tests__/log-redaction.test.ts
+++ b/apps/coding-agent/src/__tests__/log-redaction.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { redactCodingToolArgs } from "../log-redaction.js";
+
+describe("redactCodingToolArgs", () => {
+  it("write.content → 仅记长度", () => {
+    const out = redactCodingToolArgs("write", {
+      path: "src/a.ts",
+      content: "hello world",
+    });
+    expect(out).toEqual({
+      path: "src/a.ts",
+      content: "[redacted content, 11 chars]",
+    });
+  });
+
+  it("edit.oldText + newText → 各自仅记长度", () => {
+    const out = redactCodingToolArgs("edit", {
+      path: "src/a.ts",
+      oldText: "abc",
+      newText: "abcde",
+    });
+    expect(out).toEqual({
+      path: "src/a.ts",
+      oldText: "[redacted text, 3 chars]",
+      newText: "[redacted text, 5 chars]",
+    });
+  });
+
+  it("bash.command → 仅记长度", () => {
+    const out = redactCodingToolArgs("bash", {
+      command: "echo $TOKEN",
+    });
+    expect(out).toEqual({ command: "[redacted command, 11 chars]" });
+  });
+
+  it("read.path 透传不变（低危字段）", () => {
+    const out = redactCodingToolArgs("read", { path: "src/a.ts" });
+    expect(out).toEqual({ path: "src/a.ts" });
+  });
+
+  it("非对象 args 原样返回", () => {
+    expect(redactCodingToolArgs("write", "raw")).toBe("raw");
+    expect(redactCodingToolArgs("write", null)).toBeNull();
+    expect(redactCodingToolArgs("write", undefined)).toBeUndefined();
+  });
+
+  it("未知工具原样透传", () => {
+    const out = redactCodingToolArgs("grep", {
+      pattern: "TODO",
+      path: "src",
+      glob: "*.ts",
+    });
+    expect(out).toEqual({ pattern: "TODO", path: "src", glob: "*.ts" });
+  });
+});

--- a/apps/coding-agent/src/agent.ts
+++ b/apps/coding-agent/src/agent.ts
@@ -30,6 +30,7 @@ import {
   type ToolStats,
 } from "@harness-pi/plugins";
 import { createModelSummarizer } from "./compaction.js";
+import { redactCodingToolArgs } from "./log-redaction.js";
 import { defaultPermissionRules } from "./tui/permissions.js";
 import {
   createAllTools,
@@ -58,6 +59,15 @@ export interface CreateCodingAgentOptions {
   readOnly?: boolean;
   disabledTools?: ToolName[];
   logDir?: string;
+  /**
+   * session log 是否挂载。默认 true；false ⇒ 完全不挂 sessionLog（不落盘任何 event）。
+   */
+  log?: boolean;
+  /**
+   * session log 里 tool args 的记录方式。默认 "redacted"：write 内容 / edit 文本 / bash 命令仅记长度、
+   * 不落原文（见 log-redaction.ts）。"full" ⇒ 记原始 args（仅本地调试）；"none" ⇒ 不记 args。
+   */
+  logArgs?: "redacted" | "full" | "none";
   metricsFile?: string;
   systemPrompt?: string;
   toolsOptions?: ToolsOptions;
@@ -296,8 +306,16 @@ function buildAgentContext(opts: CreateCodingAgentOptions): AgentContext {
     };
   }
 
+  // session log：默认挂；`log:false` 完全不挂。logArgs 控制 tool args 记录方式（默认 redacted 脱敏，
+  // 防止 write 内容 / edit 文本 / bash 命令含密钥静默落盘到 .harness-pi/logs）。
+  const logArgs = opts.logArgs ?? "redacted";
+  const sessionLogOptions: Parameters<typeof sessionLog>[0] = { dir: logDir };
+  if (logArgs === "redacted") sessionLogOptions.redactToolArgs = redactCodingToolArgs;
+  else if (logArgs === "none") sessionLogOptions.redactToolArgs = () => "[args omitted]";
+  // logArgs === "full"：不设 redactToolArgs，记原始 args。
+
   const hooks = [
-    sessionLog({ dir: logDir }),
+    ...(opts.log === false ? [] : [sessionLog(sessionLogOptions)]),
     // compactSummarize 须排在 trimHistory 前：先把早期消息总结成 summary，再让 trimHistory 裁中段
     // toolResult（docs/09 §3.6「先 summarize 早期、再 trim 中段」的组合顺序）。未启用 compaction 时不挂。
     ...(compactionOpts ? [compactSummarize(compactionOpts)] : []),

--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -33,6 +33,8 @@ interface CliArgs {
   readOnly: boolean;
   disabledTools: ToolName[];
   logDir?: string | undefined;
+  noLog?: boolean | undefined;
+  logArgs?: "redacted" | "full" | "none" | undefined;
   metricsFile?: string | undefined;
   task?: string | undefined;
   tui: boolean;
@@ -167,6 +169,8 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     createOptions.llmOptions = runtime.llmOptions;
   }
   if (args.logDir !== undefined) createOptions.logDir = args.logDir;
+  if (args.noLog === true) createOptions.log = false;
+  if (args.logArgs !== undefined) createOptions.logArgs = args.logArgs;
   if (args.metricsFile !== undefined) {
     createOptions.metricsFile = args.metricsFile;
   }
@@ -338,6 +342,14 @@ export function parseArgs(argv: string[]): CliArgs {
       out.logDir = requireValue(argv, ++i, "--log-dir");
       continue;
     }
+    if (arg === "--no-log") {
+      out.noLog = true;
+      continue;
+    }
+    if (arg === "--log-args") {
+      out.logArgs = parseLogArgs(requireValue(argv, ++i, "--log-args"));
+      continue;
+    }
     if (arg === "--metrics-file") {
       out.metricsFile = requireValue(argv, ++i, "--metrics-file");
       continue;
@@ -366,6 +378,15 @@ export function parseDisabledTools(value: string): ToolName[] {
       }
       return part as ToolName;
     });
+}
+
+export function parseLogArgs(value: string): "redacted" | "full" | "none" {
+  if (value !== "redacted" && value !== "full" && value !== "none") {
+    throw new Error(
+      `Invalid --log-args "${value}". Expected one of: redacted, full, none.`,
+    );
+  }
+  return value;
 }
 
 function requireValue(argv: string[], index: number, flag: string): string {
@@ -492,6 +513,8 @@ Options:
   --disable <a,b>          Disable named first-party tools (read,bash,edit,write,grep,find,ls).
   --env-file <path>        Load env vars from a .env file (./.env is auto-loaded too).
   --log-dir <path>         Session log directory. Defaults to .harness-pi/logs.
+  --no-log                 Disable the session log entirely.
+  --log-args <mode>        Tool-arg logging: redacted (default) | full | none.
   --metrics-file <path>    Write run metrics as NDJSON.
   --list-providers         List supported providers and their API-key env vars.
   --list-models <provider> List model ids for a provider.

--- a/apps/coding-agent/src/log-redaction.ts
+++ b/apps/coding-agent/src/log-redaction.ts
@@ -9,29 +9,49 @@
  */
 
 /**
+ * 把 `clone` 里一个**存在的**高危字段就地脱敏：字符串记长度，非字符串只记一个无值标记。
+ *
+ * 为何非字符串也脱敏：tool schema 虽声明这些字段是 string，但模型可能发来错误类型（如对象/数组），
+ * 内核不保证落盘前已 schema 校验。若只对 string 脱敏，一个 `content: { secret: ... }` 会原文落盘——
+ * 这正是泄密点。故只要 key 存在就脱敏，类型不对也不放过（堵住对象/数组内容泄漏）。
+ * 字段不存在则不动（不引入 undefined 字段，例如 edit 只给单边）。
+ */
+function redactField(
+  clone: Record<string, unknown>,
+  key: string,
+  label: string,
+): void {
+  if (!(key in clone)) return;
+  const v = clone[key];
+  clone[key] =
+    typeof v === "string"
+      ? `[redacted ${label}, ${v.length} chars]`
+      : `[redacted ${label}]`;
+}
+
+/**
  * 默认脱敏器：注入给 `sessionLog({ redactToolArgs })`。
  *
- * 行为：`args` 是非空对象时浅拷贝，只替换高危字符串字段，其余一律保留：
- * - `write.content` → `[redacted content, N chars]`
+ * 行为：`args` 是非数组的非空对象时浅拷贝，只替换高危字段（存在即脱敏，含非字符串），其余一律保留：
+ * - `write.content` → `[redacted content, N chars]`（非字符串 → `[redacted content]`）
  * - `edit.oldText` / `edit.newText` → `[redacted text, N chars]`
  * - `bash.command` → `[redacted command, N chars]`
  *
- * 其它工具、非字符串字段、以及非对象 args 一律原样返回。
+ * 其它工具、低危字段（path/pattern/glob…）、数组与非对象 args 一律原样返回。**无副作用**：浅拷贝后改副本，
+ * 不原地 mutate 传入的 `args`（避免脱敏污染下游 tool 执行）。
  */
 export function redactCodingToolArgs(toolName: string, args: unknown): unknown {
-  if (typeof args !== "object" || args === null) return args;
+  if (typeof args !== "object" || args === null || Array.isArray(args)) {
+    return args;
+  }
   const clone: Record<string, unknown> = { ...(args as Record<string, unknown>) };
-  if (toolName === "write" && typeof clone["content"] === "string") {
-    clone["content"] = `[redacted content, ${clone["content"].length} chars]`;
+  if (toolName === "write") {
+    redactField(clone, "content", "content");
   } else if (toolName === "edit") {
-    if (typeof clone["oldText"] === "string") {
-      clone["oldText"] = `[redacted text, ${clone["oldText"].length} chars]`;
-    }
-    if (typeof clone["newText"] === "string") {
-      clone["newText"] = `[redacted text, ${clone["newText"].length} chars]`;
-    }
-  } else if (toolName === "bash" && typeof clone["command"] === "string") {
-    clone["command"] = `[redacted command, ${clone["command"].length} chars]`;
+    redactField(clone, "oldText", "text");
+    redactField(clone, "newText", "text");
+  } else if (toolName === "bash") {
+    redactField(clone, "command", "command");
   }
   return clone;
 }

--- a/apps/coding-agent/src/log-redaction.ts
+++ b/apps/coding-agent/src/log-redaction.ts
@@ -1,0 +1,37 @@
+/**
+ * Session log 的 tool-arg 脱敏策略（coding-agent 专用）。
+ *
+ * session-log 库层默认把 `call.arguments` 原样落盘；coding-agent 默认每会话挂它，会把第一方 mutating
+ * 工具的高危内容（write 的整文件内容、edit 的源码片段/密钥、bash 含凭据的命令）静默写进
+ * `.harness-pi/logs/<sessionId>.ndjson`——而目标 repo 未必把 `.harness-pi/` 加进 .gitignore。
+ *
+ * 本模块只对**已知的高危字符串字段**仅记长度、不落原文；其余字段（path/pattern/glob 等低危）原样透传。
+ */
+
+/**
+ * 默认脱敏器：注入给 `sessionLog({ redactToolArgs })`。
+ *
+ * 行为：`args` 是非空对象时浅拷贝，只替换高危字符串字段，其余一律保留：
+ * - `write.content` → `[redacted content, N chars]`
+ * - `edit.oldText` / `edit.newText` → `[redacted text, N chars]`
+ * - `bash.command` → `[redacted command, N chars]`
+ *
+ * 其它工具、非字符串字段、以及非对象 args 一律原样返回。
+ */
+export function redactCodingToolArgs(toolName: string, args: unknown): unknown {
+  if (typeof args !== "object" || args === null) return args;
+  const clone: Record<string, unknown> = { ...(args as Record<string, unknown>) };
+  if (toolName === "write" && typeof clone["content"] === "string") {
+    clone["content"] = `[redacted content, ${clone["content"].length} chars]`;
+  } else if (toolName === "edit") {
+    if (typeof clone["oldText"] === "string") {
+      clone["oldText"] = `[redacted text, ${clone["oldText"].length} chars]`;
+    }
+    if (typeof clone["newText"] === "string") {
+      clone["newText"] = `[redacted text, ${clone["newText"].length} chars]`;
+    }
+  } else if (toolName === "bash" && typeof clone["command"] === "string") {
+    clone["command"] = `[redacted command, ${clone["command"].length} chars]`;
+  }
+  return clone;
+}

--- a/packages/plugins/src/__tests__/plugins.test.ts
+++ b/packages/plugins/src/__tests__/plugins.test.ts
@@ -298,6 +298,67 @@ describe("session-log", () => {
     rmSync(tmp, { recursive: true, force: true });
   });
 
+  it("redactToolArgs 给定时，preToolUse 记脱敏后的 args（原始值不落盘）", async () => {
+    const model = createFakeModel([
+      { content: [{ type: "toolCall", name: "echo", arguments: { msg: "secret-value" } }] },
+      { content: [{ type: "text", text: "done" }] },
+    ]);
+    let seenArgs: unknown;
+    const session = new AgentSession({
+      model,
+      tools: [echoTool],
+      hooks: [
+        sessionLog({
+          dir: tmp,
+          redactToolArgs: (name, args) => {
+            seenArgs = args; // 证明 redactor 拿到的是**原始** args（脱敏发生在落盘前）
+            return { tool: name, redacted: true };
+          },
+        }),
+      ],
+    });
+    await session.run("hi");
+    await new Promise((r) => setTimeout(r, 30));
+
+    // redactor 收到的是未脱敏的原始 args
+    expect(seenArgs).toEqual({ msg: "secret-value" });
+    const content = readFileSync(join(tmp, `${session.id}.ndjson`), "utf-8");
+    const pre = content
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l))
+      .find((e) => e.event === "preToolUse");
+    expect(pre).toBeDefined();
+    expect(pre.args).toEqual({ tool: "echo", redacted: true });
+    // 原始 arg 值不应出现在整份日志里
+    expect(content).not.toContain("secret-value");
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("未给 redactToolArgs 时，preToolUse 记原始 args（库层默认不脱敏）", async () => {
+    const model = createFakeModel([
+      { content: [{ type: "toolCall", name: "echo", arguments: { msg: "raw-value" } }] },
+      { content: [{ type: "text", text: "done" }] },
+    ]);
+    const session = new AgentSession({
+      model,
+      tools: [echoTool],
+      hooks: [sessionLog({ dir: tmp })],
+    });
+    await session.run("hi");
+    await new Promise((r) => setTimeout(r, 30));
+
+    const content = readFileSync(join(tmp, `${session.id}.ndjson`), "utf-8");
+    const pre = content
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l))
+      .find((e) => e.event === "preToolUse");
+    expect(pre).toBeDefined();
+    expect(pre.args).toEqual({ msg: "raw-value" });
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
   it("dead 状态：stream error 后 status 转 dead，dropped 累加，永不回 ok", async () => {
     const model = createFakeModel([
       { content: [{ type: "toolCall", name: "echo", arguments: { msg: "1" } }] },

--- a/packages/plugins/src/session-log.ts
+++ b/packages/plugins/src/session-log.ts
@@ -27,6 +27,11 @@ export interface SessionLogOptions {
   events?: SessionLogEventName[];
   /** 文件名（默认 `<sessionId>.ndjson`）。 */
   filenameFor?: (sessionId: string) => string;
+  /**
+   * 可选：preToolUse 写日志前对 tool args 脱敏。给定后，`onPreToolUse` 记录 `redactToolArgs(name, args)`
+   * 的返回值而非原始 `call.arguments`。库层默认**不脱敏**（保持通用）；脱敏策略由消费者（如 coding-agent）注入。
+   */
+  redactToolArgs?: (toolName: string, args: unknown) => unknown;
 }
 
 interface StreamState {
@@ -212,7 +217,9 @@ export function sessionLog(opts: SessionLogOptions): Hook {
       if (includes("preToolUse")) {
         write(ctx, "preToolUse", {
           tool: input.call.name,
-          args: input.call.arguments,
+          args: opts.redactToolArgs
+            ? opts.redactToolArgs(input.call.name, input.call.arguments)
+            : input.call.arguments,
         });
       }
     },


### PR DESCRIPTION
Part of #11 — resolves **item 2** (P1: coding-agent session logs persist raw tool args / file contents / commands). 不 auto-close #11(item 3 严格持久化另开 PR)。

## 问题
`session-log` 的 `onPreToolUse` 原样落 `call.arguments`;coding-agent 默认每会话挂它,会把 `write.content`(整文件)、`edit.oldText/newText`(源码/密钥)、`bash.command`(含凭据)静默写进 `.harness-pi/logs/<id>.ndjson`——而目标 repo 未必 gitignore 它。

## 根因修复(无 workaround)
- **plugins/session-log**:新增可选 `redactToolArgs(name,args)`;库层默认**不脱敏**(保持通用),策略由消费者注入。
- **coding-agent/log-redaction**:`redactCodingToolArgs` 对 `write.content` / `edit.oldText`+`newText` / `bash.command` **存在即脱敏**(含非字符串 → `[redacted X]`,堵对象/数组内容绕过 string 检查泄漏);低危字段(path/pattern/glob)透传;数组 args 原样返回;无副作用。CLI 加 `--no-log`(整体关闭)与 `--log-args redacted|full|none`(默认 redacted)。
- **测试**:端到端(真 redactor + 真 sessionLog + 真 .ndjson)验证默认脱敏 / none / full / log:false 四分支;redactor 边界(空串/非字符串/单边 edit/UTF-16 长度/数组/大小写/无副作用);parseLogArgs 错误路径。
- **README**:记录默认日志行为与开关。

## 验证
- coding-agent 198 ✅、plugins 222 ✅;`pnpm -r typecheck` 全 9 项目绿。
- 三审:code 8.9 ✅ / test 9.0 ✅ / linus "Looks reasonable." ✅。

> 注:code-review 指出 resume 存储(`.harness-pi/sessions/*.jsonl`)未被本次脱敏覆盖,超出本 diff 范围,已单开 follow-up issue 跟踪。

🤖 Generated with [Claude Code](https://claude.com/claude-code)