### PR TITLE
fix(coding-agent): warn when .harness-pi is not gitignored (#22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ pnpm --filter @harness-pi/coding-agent start -- --cwd . --model dashscope:qwen-p
 - `--disable bash,write` 可以关闭指定基础 tool。
 - 默认 log 目录是 `.harness-pi/logs`；`--metrics-file path.ndjson` 可写 metrics。
 - 默认对 session log 里的高危 tool args 脱敏（`write` 内容、`edit` 文本、`bash` 命令仅记长度，不落原文，避免密钥/源码静默写进 `.harness-pi/logs`）；`--log-args full` 记原始 args（仅本地调试）；`--log-args none` 完全不记 args；`--no-log` 关闭整个 session log。
-- **`.harness-pi/` 落盘与 gitignore**：session log 已默认脱敏（见上），但 **resume 存储**（`.harness-pi/sessions/*.jsonl`，TUI / `--resume` 用）为了能正确**重放续跑**保存**完整原文**消息历史（含 `write` 内容、`bash` 命令等），**不脱敏**。启动时若检测到当前仓库未把 `.harness-pi/` 加入 `.gitignore`，会打印一条告警——请务必忽略它，以免敏感内容被误提交。
+- **`.harness-pi/` 落盘与 gitignore**：session log 已默认脱敏（见上），但 **resume 存储**（`.harness-pi/sessions/*.jsonl`，TUI / `--resume` 用）为了能正确**重放续跑**保存**完整原文**消息历史（含 `write` 内容、`bash` 命令等），**不脱敏**。启动时若检测到当前仓库未把 `.harness-pi/` 加入 `.gitignore`，会打印一条告警——请务必把 `.harness-pi/` 加入 `.gitignore`，以免敏感内容被误提交。
 - **安全边界**：`bash` 是 host shell，不是 sandbox。full mode 只应在你明确允许修改的 workspace 里运行。
 
 ## Layout

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ pnpm --filter @harness-pi/coding-agent start -- --cwd . --model dashscope:qwen-p
 - `--disable bash,write` 可以关闭指定基础 tool。
 - 默认 log 目录是 `.harness-pi/logs`；`--metrics-file path.ndjson` 可写 metrics。
 - 默认对 session log 里的高危 tool args 脱敏（`write` 内容、`edit` 文本、`bash` 命令仅记长度，不落原文，避免密钥/源码静默写进 `.harness-pi/logs`）；`--log-args full` 记原始 args（仅本地调试）；`--log-args none` 完全不记 args；`--no-log` 关闭整个 session log。
+- **`.harness-pi/` 落盘与 gitignore**：session log 已默认脱敏（见上），但 **resume 存储**（`.harness-pi/sessions/*.jsonl`，TUI / `--resume` 用）为了能正确**重放续跑**保存**完整原文**消息历史（含 `write` 内容、`bash` 命令等），**不脱敏**。启动时若检测到当前仓库未把 `.harness-pi/` 加入 `.gitignore`，会打印一条告警——请务必忽略它，以免敏感内容被误提交。
 - **安全边界**：`bash` 是 host shell，不是 sandbox。full mode 只应在你明确允许修改的 workspace 里运行。
 
 ## Layout

--- a/apps/coding-agent/src/__tests__/workspace-safety.test.ts
+++ b/apps/coding-agent/src/__tests__/workspace-safety.test.ts
@@ -122,6 +122,27 @@ describe("createCodingAgent → agent.warnings 的 .harness-pi 落盘门控", ()
     expect(hasGitignoreWarn(agent.warnings)).toBe(false);
   });
 
+  it("相对 --log-dir 指回 .harness-pi（如 .harness-pi/logs2）→ 仍告警（不漏报）", async () => {
+    // 相对 logDir 真会落进 cwd/.harness-pi；门控须先 resolve(cwd, logDir) 再比，否则相对 vs 绝对恒 false → 假阴性。
+    const cwd = await gitRepo();
+    const agent = createCodingAgent({
+      cwd,
+      model: createFakeModel([]),
+      logDir: join(".harness-pi", "logs2"), // 相对路径
+    });
+    expect(hasGitignoreWarn(agent.warnings)).toBe(true);
+  });
+
+  it("相对 --log-dir 落在 .harness-pi 之外（如 logs-elsewhere）→ 不告警", async () => {
+    const cwd = await gitRepo();
+    const agent = createCodingAgent({
+      cwd,
+      model: createFakeModel([]),
+      logDir: "logs-elsewhere", // 相对、不在 .harness-pi 下
+    });
+    expect(hasGitignoreWarn(agent.warnings)).toBe(false);
+  });
+
   it("自定义 logDir 是同前缀兄弟目录 .harness-pi-backup → 不误命中、不告警", async () => {
     // 路径边界判定：.harness-pi-backup 以 '.harness-pi' 开头但不是 .harness-pi 的子路径，不应触发。
     const cwd = await gitRepo();

--- a/apps/coding-agent/src/__tests__/workspace-safety.test.ts
+++ b/apps/coding-agent/src/__tests__/workspace-safety.test.ts
@@ -2,8 +2,9 @@ import { afterEach, describe, expect, it } from "vitest";
 import { execFileSync } from "node:child_process";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { createFakeModel } from "@harness-pi/core/testing";
+import { MemorySessionStore } from "@harness-pi/core";
 import {
   harnessPiGitignoreWarning,
   isHarnessPiGitIgnored,
@@ -23,57 +24,123 @@ async function tmp(): Promise<string> {
   return d;
 }
 function gitInit(cwd: string): void {
-  // 无 commit 也能 check-ignore；配最小 identity 防某些环境报 warning。
   execFileSync("git", ["init", "-q"], { cwd });
   execFileSync("git", ["config", "user.email", "t@t.t"], { cwd });
   execFileSync("git", ["config", "user.name", "t"], { cwd });
 }
+async function gitRepo(gitignore?: string): Promise<string> {
+  const cwd = await tmp();
+  gitInit(cwd);
+  if (gitignore !== undefined) await writeFile(join(cwd, ".gitignore"), gitignore);
+  return cwd;
+}
+const persistence = () => ({ store: new MemorySessionStore(), sessionId: "s1" });
+const hasGitignoreWarn = (ws: string[]): boolean =>
+  ws.some((w) => w.includes(".harness-pi") && w.includes(".gitignore"));
 
-describe("workspace-safety: .harness-pi gitignore 守卫 (#22)", () => {
-  it("git 仓库未忽略 .harness-pi → 报未忽略 + 出告警", async () => {
-    const cwd = await tmp();
-    gitInit(cwd);
-    expect(isHarnessPiGitIgnored(cwd)).toBe(false);
-    const w = harnessPiGitignoreWarning(cwd);
+describe("isHarnessPiGitIgnored", () => {
+  it("git 仓库未忽略 → false", async () => {
+    expect(isHarnessPiGitIgnored(await gitRepo())).toBe(false);
+  });
+
+  it("非 git 仓库 → null（无 git 泄漏面）", async () => {
+    expect(isHarnessPiGitIgnored(await tmp())).toBeNull();
+  });
+
+  it("cwd 不存在 / git 不可用 → null（不抛、不误报）", () => {
+    // 不存在的 cwd 让 execFileSync ENOENT，status 既非 1 也非 128 → 防御回退 null。
+    expect(isHarnessPiGitIgnored("/no/such/dir/xyz-harness-pi-test")).toBeNull();
+  });
+
+  it.each([
+    [".harness-pi/\n", "目录型尾斜杠"],
+    [".harness-pi\n", "无尾斜杠（文件或目录同名）"],
+    ["/.harness-pi/\n", "root-anchored"],
+    ["# c\n\n.harness-pi/\n", "含注释与空行"],
+  ])("多种 gitignore 写法都命中 → true（%s: %s）", async (pattern) => {
+    expect(isHarnessPiGitIgnored(await gitRepo(pattern))).toBe(true);
+  });
+});
+
+describe("harnessPiGitignoreWarning", () => {
+  it("未忽略的 git 仓库 → 告警含 .gitignore / .harness-pi / resume 语义", async () => {
+    const w = harnessPiGitignoreWarning(await gitRepo());
+    expect(w).not.toBeNull();
     expect(w).toContain(".gitignore");
     expect(w).toContain(".harness-pi");
+    expect(w).toContain("resume"); // 必须点出 resume 存储（无法脱敏的完整原文）这一真正安全点
   });
 
-  it("git 仓库已忽略 .harness-pi → 报已忽略 + 无告警", async () => {
-    const cwd = await tmp();
-    gitInit(cwd);
-    await writeFile(join(cwd, ".gitignore"), ".harness-pi/\n");
-    expect(isHarnessPiGitIgnored(cwd)).toBe(true);
-    expect(harnessPiGitignoreWarning(cwd)).toBeNull();
+  it("已忽略 → null；非 git → null", async () => {
+    expect(harnessPiGitignoreWarning(await gitRepo(".harness-pi/\n"))).toBeNull();
+    expect(harnessPiGitignoreWarning(await tmp())).toBeNull();
   });
+});
 
-  it("非 git 仓库 → null（无 git 泄漏面，不告警）", async () => {
-    const cwd = await tmp();
-    expect(isHarnessPiGitIgnored(cwd)).toBeNull();
-    expect(harnessPiGitignoreWarning(cwd)).toBeNull();
-  });
-
-  it("createCodingAgent 默认在未忽略的 git repo → agent.warnings 含 gitignore 告警", async () => {
-    const cwd = await tmp();
-    gitInit(cwd);
+describe("createCodingAgent → agent.warnings 的 .harness-pi 落盘门控", () => {
+  it("默认（log on）+ 未忽略 git repo → 出告警，且恰一条（不重复堆叠）", async () => {
+    const cwd = await gitRepo();
     const agent = createCodingAgent({ cwd, model: createFakeModel([]) });
-    expect(agent.warnings.some((w) => w.includes(".harness-pi") && w.includes(".gitignore"))).toBe(
-      true,
-    );
+    const gw = agent.warnings.filter((w) => w.includes(".harness-pi") && w.includes(".gitignore"));
+    expect(gw).toHaveLength(1);
+    // CLI 启动期 stderr 门控依赖这条恒等：harnessPiGitignoreWarning(resolve(cwd)) 必在 agent.warnings 里。
+    expect(agent.warnings).toContain(harnessPiGitignoreWarning(resolve(cwd)));
   });
 
-  it("log:false 且无 resume 存储 → 不往 .harness-pi 落盘 → 即便未忽略也不告警", async () => {
-    const cwd = await tmp();
-    gitInit(cwd);
+  it("persistence（resume 存储）+ 未忽略 → 出告警（头号泄漏面）", async () => {
+    const cwd = await gitRepo();
+    const agent = createCodingAgent({ cwd, model: createFakeModel([]), persistence: persistence() });
+    expect(hasGitignoreWarn(agent.warnings)).toBe(true);
+  });
+
+  it("log:false 但挂了 persistence + 未忽略 → 仍出告警（resume 存储照样落原文）", async () => {
+    const cwd = await gitRepo();
+    const agent = createCodingAgent({
+      cwd,
+      model: createFakeModel([]),
+      log: false,
+      persistence: persistence(),
+    });
+    expect(hasGitignoreWarn(agent.warnings)).toBe(true); // log:false ≠ 安全
+  });
+
+  it("log:false 且无 persistence + 未忽略 → 不落盘 → 不告警", async () => {
+    const cwd = await gitRepo();
     const agent = createCodingAgent({ cwd, model: createFakeModel([]), log: false });
-    expect(agent.warnings.some((w) => w.includes(".harness-pi"))).toBe(false);
+    expect(hasGitignoreWarn(agent.warnings)).toBe(false);
+    // 这条同时锁住 CLI 启动期 stderr 不会假阳性（它只在告警进了 agent.warnings 时才打）。
+    expect(agent.warnings).not.toContain(harnessPiGitignoreWarning(resolve(cwd)));
   });
 
-  it("已忽略的 git repo → createCodingAgent 默认不产生 gitignore 告警", async () => {
-    const cwd = await tmp();
-    gitInit(cwd);
-    await writeFile(join(cwd, ".gitignore"), ".harness-pi/\n");
+  it("自定义 logDir 落在 .harness-pi 之外 + 无 persistence → 不告警", async () => {
+    const cwd = await gitRepo();
+    const agent = createCodingAgent({
+      cwd,
+      model: createFakeModel([]),
+      logDir: join(cwd, "logs-elsewhere"),
+    });
+    expect(hasGitignoreWarn(agent.warnings)).toBe(false);
+  });
+
+  it("自定义 logDir 仍在 cwd/.harness-pi 下 + 未忽略 → 告警", async () => {
+    const cwd = await gitRepo();
+    const agent = createCodingAgent({
+      cwd,
+      model: createFakeModel([]),
+      logDir: join(cwd, ".harness-pi", "custom-logs"),
+    });
+    expect(hasGitignoreWarn(agent.warnings)).toBe(true);
+  });
+
+  it("已忽略 .harness-pi 的 git repo → 默认不告警", async () => {
+    const cwd = await gitRepo(".harness-pi/\n");
     const agent = createCodingAgent({ cwd, model: createFakeModel([]) });
-    expect(agent.warnings.some((w) => w.includes(".harness-pi"))).toBe(false);
+    expect(hasGitignoreWarn(agent.warnings)).toBe(false);
+  });
+
+  it("非 git 仓库 → 不告警（无 git 泄漏面）", async () => {
+    const cwd = await tmp();
+    const agent = createCodingAgent({ cwd, model: createFakeModel([]) });
+    expect(hasGitignoreWarn(agent.warnings)).toBe(false);
   });
 });

--- a/apps/coding-agent/src/__tests__/workspace-safety.test.ts
+++ b/apps/coding-agent/src/__tests__/workspace-safety.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createFakeModel } from "@harness-pi/core/testing";
+import {
+  harnessPiGitignoreWarning,
+  isHarnessPiGitIgnored,
+} from "../workspace-safety.js";
+import { createCodingAgent } from "../agent.js";
+
+const dirs: string[] = [];
+afterEach(async () => {
+  while (dirs.length) {
+    const d = dirs.pop();
+    if (d) await rm(d, { recursive: true, force: true });
+  }
+});
+async function tmp(): Promise<string> {
+  const d = await mkdtemp(join(tmpdir(), "harness-pi-wssafety-"));
+  dirs.push(d);
+  return d;
+}
+function gitInit(cwd: string): void {
+  // 无 commit 也能 check-ignore；配最小 identity 防某些环境报 warning。
+  execFileSync("git", ["init", "-q"], { cwd });
+  execFileSync("git", ["config", "user.email", "t@t.t"], { cwd });
+  execFileSync("git", ["config", "user.name", "t"], { cwd });
+}
+
+describe("workspace-safety: .harness-pi gitignore 守卫 (#22)", () => {
+  it("git 仓库未忽略 .harness-pi → 报未忽略 + 出告警", async () => {
+    const cwd = await tmp();
+    gitInit(cwd);
+    expect(isHarnessPiGitIgnored(cwd)).toBe(false);
+    const w = harnessPiGitignoreWarning(cwd);
+    expect(w).toContain(".gitignore");
+    expect(w).toContain(".harness-pi");
+  });
+
+  it("git 仓库已忽略 .harness-pi → 报已忽略 + 无告警", async () => {
+    const cwd = await tmp();
+    gitInit(cwd);
+    await writeFile(join(cwd, ".gitignore"), ".harness-pi/\n");
+    expect(isHarnessPiGitIgnored(cwd)).toBe(true);
+    expect(harnessPiGitignoreWarning(cwd)).toBeNull();
+  });
+
+  it("非 git 仓库 → null（无 git 泄漏面，不告警）", async () => {
+    const cwd = await tmp();
+    expect(isHarnessPiGitIgnored(cwd)).toBeNull();
+    expect(harnessPiGitignoreWarning(cwd)).toBeNull();
+  });
+
+  it("createCodingAgent 默认在未忽略的 git repo → agent.warnings 含 gitignore 告警", async () => {
+    const cwd = await tmp();
+    gitInit(cwd);
+    const agent = createCodingAgent({ cwd, model: createFakeModel([]) });
+    expect(agent.warnings.some((w) => w.includes(".harness-pi") && w.includes(".gitignore"))).toBe(
+      true,
+    );
+  });
+
+  it("log:false 且无 resume 存储 → 不往 .harness-pi 落盘 → 即便未忽略也不告警", async () => {
+    const cwd = await tmp();
+    gitInit(cwd);
+    const agent = createCodingAgent({ cwd, model: createFakeModel([]), log: false });
+    expect(agent.warnings.some((w) => w.includes(".harness-pi"))).toBe(false);
+  });
+
+  it("已忽略的 git repo → createCodingAgent 默认不产生 gitignore 告警", async () => {
+    const cwd = await tmp();
+    gitInit(cwd);
+    await writeFile(join(cwd, ".gitignore"), ".harness-pi/\n");
+    const agent = createCodingAgent({ cwd, model: createFakeModel([]) });
+    expect(agent.warnings.some((w) => w.includes(".harness-pi"))).toBe(false);
+  });
+});

--- a/apps/coding-agent/src/__tests__/workspace-safety.test.ts
+++ b/apps/coding-agent/src/__tests__/workspace-safety.test.ts
@@ -122,6 +122,17 @@ describe("createCodingAgent → agent.warnings 的 .harness-pi 落盘门控", ()
     expect(hasGitignoreWarn(agent.warnings)).toBe(false);
   });
 
+  it("自定义 logDir 是同前缀兄弟目录 .harness-pi-backup → 不误命中、不告警", async () => {
+    // 路径边界判定：.harness-pi-backup 以 '.harness-pi' 开头但不是 .harness-pi 的子路径，不应触发。
+    const cwd = await gitRepo();
+    const agent = createCodingAgent({
+      cwd,
+      model: createFakeModel([]),
+      logDir: join(cwd, ".harness-pi-backup", "logs"),
+    });
+    expect(hasGitignoreWarn(agent.warnings)).toBe(false);
+  });
+
   it("自定义 logDir 仍在 cwd/.harness-pi 下 + 未忽略 → 告警", async () => {
     const cwd = await gitRepo();
     const agent = createCodingAgent({

--- a/apps/coding-agent/src/agent.ts
+++ b/apps/coding-agent/src/agent.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from "node:path";
+import { join, resolve, sep } from "node:path";
 import {
   AgentSession,
   type Api,
@@ -277,8 +277,10 @@ function buildAgentContext(opts: CreateCodingAgentOptions): AgentContext {
   const warnings: string[] = [];
   // .harness-pi 落盘安全守卫（#22）：会往 cwd/.harness-pi 落盘（默认 session log 在此，或挂了 resume
   // 存储）且该目录未被 gitignore 时，提示完整原文有被误提交的风险（resume 存储无法脱敏）。
+  const harnessDir = join(cwd, ".harness-pi");
   const writesUnderHarnessPi =
-    (opts.log !== false && logDir.startsWith(join(cwd, ".harness-pi"))) ||
+    (opts.log !== false &&
+      (logDir === harnessDir || logDir.startsWith(harnessDir + sep))) || // 路径边界，不误命中 .harness-pi-backup
     opts.persistence !== undefined;
   if (writesUnderHarnessPi) {
     const w = harnessPiGitignoreWarning(cwd);

--- a/apps/coding-agent/src/agent.ts
+++ b/apps/coding-agent/src/agent.ts
@@ -31,6 +31,7 @@ import {
 } from "@harness-pi/plugins";
 import { createModelSummarizer } from "./compaction.js";
 import { redactCodingToolArgs } from "./log-redaction.js";
+import { harnessPiGitignoreWarning } from "./workspace-safety.js";
 import { defaultPermissionRules } from "./tui/permissions.js";
 import {
   createAllTools,
@@ -274,6 +275,15 @@ function buildAgentContext(opts: CreateCodingAgentOptions): AgentContext {
   let lastCostStats: CostStats | undefined;
   let lastToolStats: ToolStats | undefined;
   const warnings: string[] = [];
+  // .harness-pi 落盘安全守卫（#22）：会往 cwd/.harness-pi 落盘（默认 session log 在此，或挂了 resume
+  // 存储）且该目录未被 gitignore 时，提示完整原文有被误提交的风险（resume 存储无法脱敏）。
+  const writesUnderHarnessPi =
+    (opts.log !== false && logDir.startsWith(join(cwd, ".harness-pi"))) ||
+    opts.persistence !== undefined;
+  if (writesUnderHarnessPi) {
+    const w = harnessPiGitignoreWarning(cwd);
+    if (w) warnings.push(w);
+  }
   const dashScopeCost = createDashScopeCostAccumulator(opts.model, opts.llmOptions);
   const costTrackerOptions: CostTrackerOptions = {
     mode: "lifetime",

--- a/apps/coding-agent/src/agent.ts
+++ b/apps/coding-agent/src/agent.ts
@@ -265,7 +265,9 @@ function buildAgentContext(opts: CreateCodingAgentOptions): AgentContext {
     toolModeOptions.toolsOptions = opts.toolsOptions;
   }
   const tools = createToolsForMode(cwd, toolModeOptions);
-  const logDir = opts.logDir ?? join(cwd, ".harness-pi", "logs");
+  // resolve 成绝对路径（锚定 workspace cwd）：相对 --log-dir 也有确定落点，且下面的路径边界门控
+  // 不会因「相对 logDir vs 绝对 harnessDir」字符串比较恒 false 而漏告警（安全守卫的假阴性）。
+  const logDir = resolve(cwd, opts.logDir ?? join(".harness-pi", "logs"));
   const metricsSink = opts.metricsFile
     ? new NdjsonFileSink({ path: opts.metricsFile, batchSize: 1 })
     : undefined;

--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -22,6 +22,7 @@ import {
   formatProviderList,
   loadDotEnv,
 } from "./config.js";
+import { harnessPiGitignoreWarning } from "./workspace-safety.js";
 import { toolNames, type ToolName } from "@harness-pi/tools";
 import { JsonlSessionStore } from "@harness-pi/adapters";
 import { ProcessTerminal } from "@mariozechner/pi-tui";
@@ -210,6 +211,11 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     }
     agent = createCodingAgent(createOptions);
   }
+
+  // #22 守卫：启动期就把 .harness-pi 未被 gitignore 的风险打到 stderr（早于任何落盘，且 TUI 路径
+  // 不渲染 run report 也能看到）。one-shot 的 run report 也会再列一次（agent.warnings），刻意冗余。
+  const gitignoreWarning = harnessPiGitignoreWarning(args.cwd);
+  if (gitignoreWarning) process.stderr.write(`⚠️  ${gitignoreWarning}\n`);
 
   try {
     if (!args.readOnly) {

--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -213,9 +213,13 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
   }
 
   // #22 守卫：启动期就把 .harness-pi 未被 gitignore 的风险打到 stderr（早于任何落盘，且 TUI 路径
-  // 不渲染 run report 也能看到）。one-shot 的 run report 也会再列一次（agent.warnings），刻意冗余。
-  const gitignoreWarning = harnessPiGitignoreWarning(args.cwd);
-  if (gitignoreWarning) process.stderr.write(`⚠️  ${gitignoreWarning}\n`);
+  // 不渲染 run report 也能看到）。**复用 agent 已算好的「会往 .harness-pi 落盘」门控**：只有当该告警确实
+  // 进了 agent.warnings（本次运行真会落盘）才打——避免 --no-log（不落盘）下的假阳性，且与 agent 层
+  // 同一来源、同一 resolve(cwd)，不重复门控逻辑。one-shot 的 run report 也会再列一次，刻意冗余。
+  const gitignoreWarning = harnessPiGitignoreWarning(resolve(args.cwd));
+  if (gitignoreWarning && agent.warnings.includes(gitignoreWarning)) {
+    process.stderr.write(`⚠️  ${gitignoreWarning}\n`);
+  }
 
   try {
     if (!args.readOnly) {

--- a/apps/coding-agent/src/workspace-safety.ts
+++ b/apps/coding-agent/src/workspace-safety.ts
@@ -1,0 +1,54 @@
+/**
+ * Workspace 落盘安全守卫（#22）。
+ *
+ * coding-agent 默认把 **session log**（`.harness-pi/logs/*.ndjson`）与 **resume 存储**
+ * （`.harness-pi/sessions/*.jsonl`）写在 cwd 的 `.harness-pi/` 下。前者的 tool args 默认已脱敏
+ * （见 log-redaction.ts），但 resume 存储为了能正确**重放续跑**，必须保存**完整原文**消息历史
+ * （含 write 文件内容、bash 命令等）——这是无法脱敏的（脱了 resume 就坏了）。
+ *
+ * 由于 agent 常跑在**任意用户 repo** 里，若该 repo 没把 `.harness-pi/` 加进 .gitignore，这些原文
+ * 可能被误 `git add` / 提交进仓库。本模块在启动期做一次轻量检测并给出醒目告警（不改写用户的
+ * .gitignore，只提示——是否忽略由用户决定）。
+ */
+
+import { execFileSync } from "node:child_process";
+
+/**
+ * `.harness-pi/` 是否被 `cwd` 的 git 忽略。
+ * - `true`：已忽略（安全）。
+ * - `false`：是 git 仓库但**未**忽略（泄漏面）。
+ * - `null`：非 git 仓库 / git 不可用 —— 没有「被 git 提交」这条泄漏面，不告警。
+ *
+ * 探测的是 `.harness-pi/` **下的一个代表性子路径**（而非 `.harness-pi` 本身）：目录型 pattern
+ * （`.harness-pi/`）只匹配目录，而 `git check-ignore .harness-pi` 在该目录尚不存在时不会判定为忽略；
+ * 改查 `.harness-pi/<probe>` 则 `.harness-pi/`、`.harness-pi`、`/.harness-pi/` 等写法都能正确命中
+ * （目录被忽略 ⇒ 其全部内容被忽略，正是 log/sessions 的实际落点）。
+ * `git check-ignore -q`：exit 0=忽略、exit 1=未忽略、exit 128=非 git 仓库
+ * （execFileSync 在非 0 退出时抛错，错误对象的 `status` 即退出码）。
+ */
+export function isHarnessPiGitIgnored(cwd: string): boolean | null {
+  try {
+    execFileSync("git", ["check-ignore", "-q", ".harness-pi/probe"], {
+      cwd,
+      stdio: "ignore",
+    });
+    return true; // exit 0 → 已忽略
+  } catch (err) {
+    const status = (err as { status?: number }).status;
+    if (status === 1) return false; // 明确未忽略
+    return null; // 128（非 git 仓库）/ ENOENT（无 git）等 → 无 git 泄漏面，不告警
+  }
+}
+
+/**
+ * 若 `cwd` 是 git 仓库且**未**忽略 `.harness-pi/`，返回一条醒目告警文案；否则返回 `null`。
+ * 仅在 agent 确实会往 `.harness-pi/` 落盘（session log 或 resume 存储）时由调用方触发。
+ */
+export function harnessPiGitignoreWarning(cwd: string): string | null {
+  if (isHarnessPiGitIgnored(cwd) !== false) return null;
+  return (
+    "'.harness-pi/' 未被 .gitignore 忽略：session log 与 resume 存储会在此保存完整对话历史" +
+    "（resume 存储含 write 文件内容、bash 命令等**原文**，无法脱敏）。请把 '.harness-pi/' 加入 " +
+    ".gitignore，以免敏感内容被误提交进仓库。"
+  );
+}


### PR DESCRIPTION
Closes #22。

## 问题
resume 持久化存储（`.harness-pi/sessions/*.jsonl`，TUI / `--resume`）为能正确**重放续跑**，必须保存**完整原文**消息历史（含 `write` 内容、`bash` 命令），**无法脱敏**（脱了 resume 就坏）。agent 常跑在任意用户 repo，若未 gitignore `.harness-pi/`，这些原文可能被误提交——与 #11 item2（已脱敏 session log）同类泄漏面的另一条落盘通道。

## 方案:运行时守卫(用户选定,非裸脱敏、不改用户 .gitignore)
- **workspace-safety.ts**：`isHarnessPiGitIgnored` 用 `git check-ignore -q .harness-pi/<probe>`（探子路径，正确命中目录型 pattern）；三态 `true/false/null`（非 git 仓库 / git 不可用 → null，无泄漏面不告警，ENOENT 防御回退）。
- **agent.ts**：logDir `resolve` 成绝对路径（相对 `--log-dir` 也有确定落点、门控不假阴性）；会往 `cwd/.harness-pi` 落盘（默认 log,或挂了 resume 存储）且未忽略时，把告警 push 进 `RunReport.warnings`。路径边界用 `harnessDir + sep`，不误命中 `.harness-pi-backup`。
- **cli.ts**：启动期（早于落盘、TUI 也可见）把告警打到 stderr,复用 agent 已算好的落盘门控（无 `--no-log` 假阳性）。
- **README**：说明 resume 存储保存完整原文、需 gitignore `.harness-pi/`。
- **测试(20)**：三态 + 多种 gitignore 写法 + 相对/绝对/兄弟目录 logDir 边界 + log×persistence 矩阵（`log:false ≠ 安全`）+ 非 git + ENOENT 回退 + 跨层门控恒等。

## 验证
- coding-agent 218 ✅；`pnpm -r typecheck` 全 9 项目绿。
- 三审:code 8.78 ✅ / test 8.15 ✅ / linus "Looks reasonable." ✅。

> 后续可选(linus 非阻塞建议):把 CLI 对告警文案的 `includes` 匹配换成结构化标志,降低隐式契约脆性。

🤖 Generated with [Claude Code](https://claude.com/claude-code)