### PR TITLE
fix(core,adapters): strict persistence mode + surfaced persistenceErrors + atomic PG append (#11.3)

### DIFF
--- a/packages/adapters/src/__tests__/postgres-session-store.test.ts
+++ b/packages/adapters/src/__tests__/postgres-session-store.test.ts
@@ -32,6 +32,25 @@ describe("PostgresSessionStore specifics", () => {
   // `IF NOT EXISTS` DDL（第二次会抛 "AST not supported"），故不在此用 pg-mem 验证幂等——那是
   // 模拟器的局限、不是 adapter 的行为。每个契约测试都已成功跑过一次 migrate()，覆盖建表路径。
 
+  it("新 INSERT...SELECT...RETURNING：空 session 首条 parent_id 为 SQL NULL，第二条链到第一条", async () => {
+    // 定向钉死单条 INSERT...SELECT（leaf/seq 走 FROM 子句 LEFT JOIN）的语义：空 session 时 leaf 子查询
+    // 无行 → RETURNING parent_id 必为 SQL NULL（归一化成 JS null，非字符串 "null"）；seq 从 COALESCE(MAX,0)+1
+    // 起算；第二条经 leaf LEFT JOIN 取到上一条 id 作 parent。
+    const store = await freshStore();
+    const a = await store.appendEntry("s1", {
+      kind: "message",
+      message: { role: "user", content: "hi" } as never,
+    });
+    expect(a.parentId).toBeNull();
+    expect(a.seq).toBe(1);
+    const b = await store.appendEntry("s1", {
+      kind: "message",
+      message: { role: "assistant", content: "yo" } as never,
+    });
+    expect(b.parentId).toBe(a.id);
+    expect(b.seq).toBe(2);
+  });
+
   it("persists jsonb entry content faithfully (terminal RunSummary deep round-trip)", async () => {
     const store = await freshStore();
     const terminal: SessionEntry = {

--- a/packages/adapters/src/postgres-session-store.ts
+++ b/packages/adapters/src/postgres-session-store.ts
@@ -7,10 +7,11 @@
  *
  * DDL 见导出的 `POSTGRES_SESSION_STORE_DDL`；`migrate()` 会执行它（IF NOT EXISTS，幂等）。
  *
- * **并发契约**：协议要求同一 sessionId 的 appendEntry / fork 串行。本实现的 appendEntry 是
- * read-leaf → insert → upsert-leaf 的读改写——并发写同一 session 会读到同一个 leaf、生成 parentId
- * 相同的两条 entry。`session_entries(session_id, seq)` 的 UNIQUE 约束会让并发写中的一方插入失败
- * （seq 撞号），是兜底而非协调；真要并发写同一 session，调用方应包事务 + 行锁（见 DDL 注释）。
+ * **并发契约**：协议要求同一 sessionId 的 appendEntry / fork 串行。appendEntry 的 leaf+seq 现在
+ * 并入 INSERT 自身的同一条语句（单条 INSERT...SELECT...RETURNING）读取，在该语句自己的快照里算出
+ * parent_id 与 seq，**消除了原先 getLeafId + SELECT MAX 多次往返的 read-modify-write 窗口**。
+ * `session_entries(session_id, seq)` 的 UNIQUE 约束仍是**跨进程真并发**写同一 session 的兜底
+ * （协议本就禁止——同 session 的 append 由调用方串行）：并发写中撞号的一方插入失败，是兜底而非协调。
  * 不同 sessionId 之间可并发。
  */
 
@@ -92,18 +93,24 @@ export class PostgresSessionStore implements SessionStore {
     sessionId: string,
     entry: SessionEntry,
   ): Promise<StoredEntry> {
-    const parentId = await this.getLeafId(sessionId);
-    const seqRes = await this.client.query(
-      `SELECT COALESCE(MAX(seq), 0) + 1 AS next FROM session_entries WHERE session_id = $1`,
-      [sessionId],
-    );
-    const seq = Number(seqRes.rows[0]!.next);
     const id = randomUUID();
-    await this.client.query(
+    // 单条 INSERT...SELECT...RETURNING：parent_id（当前 leaf）与 seq（MAX+1）在 INSERT 自身的
+    // 快照里算出并写入，消除原先 getLeafId + SELECT MAX 多次往返的 read-modify-write 窗口。
+    // leaf / max(seq) 用 FROM 子句的 LEFT JOIN（而非 SELECT-list 标量子查询）取值——两者在真 PG 等价
+    // （单行源 LEFT JOIN 恰产一行），但 pg-mem 会把 SELECT-list 里的标量子查询错当成 record 行包裹，
+    // 故走 FROM 子查询绕开模拟器这一限制，语义不变。
+    const insRes = await this.client.query(
       `INSERT INTO session_entries (id, session_id, parent_id, seq, entry)
-       VALUES ($1, $2, $3, $4, $5::jsonb)`,
-      [id, sessionId, parentId, seq, JSON.stringify(entry)],
+       SELECT $1, $2, l.leaf_id, COALESCE(m.mx, 0) + 1, $3::jsonb
+       FROM (SELECT 1) AS one
+       LEFT JOIN (SELECT leaf_id FROM session_leaf WHERE session_id = $2) AS l ON true
+       LEFT JOIN (SELECT MAX(seq) AS mx FROM session_entries WHERE session_id = $2) AS m ON true
+       RETURNING parent_id, seq`,
+      [id, sessionId, JSON.stringify(entry)],
     );
+    const row = insRes.rows[0]!;
+    const parentId = row.parent_id === null ? null : String(row.parent_id);
+    const seq = Number(row.seq);
     await this.client.query(
       `INSERT INTO session_leaf (session_id, leaf_id) VALUES ($1, $2)
        ON CONFLICT (session_id) DO UPDATE SET leaf_id = EXCLUDED.leaf_id`,

--- a/packages/core/src/__tests__/strict-persistence.test.ts
+++ b/packages/core/src/__tests__/strict-persistence.test.ts
@@ -15,7 +15,7 @@ import type { HarnessTool } from "../types.js";
 class FailingStore extends MemorySessionStore {
   calls = 0;
   constructor(
-    private readonly opts: {
+    private opts: {
       failKind?: SessionEntry["kind"];
       failKinds?: SessionEntry["kind"][];
       failFirstCall?: boolean;
@@ -23,6 +23,10 @@ class FailingStore extends MemorySessionStore {
     } = {},
   ) {
     super();
+  }
+  /** 恢复健康（清掉所有失败规则）——受支持的测试 API，避免靠反射改私有字段。 */
+  heal(): void {
+    this.opts = {};
   }
   override async appendEntry(sessionId: string, entry: SessionEntry) {
     this.calls++;
@@ -275,11 +279,74 @@ describe("strict persistence + surfaced persistenceErrors", () => {
     const r1 = await session.run("q1");
     expect(r1.persistenceErrors!.length).toBeGreaterThan(0); // R1 有失败
 
-    // 让 store 恢复健康（清掉 failKind），第二次 run 走干净路径。
-    delete (badStore as unknown as { opts: { failKind?: string } }).opts.failKind;
+    // 让 store 恢复健康，第二次 run 走干净路径。
+    badStore.heal();
     const r2 = await session.run("q2");
     expect(r2.reason).toBe("done");
     expect(r2.persistenceErrors).toBeUndefined(); // 不带 R1 的陈旧错误
+    fake.teardown();
+  });
+
+  it("strict 不覆盖自然 max_turns（非 done 终态不提级）", async () => {
+    // toolCall → toolUse → 想续跑，但 maxTurns=1 截断 → reason 自然为 'max_turns'。
+    // 配 terminal 落盘失败 + strict：reason 仍 'max_turns'（不被盖成 error），persistenceErrors 仍暴露。
+    const store = new FailingStore({ failKind: "terminal" });
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [noopTool],
+      store,
+      strictPersistence: true,
+      maxTurns: 1,
+      consoleSink: sink,
+    });
+    const summary = await session.run("q");
+
+    expect(summary.reason).toBe("max_turns"); // strict 不把合法 max_turns 盖成 error
+    expect(summary.persistenceErrors!.some((e) => e.includes("appendEntry(terminal)"))).toBe(true);
+    fake.teardown();
+  });
+
+  it("strict + 健康 store：不误伤干净 run（reason done、无 persistenceErrors、落盘完整）", async () => {
+    // 基线：strict 开着但一切正常，绝不无脑改写——证明提级只针对真实失败。
+    const store = new MemorySessionStore();
+    const fake = createFakeModel([{ content: [{ type: "text", text: "a" }] }]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [],
+      store,
+      strictPersistence: true,
+      consoleSink: sink,
+    });
+    const summary = await session.run("q");
+
+    expect(summary.reason).toBe("done");
+    expect(summary.persistenceErrors).toBeUndefined();
+    const path = await store.getPathToLeaf(session.id);
+    expect(path.at(-1)!.entry.kind).toBe("terminal"); // transcript + terminal 都落了
+    fake.teardown();
+  });
+
+  it("strict message-fail：store 里 transcript 确实不全（messages 一条没落）——钉住 strict 要防的核心事实", async () => {
+    // 只断言返回的 summary 不够；这里直查 store：message append 全失败 → 落盘 0 条 message，
+    // 「done 但 transcript 不全」正是 strict 要拦的危险情形，这条把它从数据层钉死。
+    const store = new FailingStore({ failKind: "message" });
+    const fake = createFakeModel([{ content: [{ type: "text", text: "a" }] }]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [],
+      store,
+      strictPersistence: true,
+      consoleSink: sink,
+    });
+    const summary = await session.run("q");
+
+    expect(summary.reason).toBe("error"); // done 被提级
+    const path = await store.getPathToLeaf(session.id);
+    const msgs = path.filter((e) => e.entry.kind === "message");
+    expect(msgs).toHaveLength(0); // transcript 一条没落 = 落盘不全
     fake.teardown();
   });
 });

--- a/packages/core/src/__tests__/strict-persistence.test.ts
+++ b/packages/core/src/__tests__/strict-persistence.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import { AgentSession } from "../session.js";
+import { MemorySessionStore } from "../session-store.js";
+import type { SessionEntry } from "../session-store.js";
+import { createFakeModel } from "../testing.js";
+
+/**
+ * 可配置失败的 SessionStore：读全部委托给 MemorySessionStore，只在 appendEntry 上按规则失败。
+ * - `failKind`：对该 kind 的 entry，appendEntry 抛错（不落库）。
+ * - `failFirstCall`：只在第 1 次 appendEntry 调用抛错，之后恢复（验证瞬时错误 + HWM 重试）。
+ */
+class FailingStore extends MemorySessionStore {
+  calls = 0;
+  constructor(
+    private readonly opts: { failKind?: SessionEntry["kind"]; failFirstCall?: boolean } = {},
+  ) {
+    super();
+  }
+  override async appendEntry(sessionId: string, entry: SessionEntry) {
+    this.calls++;
+    if (this.opts.failFirstCall && this.calls === 1) {
+      throw new Error("transient store blip");
+    }
+    if (this.opts.failKind && entry.kind === this.opts.failKind) {
+      throw new Error(`append(${entry.kind}) boom`);
+    }
+    return super.appendEntry(sessionId, entry);
+  }
+}
+
+const sink = () => {};
+
+describe("strict persistence + surfaced persistenceErrors", () => {
+  it("message-append failure, best-effort: natural reason kept, error surfaced", async () => {
+    const store = new FailingStore({ failKind: "message" });
+    const fake = createFakeModel([{ content: [{ type: "text", text: "a" }] }]);
+    const session = new AgentSession({ model: fake, tools: [], store, consoleSink: sink });
+    const summary = await session.run("q");
+
+    expect(summary.reason).toBe("done"); // best-effort: 终态不被劫持
+    expect(summary.persistenceErrors).toBeDefined();
+    expect(summary.persistenceErrors!.some((e) => e.includes("appendEntry(message)"))).toBe(true);
+    fake.teardown();
+  });
+
+  it("message-append failure, strict: reason rewritten to error", async () => {
+    const store = new FailingStore({ failKind: "message" });
+    const fake = createFakeModel([{ content: [{ type: "text", text: "a" }] }]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [],
+      store,
+      strictPersistence: true,
+      consoleSink: sink,
+    });
+    const summary = await session.run("q");
+
+    expect(summary.reason).toBe("error");
+    expect(summary.error).toBeInstanceOf(Error);
+    expect(summary.persistenceErrors).toBeDefined();
+    expect(summary.persistenceErrors!.length).toBeGreaterThan(0);
+    fake.teardown();
+  });
+
+  it("terminal-append failure, best-effort: natural reason kept, terminal error surfaced", async () => {
+    const store = new FailingStore({ failKind: "terminal" });
+    const fake = createFakeModel([{ content: [{ type: "text", text: "a" }] }]);
+    const session = new AgentSession({ model: fake, tools: [], store, consoleSink: sink });
+    const summary = await session.run("q");
+
+    expect(summary.reason).toBe("done");
+    expect(summary.persistenceErrors).toBeDefined();
+    expect(summary.persistenceErrors!.some((e) => e.includes("appendEntry(terminal)"))).toBe(true);
+    fake.teardown();
+  });
+
+  it("terminal-append failure, strict: reason rewritten to error", async () => {
+    const store = new FailingStore({ failKind: "terminal" });
+    const fake = createFakeModel([{ content: [{ type: "text", text: "a" }] }]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [],
+      store,
+      strictPersistence: true,
+      consoleSink: sink,
+    });
+    const summary = await session.run("q");
+
+    expect(summary.reason).toBe("error");
+    expect(summary.error).toBeInstanceOf(Error);
+    expect(summary.persistenceErrors!.some((e) => e.includes("appendEntry(terminal)"))).toBe(true);
+    fake.teardown();
+  });
+
+  it("transient-then-recover, strict: reason stays done (persistedOk true) BUT error surfaced", async () => {
+    // 第 1 次 append 抛错后恢复；HWM 重试让最终 flush+terminal 都成功 → persistedOk=true。
+    // strict 据「真实完成」裁决，不因「出现过 error」误判，但瞬时错误仍如实暴露。
+    const store = new FailingStore({ failFirstCall: true });
+    const fake = createFakeModel([{ content: [{ type: "text", text: "a" }] }]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [],
+      store,
+      strictPersistence: true,
+      consoleSink: sink,
+    });
+    const summary = await session.run("q");
+
+    expect(summary.reason).toBe("done"); // 最终落盘完成，strict 不误判
+    expect(summary.persistenceErrors).toBeDefined();
+    expect(summary.persistenceErrors!.length).toBeGreaterThan(0);
+    fake.teardown();
+  });
+
+  it("no store: no persistenceErrors field, normal reason (regression)", async () => {
+    const fake = createFakeModel([{ content: [{ type: "text", text: "a" }] }]);
+    const session = new AgentSession({ model: fake, tools: [] });
+    const summary = await session.run("q");
+
+    expect(summary.reason).toBe("done");
+    expect(summary.persistenceErrors).toBeUndefined();
+    fake.teardown();
+  });
+
+  it("best-effort default healthy store: no persistenceErrors, transcript fully persisted", async () => {
+    const store = new MemorySessionStore();
+    const fake = createFakeModel([{ content: [{ type: "text", text: "a" }] }]);
+    const session = new AgentSession({ model: fake, tools: [], store });
+    const summary = await session.run("q");
+
+    expect(summary.reason).toBe("done");
+    expect(summary.persistenceErrors).toBeUndefined();
+
+    const path = await store.getPathToLeaf(session.id);
+    const roles = path
+      .filter((e) => e.entry.kind === "message")
+      .map((e) => (e.entry.kind === "message" ? e.entry.message.role : null));
+    expect(roles).toEqual(["user", "assistant"]);
+    expect(path.at(-1)!.entry.kind).toBe("terminal"); // terminal 也落盘了
+    fake.teardown();
+  });
+});

--- a/packages/core/src/__tests__/strict-persistence.test.ts
+++ b/packages/core/src/__tests__/strict-persistence.test.ts
@@ -3,16 +3,24 @@ import { AgentSession } from "../session.js";
 import { MemorySessionStore } from "../session-store.js";
 import type { SessionEntry } from "../session-store.js";
 import { createFakeModel } from "../testing.js";
+import type { Hook } from "../hook.js";
+import type { HarnessTool } from "../types.js";
 
 /**
  * 可配置失败的 SessionStore：读全部委托给 MemorySessionStore，只在 appendEntry 上按规则失败。
- * - `failKind`：对该 kind 的 entry，appendEntry 抛错（不落库）。
+ * - `failKind` / `failKinds`：对该（些）kind 的 entry，appendEntry 抛错（不落库）。
  * - `failFirstCall`：只在第 1 次 appendEntry 调用抛错，之后恢复（验证瞬时错误 + HWM 重试）。
+ * - `failOnCall`：只在第 N 次 appendEntry 调用抛错一次，之后恢复（验证多 turn HWM 重试不重不漏）。
  */
 class FailingStore extends MemorySessionStore {
   calls = 0;
   constructor(
-    private readonly opts: { failKind?: SessionEntry["kind"]; failFirstCall?: boolean } = {},
+    private readonly opts: {
+      failKind?: SessionEntry["kind"];
+      failKinds?: SessionEntry["kind"][];
+      failFirstCall?: boolean;
+      failOnCall?: number;
+    } = {},
   ) {
     super();
   }
@@ -21,7 +29,13 @@ class FailingStore extends MemorySessionStore {
     if (this.opts.failFirstCall && this.calls === 1) {
       throw new Error("transient store blip");
     }
+    if (this.opts.failOnCall && this.calls === this.opts.failOnCall) {
+      throw new Error(`store blip on call #${this.calls}`);
+    }
     if (this.opts.failKind && entry.kind === this.opts.failKind) {
+      throw new Error(`append(${entry.kind}) boom`);
+    }
+    if (this.opts.failKinds?.includes(entry.kind)) {
       throw new Error(`append(${entry.kind}) boom`);
     }
     return super.appendEntry(sessionId, entry);
@@ -29,6 +43,15 @@ class FailingStore extends MemorySessionStore {
 }
 
 const sink = () => {};
+
+const noopTool: HarnessTool = {
+  name: "noop",
+  description: "noop",
+  parameters: { type: "object", properties: {} } as never,
+  async execute() {
+    return { content: [{ type: "text", text: "ok" }] };
+  },
+};
 
 describe("strict persistence + surfaced persistenceErrors", () => {
   it("message-append failure, best-effort: natural reason kept, error surfaced", async () => {
@@ -137,6 +160,126 @@ describe("strict persistence + surfaced persistenceErrors", () => {
       .map((e) => (e.entry.kind === "message" ? e.entry.message.role : null));
     expect(roles).toEqual(["user", "assistant"]);
     expect(path.at(-1)!.entry.kind).toBe("terminal"); // terminal 也落盘了
+    fake.teardown();
+  });
+
+  it("multi-turn: 第 N 条 append 瞬时失败 → HWM 重试，最终 transcript 不重不漏", async () => {
+    // 两 turn 续跑：turn1 assistant(toolCall) + toolResult，turn2 assistant(text)。
+    // 让第 2 次 appendEntry（assistant-toolCall）失败一次：HWM 停在已成功处，下一 turn 从该条重试。
+    const store = new FailingStore({ failOnCall: 2 });
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "text", text: "done" }] },
+    ]);
+    const session = new AgentSession({ model: fake, tools: [noopTool], store, consoleSink: sink });
+    const summary = await session.run("q");
+
+    expect(summary.reason).toBe("done");
+    expect(summary.persistenceErrors!.some((e) => e.includes("call #2"))).toBe(true);
+
+    // 最终落盘的 message 序列必须恰好 = 真实历史，无重复、无缺失（HWM 不变量）。
+    const path = await store.getPathToLeaf(session.id);
+    const roles = path
+      .filter((e) => e.entry.kind === "message")
+      .map((e) => (e.entry.kind === "message" ? e.entry.message.role : null));
+    expect(roles).toEqual(["user", "assistant", "toolResult", "assistant"]);
+    expect(path.at(-1)!.entry.kind).toBe("terminal");
+    fake.teardown();
+  });
+
+  it("message + terminal 双失败（best-effort）：两条记录都如实暴露", async () => {
+    const store = new FailingStore({ failKinds: ["message", "terminal"] });
+    const fake = createFakeModel([{ content: [{ type: "text", text: "a" }] }]);
+    const session = new AgentSession({ model: fake, tools: [], store, consoleSink: sink });
+    const summary = await session.run("q");
+
+    expect(summary.reason).toBe("done"); // best-effort 不改终态
+    expect(summary.persistenceErrors!.some((e) => e.includes("appendEntry(message)"))).toBe(true);
+    expect(summary.persistenceErrors!.some((e) => e.includes("appendEntry(terminal)"))).toBe(true);
+    fake.teardown();
+  });
+
+  it("strict 改写后的 error.message 含 'strict persistence failed' 前缀 + 底层原因", async () => {
+    const store = new FailingStore({ failKind: "message" });
+    const fake = createFakeModel([{ content: [{ type: "text", text: "a" }] }]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [],
+      store,
+      strictPersistence: true,
+      consoleSink: sink,
+    });
+    const summary = await session.run("q");
+
+    expect(summary.reason).toBe("error");
+    expect(summary.error!.message).toContain("strict persistence failed");
+    expect(summary.error!.message).toContain("boom"); // 底层 store 错误文案被带上
+    fake.teardown();
+  });
+
+  it("strict 不覆盖某 turn 自然抛错的原始 error（reason 非 done 时不提级）", async () => {
+    // streamThrows → LLM 调用同步抛 → reason 自然为 'error'、summary.error 是该 turn 错误。
+    // 同时让 terminal append 失败：strict 只提级 done，故 reason 仍 'error'、error 仍是原始 turn 错误，
+    // 不被 'strict persistence failed' 顶替；但 persistenceErrors 仍如实挂上。
+    const store = new FailingStore({ failKind: "terminal" });
+    const fake = createFakeModel([{ content: [], streamThrows: new Error("llm exploded") }]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [],
+      store,
+      strictPersistence: true,
+      consoleSink: sink,
+    });
+    const summary = await session.run("q");
+
+    expect(summary.reason).toBe("error");
+    expect(summary.error!.message).toContain("llm exploded"); // 原始 turn 错误被保留
+    expect(summary.error!.message).not.toContain("strict persistence failed");
+    expect(summary.persistenceErrors!.some((e) => e.includes("appendEntry(terminal)"))).toBe(true);
+    fake.teardown();
+  });
+
+  it("strict 不覆盖自然 aborted（onUserPromptSubmit deny halt 路径 + terminal 失败）", async () => {
+    // deny halt 走的是另一个 _finalizePersistence 调用点（prompt-deny 路径）。reason 自然为 'aborted'，
+    // 即便 strict + terminal 落盘失败也不提级为 'error'（aborted 本就非干净成功），persistenceErrors 仍暴露。
+    const store = new FailingStore({ failKinds: ["terminal", "message"] });
+    const denyHook: Hook = {
+      name: "gate",
+      onUserPromptSubmit: () => ({ decision: "deny", reason: "no go" }),
+    };
+    const fake = createFakeModel([{ content: [{ type: "text", text: "unreached" }] }]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [],
+      hooks: [denyHook],
+      store,
+      strictPersistence: true,
+      consoleSink: sink,
+    });
+    const summary = await session.run("blocked");
+
+    expect(summary.reason).toBe("aborted"); // strict 不把合法 aborted 盖成 error
+    expect(summary.abortReason).toContain("no go");
+    expect(summary.persistenceErrors!.length).toBeGreaterThan(0); // 失败仍如实暴露
+    fake.teardown();
+  });
+
+  it("persistenceErrors 是 per-run 信号：上一次失败不污染下一次干净 run", async () => {
+    // R1 用失败 store 跑出 persistenceErrors；R2 换健康 store continue，断言 R2 不带 R1 的陈旧错误。
+    const badStore = new FailingStore({ failKind: "message" });
+    const fake = createFakeModel([
+      { content: [{ type: "text", text: "r1" }] },
+      { content: [{ type: "text", text: "r2" }] },
+    ]);
+    const session = new AgentSession({ model: fake, tools: [], store: badStore, consoleSink: sink });
+    const r1 = await session.run("q1");
+    expect(r1.persistenceErrors!.length).toBeGreaterThan(0); // R1 有失败
+
+    // 让 store 恢复健康（清掉 failKind），第二次 run 走干净路径。
+    delete (badStore as unknown as { opts: { failKind?: string } }).opts.failKind;
+    const r2 = await session.run("q2");
+    expect(r2.reason).toBe("done");
+    expect(r2.persistenceErrors).toBeUndefined(); // 不带 R1 的陈旧错误
     fake.teardown();
   });
 });

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -140,6 +140,14 @@ export interface AgentSessionOptions {
   /** 覆盖自动生成的 session id。`AgentSession.resume` 用它把新 session 绑回同一 lineage。 */
   sessionId?: string;
   /**
+   * 持久化失败的处理模式。默认 false = best-effort（store I/O 失败只记日志 + 计入 RunSummary.persistenceErrors，
+   * 不改终态，下次 flush 从 HWM 重试）。true = strict：若 run 结束时持久化未真正完成（最终 flush 或 terminal
+   * append 失败），把 RunSummary.reason 改写为 "error" 并填 error，让依赖 durable resume/复现的调用方不会
+   * 把「done 但落盘不全」当成功。注意 strict 判定在 onSessionEnd 之后（terminal 持久化发生在 session 结束后），
+   * 故 onSessionEnd 仍观察到 loop 的自然 reason；strict 只改写**返回的** RunSummary。
+   */
+  strictPersistence?: boolean;
+  /**
    * 内核内部用：resume 时声明前 N 条 initialMessages 已在 store 里、不要重复 append。
    * 普通调用者不要设。
    */
@@ -223,6 +231,8 @@ export interface RunSummary {
   stopReason?: StopReason;
   error?: Error;
   abortReason?: string;
+  /** 持久化（SessionStore）失败记录。两种模式下都会**如实暴露**（非空才出现）；strict 模式还会把 reason 改 error。 */
+  persistenceErrors?: string[];
 }
 
 const DEFAULT_MAX_TURNS = 200;
@@ -264,12 +274,17 @@ export class AgentSession {
   /** 可选会话存储 + 已 append 进 store 的 messages 数（避免重复落盘）。 */
   private readonly _store: SessionStore | undefined;
   private _persistedCount: number;
+  /** strict 持久化模式：run 结束落盘不全则把返回的 RunSummary.reason 改 error（见选项注释）。 */
+  private readonly _strictPersistence: boolean;
+  /** 本 session 累积的持久化失败记录；两种模式下都如实挂上 RunSummary.persistenceErrors。 */
+  private _persistenceErrors: string[] = [];
   /** error-stopReason → 是否 context-overflow 的判定（可经选项覆盖，默认内置启发式）。 */
   private readonly _isContextOverflow: (errorMessage: string) => boolean;
 
   constructor(opts: AgentSessionOptions) {
     this.id = opts.sessionId ?? randomUUID();
     this._store = opts.store;
+    this._strictPersistence = opts.strictPersistence ?? false;
     // resume 时前 N 条 initialMessages 已在 store，不重复 append；普通构造从 0 起。
     // 夹到 initialMessages 长度，防止误传过大值导致首批新消息漏落盘。
     this._persistedCount = Math.min(
@@ -791,7 +806,8 @@ export class AgentSession {
             "onUserPromptSubmit halted";
           summary.abortReason = reasonText;
           await this._fireSessionEnd(0, 0, summary.reason);
-          await this._persistTerminal(summary);
+          const persistedOk = await this._persistTerminal(summary);
+          this._finalizePersistence(summary, persistedOk);
           return summary;
         }
         if (upsOut?.systemMessage) {
@@ -843,7 +859,8 @@ export class AgentSession {
       // 退出 loop：恰好 fire 一次 onSessionEnd（无论 done / aborted / error / max_turns / max_continuations）
       await this._fireSessionEnd(turnIdx, continuations, reason);
       const summary = this._buildSummary(turnIdx, continuations, reason);
-      await this._persistTerminal(summary);
+      const persistedOk = await this._persistTerminal(summary);
+      this._finalizePersistence(summary, persistedOk);
       return summary;
     } finally {
       cleanupCallerForward();
@@ -933,14 +950,21 @@ export class AgentSession {
     return summary;
   }
 
-  /** best-effort 持久化：store I/O 失败**不**劫持控制流/终态，记日志即可（下次 flush 从未成功处重试）。 */
+  /**
+   * 记录一次 store I/O 失败：写日志 + 计入 `_persistenceErrors`（两种模式都记，最终都挂上 RunSummary）。
+   * best-effort 下失败不劫持控制流（下次 flush 从未成功处重试）；strict 下由 `_finalizePersistence`
+   * 据「最终是否真正落盘完成」改写终态，故此处只如实记录、不改控制流。
+   */
   private _reportStoreError(op: string, err: unknown): void {
-    this._consoleSink(
-      `[session-store] ${op} failed (best-effort persistence, will retry next flush): ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-      { sessionId: this.id, turnIdx: this._ctx.turnIdx },
-    );
+    const msg = err instanceof Error ? err.message : String(err);
+    this._persistenceErrors.push(`${op}: ${msg}`);
+    const note = this._strictPersistence
+      ? "strict persistence"
+      : "best-effort persistence, will retry next flush";
+    this._consoleSink(`[session-store] ${op} failed (${note}): ${msg}`, {
+      sessionId: this.id,
+      turnIdx: this._ctx.turnIdx,
+    });
   }
 
   /**
@@ -951,9 +975,11 @@ export class AgentSession {
    * （store 是 append-only、不去重，重复 append 会让 resume 读出重复消息）。
    * best-effort：append 失败被 catch，不抛给控制流（持久化失败不该杀掉 run）。
    * 依赖 `_messages` **append-only、索引稳定**（内核只 push，从不 splice/reorder）—— HWM 才成立。
+   *
+   * 返回是否全部 flush 成功（无 store 视为成功）；调用方据此判断持久化是否真正完成。
    */
-  private async _flushToStore(): Promise<void> {
-    if (!this._store) return;
+  private async _flushToStore(): Promise<boolean> {
+    if (!this._store) return true;
     try {
       for (; this._persistedCount < this._messages.length; this._persistedCount++) {
         await this._store.appendEntry(this.id, {
@@ -961,19 +987,47 @@ export class AgentSession {
           message: this._messages[this._persistedCount]!,
         });
       }
+      return true;
     } catch (err) {
       this._reportStoreError("appendEntry(message)", err);
+      return false;
     }
   }
 
-  /** run 结束：flush 剩余 messages + append 一条 terminal entry（终态元数据）。best-effort，无 store 即 no-op。 */
-  private async _persistTerminal(summary: RunSummary): Promise<void> {
-    if (!this._store) return;
-    await this._flushToStore(); // best-effort（不会抛）
+  /**
+   * run 结束：flush 剩余 messages + append 一条 terminal entry（终态元数据）。无 store 即 no-op。
+   * 返回「最终 flush + terminal append 是否都成功」这个真实完成信号，供 `_finalizePersistence` 裁决。
+   */
+  private async _persistTerminal(summary: RunSummary): Promise<boolean> {
+    if (!this._store) return true;
+    const flushed = await this._flushToStore();
+    let terminalAppendedOk = true;
     try {
       await this._store.appendEntry(this.id, { kind: "terminal", result: summary });
     } catch (err) {
       this._reportStoreError("appendEntry(terminal)", err);
+      terminalAppendedOk = false;
+    }
+    return flushed && terminalAppendedOk;
+  }
+
+  /**
+   * run 返回前对持久化结果做最终裁决：把累积的 persistenceErrors 如实挂上 summary；strict 模式下若持久化
+   * 未真正完成（persistedOk=false）则把 reason 改 "error" 并补 error。persistedOk 用「最终 flush+terminal
+   * 是否成功」这个真实完成信号，而非「是否出现过 error」——故 best-effort 下的瞬时错误若已重试成功，strict
+   * 不会误判。
+   */
+  private _finalizePersistence(summary: RunSummary, persistedOk: boolean): void {
+    if (this._persistenceErrors.length > 0) {
+      summary.persistenceErrors = [...this._persistenceErrors];
+    }
+    if (this._strictPersistence && !persistedOk) {
+      summary.reason = "error";
+      if (!summary.error) {
+        summary.error = new Error(
+          `strict persistence failed: ${this._persistenceErrors.join("; ") || "store append did not complete"}`,
+        );
+      }
     }
   }
 

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -733,6 +733,9 @@ export class AgentSession {
     getKernelInternals(this._ctx).setSignal(this._abortCtrl.signal);
     this._pendingAttachments = [];
     this._lastTurnError = null;
+    // persistenceErrors 是 per-run 信号（对齐 error/abortReason）：每次 run/continue 清零，
+    // 否则上一次的失败会污染本次干净 run 的 RunSummary.persistenceErrors。
+    this._persistenceErrors = [];
     // 注意：_steerInbox **故意不在此清空**——park 的 steer 是「等下次跑起来时插队」的用户意图，
     // 应跨 run/continue 边界存活、在首个 turn 的安全点 drain；这与 transient 的 _pendingAttachments
     // （上次 run 的残渣、每次清零）语义相反。别"顺手"加 `this._steerInbox = []` 求对称。
@@ -1016,18 +1019,21 @@ export class AgentSession {
    * 未真正完成（persistedOk=false）则把 reason 改 "error" 并补 error。persistedOk 用「最终 flush+terminal
    * 是否成功」这个真实完成信号，而非「是否出现过 error」——故 best-effort 下的瞬时错误若已重试成功，strict
    * 不会误判。
+   *
+   * **只提级 `done`**：strict 仅把「本应成功(done)却落盘不全」这一危险情形提级为 error；已是非 done 终态
+   * （aborted/error/max_turns/max_continuations）**不被覆盖**——它们本就非干净成功、调用方不会误信，且
+   * persistenceErrors 已如实暴露失败。这避免 strict 用 "error" 盖掉合法的 aborted/max_turns 信号，
+   * 也保留某 turn 自然抛错时的原始 `summary.error`（不被 "strict persistence failed" 顶替）。
    */
   private _finalizePersistence(summary: RunSummary, persistedOk: boolean): void {
     if (this._persistenceErrors.length > 0) {
       summary.persistenceErrors = [...this._persistenceErrors];
     }
-    if (this._strictPersistence && !persistedOk) {
+    if (this._strictPersistence && !persistedOk && summary.reason === "done") {
       summary.reason = "error";
-      if (!summary.error) {
-        summary.error = new Error(
-          `strict persistence failed: ${this._persistenceErrors.join("; ") || "store append did not complete"}`,
-        );
-      }
+      summary.error = new Error(
+        `strict persistence failed: ${this._persistenceErrors.join("; ") || "store append did not complete"}`,
+      );
     }
   }
 


### PR DESCRIPTION
Closes #11 — resolves **item 3**(P1: SessionStore writes are best-effort even when resume/reproducibility depends on them)。#11 三项全部完成(item1 PR #17、item2 PR #21、item4 PR #17、item5 PR #18,item3 本 PR)。

## 问题
内核把 SessionStore 持久化当 best-effort:`_flushToStore`/`_persistTerminal` 吞掉 append 失败、只 console 记一笔。run 可能 `reason:"done"` 但 durable transcript 不全,调用方无结构化信号——对 resume/复现/审计是隐患。

## 根因修复(无 workaround)
- **core**:`AgentSessionOptions.strictPersistence`(默认 false)。`RunSummary.persistenceErrors` 两种模式都如实暴露(非空才出现)。`_flushToStore`/`_persistTerminal` 返回成功与否;run 返回前 `_finalizePersistence` 用「最终 flush+terminal 是否真正完成」(persistedOk,非「是否出现过 error」)裁决:**仅把「本应 done 却落盘不全」提级为 error**,不覆盖合法的 aborted/max_turns/max_continuations、也不顶替某 turn 自然抛错的原始 error;瞬时错误已重试成功则不误判。persistenceErrors per-run 清零。strict 裁决在 onSessionEnd 之后(terminal 持久化发生在 session 结束后)。
- **adapters**:`PostgresSessionStore.appendEntry` 从 4 条语句的 read-modify-write 压成单条 `INSERT...SELECT...RETURNING`,leaf+seq 在 INSERT 自身快照里算出,消除多次往返的 RMW 窗口;`(session_id,seq)` UNIQUE 仍为跨进程真并发兜底(协议本就要求同 session 串行)。
- **测试**:best-effort/strict × message/terminal/双失败/瞬时恢复;strict 只提级 done(不覆盖 error/aborted/max_turns、保留原始 error);per-run 重置;多 turn HWM 重试不重不漏(直查 store);健康 store 基线不误伤;PG 新 SQL 的 null-parent/seq/链接。

## 验证
- core 256 ✅、adapters 60 ✅(18 skip=env-gated 真 PG 集成,基线一致);`pnpm -r typecheck` 全 9 项目绿。
- 三审:code 8.83 ✅ / test 8.6 ✅ / linus "Looks reasonable." ✅。

🤖 Generated with [Claude Code](https://claude.com/claude-code)