### PR TITLE
chore: add CI (typecheck/build/test + real-PG) and bump to 0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    # 真 Postgres service：让 packages/adapters 那 18 个 env-gated 集成测试在 CI 真跑（pg-mem 与真 PG
+    # 有已知偏差，单链路靠模拟器背书不够）。POSTGRES_TEST_URL 一设，integration 测试就从 skip 转为执行。
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: harness_pi_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      POSTGRES_TEST_URL: postgres://postgres:test@localhost:5432/harness_pi_test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.15.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      # build 必须先于 typecheck/test：coding-agent 等下游按各包的**已构建 dist** 做类型检查与跨包导入。
+      - name: Build
+        run: pnpm -r build
+
+      - name: Typecheck
+        run: pnpm -r typecheck
+
+      - name: Test
+        run: pnpm -r test

--- a/apps/coding-agent/package.json
+++ b/apps/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-pi/coding-agent",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Dogfood coding agent built on harness-pi — usable pi-tui CLI showcasing the harness-pi kernel",
   "license": "MIT",
   "repository": {
@@ -22,7 +22,12 @@
       "default": "./dist/cli.js"
     }
   },
-  "files": ["dist", "README.md", "!**/__tests__/**", "!**/*.test.*"],
+  "files": [
+    "dist",
+    "README.md",
+    "!**/__tests__/**",
+    "!**/*.test.*"
+  ],
   "engines": {
     "node": ">=20"
   },

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-pi/adapters",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "SessionStore adapters for harness-pi (JSONL file + Postgres). Concrete I/O behind the kernel SessionStore protocol.",
   "license": "MIT",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-pi/core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Agent kernel — pi-ai loop + first-class hook system",
   "license": "MIT",
   "repository": {
@@ -23,7 +23,13 @@
       "default": "./dist/testing.js"
     }
   },
-  "files": ["dist", "src", "README.md", "!**/__tests__/**", "!**/*.test.*"],
+  "files": [
+    "dist",
+    "src",
+    "README.md",
+    "!**/__tests__/**",
+    "!**/*.test.*"
+  ],
   "scripts": {
     "prepublishOnly": "pnpm run build",
     "build": "tsc -p .",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-pi/plugins",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Standard library of harness-pi plugins + controllers + sinks",
   "license": "MIT",
   "repository": {
@@ -35,7 +35,13 @@
       "default": "./dist/metrics/sinks/postgres.js"
     }
   },
-  "files": ["dist", "src", "README.md", "!**/__tests__/**", "!**/*.test.*"],
+  "files": [
+    "dist",
+    "src",
+    "README.md",
+    "!**/__tests__/**",
+    "!**/*.test.*"
+  ],
   "scripts": {
     "prepublishOnly": "pnpm run build",
     "build": "tsc -p .",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-pi/tools",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "First-party coding tools for harness-pi agents",
   "license": "MIT",
   "repository": {
@@ -19,7 +19,13 @@
       "default": "./dist/index.js"
     }
   },
-  "files": ["dist", "src", "README.md", "!**/__tests__/**", "!**/*.test.*"],
+  "files": [
+    "dist",
+    "src",
+    "README.md",
+    "!**/__tests__/**",
+    "!**/*.test.*"
+  ],
   "scripts": {
     "prepublishOnly": "pnpm run build",
     "build": "tsc -p .",


### PR DESCRIPTION
为「dev→main + main 保护」铺路 & 把本轮全部 hardening 发布到 npm。

## CI（首次引入）
`.github/workflows/ci.yml`:`pnpm install --frozen-lockfile → build → typecheck → test`,on push/PR to `main|dev`。
- 挂 `postgres:16` service + `POSTGRES_TEST_URL`,让 adapters 那 **18 个 env-gated 真 PG 集成测试在 CI 真跑**(pg-mem 与真 PG 有已知偏差——PR #23 那个 INSERT...SELECT 标量子查询 bug 就是例证)。
- 本地已用 docker 真 PG(postgres:16)跑通这 18 个,**adapters 78 passed**,验证 PR #23 的原子 `INSERT...SELECT...RETURNING` 在真库正确。

## 版本 → 0.2.0
4 库 + hpi 从 0.1.0/0.1.1 统一 bump 到 **0.2.0**(自 0.1.0 起新增 strictPersistence / redactToolArgs / message_update 契约 / tool-order barrier 修复 / auto-compaction / PG 加固,feature 级 → minor)。`workspace:*` 不动,`--frozen-lockfile` 无漂移。

## 后续(本 PR 合并后)
建 `dev`、保护 `main`(require PR from dev + 本 CI 绿 + linear history),然后从 0.2.0 commit 发 npm。

> 本 PR 为 CI 配置 + 版本号,无源码逻辑/测试可供 code/test/linus 三审;其正确性由本 PR 上的 CI 跑绿验证(这正是要建立的新 gate)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)