### PR TITLE
refactor(coding-agent): structured harnessPiWarning flag (#22 followup)

### DIFF
--- a/apps/coding-agent/src/__tests__/workspace-safety.test.ts
+++ b/apps/coding-agent/src/__tests__/workspace-safety.test.ts
@@ -2,14 +2,17 @@ import { afterEach, describe, expect, it } from "vitest";
 import { execFileSync } from "node:child_process";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
+import { mkdir } from "node:fs/promises";
 import { createFakeModel } from "@harness-pi/core/testing";
 import { MemorySessionStore } from "@harness-pi/core";
+import { JsonlSessionStore } from "@harness-pi/adapters";
 import {
   harnessPiGitignoreWarning,
   isHarnessPiGitIgnored,
 } from "../workspace-safety.js";
-import { createCodingAgent } from "../agent.js";
+import { createCodingAgent, resumeCodingAgent } from "../agent.js";
+import { emitStartupWarnings } from "../cli.js";
 
 const dirs: string[] = [];
 afterEach(async () => {
@@ -82,9 +85,10 @@ describe("createCodingAgent → agent.warnings 的 .harness-pi 落盘门控", ()
     const cwd = await gitRepo();
     const agent = createCodingAgent({ cwd, model: createFakeModel([]) });
     const gw = agent.warnings.filter((w) => w.includes(".harness-pi") && w.includes(".gitignore"));
-    expect(gw).toHaveLength(1);
-    // CLI 启动期 stderr 门控依赖这条恒等：harnessPiGitignoreWarning(resolve(cwd)) 必在 agent.warnings 里。
-    expect(agent.warnings).toContain(harnessPiGitignoreWarning(resolve(cwd)));
+    expect(gw).toHaveLength(1); // run report 里恰一条，不重复堆叠
+    // 结构化标志（CLI 启动期 stderr 据此判断，不靠文案字符串匹配）也置位，且与 warnings 里那条一致。
+    expect(agent.harnessPiWarning).toBeTruthy();
+    expect(agent.warnings).toContain(agent.harnessPiWarning!);
   });
 
   it("persistence（resume 存储）+ 未忽略 → 出告警（头号泄漏面）", async () => {
@@ -108,8 +112,8 @@ describe("createCodingAgent → agent.warnings 的 .harness-pi 落盘门控", ()
     const cwd = await gitRepo();
     const agent = createCodingAgent({ cwd, model: createFakeModel([]), log: false });
     expect(hasGitignoreWarn(agent.warnings)).toBe(false);
-    // 这条同时锁住 CLI 启动期 stderr 不会假阳性（它只在告警进了 agent.warnings 时才打）。
-    expect(agent.warnings).not.toContain(harnessPiGitignoreWarning(resolve(cwd)));
+    // 结构化标志也为 undefined → CLI 启动期 stderr 不会假阳性（emitStartupWarnings 据此判断）。
+    expect(agent.harnessPiWarning).toBeUndefined();
   });
 
   it("自定义 logDir 落在 .harness-pi 之外 + 无 persistence → 不告警", async () => {
@@ -174,5 +178,59 @@ describe("createCodingAgent → agent.warnings 的 .harness-pi 落盘门控", ()
     const cwd = await tmp();
     const agent = createCodingAgent({ cwd, model: createFakeModel([]) });
     expect(hasGitignoreWarn(agent.warnings)).toBe(false);
+    expect(agent.harnessPiWarning).toBeUndefined();
+  });
+
+  it("resumeCodingAgent（--resume/TUI 路径，必挂 persistence）+ 未忽略 → 告警（头号泄漏面）", async () => {
+    // resume 走 resumeCodingAgent，与 createCodingAgent 共享 buildAgentContext；persistence 必填，
+    // 故 resume 必然会落 .harness-pi/sessions 原文，未忽略时必须告警。直接锁住这条真实入口。
+    const cwd = await gitRepo();
+    const store = new JsonlSessionStore(join(cwd, ".harness-pi", "sessions", "s1.jsonl"));
+    const agent = await resumeCodingAgent({
+      cwd,
+      model: createFakeModel([]),
+      persistence: { store, sessionId: "s1" }, // 文件不存在 → 空历史 resume，足以验证门控
+    });
+    expect(agent.harnessPiWarning).toBeTruthy();
+    expect(hasGitignoreWarn(agent.warnings)).toBe(true);
+  });
+});
+
+describe("emitStartupWarnings（CLI 启动期 stderr 发射，直测）", () => {
+  it("harnessPiWarning 存在 → 写一行带 ⚠️ 前缀的告警", () => {
+    const out: string[] = [];
+    emitStartupWarnings({ harnessPiWarning: "X 未被 gitignore" }, (s) => out.push(s));
+    expect(out).toHaveLength(1);
+    expect(out[0]).toBe("⚠️  X 未被 gitignore\n");
+  });
+
+  it("harnessPiWarning 为 undefined → 不写（锁住 --no-log 等不落盘场景无假阳性）", () => {
+    const out: string[] = [];
+    emitStartupWarnings({ harnessPiWarning: undefined }, (s) => out.push(s));
+    expect(out).toHaveLength(0);
+  });
+});
+
+describe("isHarnessPiGitIgnored 进阶边界", () => {
+  it("否定/再包含 pattern（.harness-pi/ + !.harness-pi/keep）→ probe 子路径仍判忽略", async () => {
+    // 尾部 negation 只放行 .harness-pi/keep，不翻转 .harness-pi/probe 的忽略状态。
+    const cwd = await gitRepo(".harness-pi/\n!.harness-pi/keep\n");
+    expect(isHarnessPiGitIgnored(cwd)).toBe(true);
+  });
+
+  it("从仓库子目录运行：根 .gitignore 的 .harness-pi/ 在子目录下仍命中", async () => {
+    const root = await gitRepo(".harness-pi/\n");
+    const sub = join(root, "packages", "app");
+    await mkdir(sub, { recursive: true });
+    // git check-ignore 以 sub 为 cwd 查 .harness-pi/probe（= sub/.harness-pi/probe），
+    // 根 .gitignore 的无锚 pattern 在任意层级生效 → 仍判忽略。
+    expect(isHarnessPiGitIgnored(sub)).toBe(true);
+  });
+
+  it("从仓库子目录运行 + 未忽略 → 仍报未忽略", async () => {
+    const root = await gitRepo();
+    const sub = join(root, "packages", "app");
+    await mkdir(sub, { recursive: true });
+    expect(isHarnessPiGitIgnored(sub)).toBe(false);
   });
 });

--- a/apps/coding-agent/src/__tests__/workspace-safety.test.ts
+++ b/apps/coding-agent/src/__tests__/workspace-safety.test.ts
@@ -1,9 +1,8 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { execFileSync } from "node:child_process";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { mkdir } from "node:fs/promises";
 import { createFakeModel } from "@harness-pi/core/testing";
 import { MemorySessionStore } from "@harness-pi/core";
 import { JsonlSessionStore } from "@harness-pi/adapters";
@@ -193,6 +192,33 @@ describe("createCodingAgent → agent.warnings 的 .harness-pi 落盘门控", ()
     });
     expect(agent.harnessPiWarning).toBeTruthy();
     expect(hasGitignoreWarn(agent.warnings)).toBe(true);
+    expect(agent.warnings).toContain(agent.harnessPiWarning!); // flag 与 warnings 同源一致（与 create 路径同等强度）
+  });
+
+  it("resumeCodingAgent + 已忽略 .harness-pi → 不告警（resume 入口负向对照）", async () => {
+    const cwd = await gitRepo(".harness-pi/\n");
+    const store = new JsonlSessionStore(join(cwd, ".harness-pi", "sessions", "s1.jsonl"));
+    const agent = await resumeCodingAgent({
+      cwd,
+      model: createFakeModel([]),
+      persistence: { store, sessionId: "s1" },
+    });
+    expect(agent.harnessPiWarning).toBeUndefined();
+    expect(hasGitignoreWarn(agent.warnings)).toBe(false);
+  });
+
+  it("resume 有真实落盘历史 + 未忽略 → 仍告警（门控基于「会落盘」而非历史是否为空）", async () => {
+    const cwd = await gitRepo();
+    const file = join(cwd, ".harness-pi", "sessions", "s1.jsonl");
+    await mkdir(join(cwd, ".harness-pi", "sessions"), { recursive: true });
+    const store = new JsonlSessionStore(file);
+    await store.appendEntry("s1", { kind: "message", message: { role: "user", content: "hi" } as never });
+    const agent = await resumeCodingAgent({
+      cwd,
+      model: createFakeModel([]),
+      persistence: { store, sessionId: "s1" },
+    });
+    expect(agent.harnessPiWarning).toBeTruthy();
   });
 });
 
@@ -207,6 +233,12 @@ describe("emitStartupWarnings（CLI 启动期 stderr 发射，直测）", () => 
   it("harnessPiWarning 为 undefined → 不写（锁住 --no-log 等不落盘场景无假阳性）", () => {
     const out: string[] = [];
     emitStartupWarnings({ harnessPiWarning: undefined }, (s) => out.push(s));
+    expect(out).toHaveLength(0);
+  });
+
+  it("harnessPiWarning 为空串 → 不写（真值判断，空串=无话可说）", () => {
+    const out: string[] = [];
+    emitStartupWarnings({ harnessPiWarning: "" }, (s) => out.push(s));
     expect(out).toHaveLength(0);
   });
 });

--- a/apps/coding-agent/src/agent.ts
+++ b/apps/coding-agent/src/agent.ts
@@ -103,6 +103,12 @@ export interface CodingAgent {
   model: Model<Api>;
   costKnown: boolean;
   warnings: string[];
+  /**
+   * #22 守卫：若本次运行会往未被 gitignore 的 `cwd/.harness-pi` 落盘，则为那条告警文案，否则 undefined。
+   * 这是个**结构化标志**——消费者（如 CLI 启动期 stderr）据此判断要不要提示，**不靠**按文案字符串匹配
+   * `warnings` 数组（那是脆弱的隐式契约）。同一条文案也会进 `warnings`（供 run report 呈现）。
+   */
+  harnessPiWarning?: string | undefined;
   readOnly: boolean;
   logPath: string;
   metricsPath?: string | undefined;
@@ -284,10 +290,11 @@ function buildAgentContext(opts: CreateCodingAgentOptions): AgentContext {
     (opts.log !== false &&
       (logDir === harnessDir || logDir.startsWith(harnessDir + sep))) || // 路径边界，不误命中 .harness-pi-backup
     opts.persistence !== undefined;
-  if (writesUnderHarnessPi) {
-    const w = harnessPiGitignoreWarning(cwd);
-    if (w) warnings.push(w);
-  }
+  // 算一次：结构化标志（暴露给 CLI 等消费者）+ 进 warnings（供 run report）。
+  const harnessPiWarning = writesUnderHarnessPi
+    ? (harnessPiGitignoreWarning(cwd) ?? undefined)
+    : undefined;
+  if (harnessPiWarning) warnings.push(harnessPiWarning);
   const dashScopeCost = createDashScopeCostAccumulator(opts.model, opts.llmOptions);
   const costTrackerOptions: CostTrackerOptions = {
     mode: "lifetime",
@@ -385,6 +392,7 @@ function buildAgentContext(opts: CreateCodingAgentOptions): AgentContext {
         model: opts.model,
         costKnown,
         warnings,
+        harnessPiWarning,
         readOnly,
         logPath: join(logDir, `${session.id}.ndjson`),
         metricsPath: opts.metricsFile,

--- a/apps/coding-agent/src/agent.ts
+++ b/apps/coding-agent/src/agent.ts
@@ -291,6 +291,8 @@ function buildAgentContext(opts: CreateCodingAgentOptions): AgentContext {
       (logDir === harnessDir || logDir.startsWith(harnessDir + sep))) || // 路径边界，不误命中 .harness-pi-backup
     opts.persistence !== undefined;
   // 算一次：结构化标志（暴露给 CLI 等消费者）+ 进 warnings（供 run report）。
+  // `?? undefined`：harnessPiGitignoreWarning 返回 string|null，转成 string|undefined 以对齐字段类型
+  // （exactOptionalPropertyTypes 下 null 不可赋给 string|undefined）。
   const harnessPiWarning = writesUnderHarnessPi
     ? (harnessPiGitignoreWarning(cwd) ?? undefined)
     : undefined;

--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -22,7 +22,6 @@ import {
   formatProviderList,
   loadDotEnv,
 } from "./config.js";
-import { harnessPiGitignoreWarning } from "./workspace-safety.js";
 import { toolNames, type ToolName } from "@harness-pi/tools";
 import { JsonlSessionStore } from "@harness-pi/adapters";
 import { ProcessTerminal } from "@mariozechner/pi-tui";
@@ -53,6 +52,17 @@ interface CliArgs {
 /** TUI 会话落盘文件路径:.harness-pi/sessions/<id>.jsonl（相对 cwd）。 */
 function sessionFilePath(cwd: string, sessionId: string): string {
   return join(resolve(cwd), ".harness-pi", "sessions", `${sessionId}.jsonl`);
+}
+
+/**
+ * 启动期把 agent 的 `.harness-pi` 落盘安全告警（若有）发到 stderr。抽成纯函数（注入 `write`）便于直测，
+ * 且只读结构化标志 `harnessPiWarning`——不按文案字符串匹配 warnings 数组。
+ */
+export function emitStartupWarnings(
+  agent: Pick<CodingAgent, "harnessPiWarning">,
+  write: (s: string) => void,
+): void {
+  if (agent.harnessPiWarning) write(`⚠️  ${agent.harnessPiWarning}\n`);
 }
 
 /** 该会话的 persistence 子对象（store + id 捆一起，对齐 createCodingAgent.persistence）。 */
@@ -213,13 +223,9 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
   }
 
   // #22 守卫：启动期就把 .harness-pi 未被 gitignore 的风险打到 stderr（早于任何落盘，且 TUI 路径
-  // 不渲染 run report 也能看到）。**复用 agent 已算好的「会往 .harness-pi 落盘」门控**：只有当该告警确实
-  // 进了 agent.warnings（本次运行真会落盘）才打——避免 --no-log（不落盘）下的假阳性，且与 agent 层
-  // 同一来源、同一 resolve(cwd)，不重复门控逻辑。one-shot 的 run report 也会再列一次，刻意冗余。
-  const gitignoreWarning = harnessPiGitignoreWarning(resolve(args.cwd));
-  if (gitignoreWarning && agent.warnings.includes(gitignoreWarning)) {
-    process.stderr.write(`⚠️  ${gitignoreWarning}\n`);
-  }
+  // 不渲染 run report 也能看到）。读 agent 的**结构化标志** harnessPiWarning（agent 已算好「是否落盘」
+  // 门控），不按文案字符串匹配 warnings 数组。one-shot 的 run report 也会再列一次，刻意冗余。
+  emitStartupWarnings(agent, (s) => process.stderr.write(s));
 
   try {
     if (!args.readOnly) {


### PR DESCRIPTION
#22 守卫的收尾重构——把 linus 在 #24 留下的非阻塞建议根治掉,不留 actionable 遗留。

## 改动(apps/coding-agent only,+126/-20)
- **结构化标志取代脆弱隐式契约**:`CodingAgent` 新增 `harnessPiWarning?: string`。`buildAgentContext` 一次性计算门控,既进 `warnings`(run report)又作类型化标志暴露。CLI 不再 `harnessPiGitignoreWarning(resolve(cwd))` 重算 + 按整段中文文案 `agent.warnings.includes(...)` 双重门控(文案/路径一漂就静默假阴性——对安全告警是最恶心的 bug)。省掉第二次 git 调用。
- **可直测**:CLI 启动期 stderr 发射抽成纯函数 `emitStartupWarnings(agent, write)`(注入 `write`、`Pick<CodingAgent,'harnessPiWarning'>` 收窄入参)。
- **补真实入口与边界测试**:`resumeCodingAgent`(`--resume`/TUI,头号泄漏面,persistence 必挂)未忽略→告警 / 已忽略→不告警 / 有真实落盘历史仍告警 / flag 与 warnings 同源一致;emitStartupWarnings present/undefined/空串;否定 pattern;子目录运行命中根 .gitignore。

## 验证
- coding-agent 227 ✅(workspace-safety 29);`pnpm -r typecheck` 全 9 项目绿。
- 三审:code 8.92 ✅ / test 8.3 ✅ / linus **"Applied."** ✅。

> 有意接受的缺口:CLI `main()` 全链路 e2e——发射逻辑已抽成纯函数直测、`harnessPiWarning` 字段充分测,两半都覆盖;强行驱动 `main()` 需真 provider 跑会引入 flaky,reviewer 亦判为可接受。

🤖 Generated with [Claude Code](https://claude.com/claude-code)