### PR TITLE
fix(coding-agent): strict persistence in TUI/resume + surface persistenceErrors (#30)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ dist/
 
 # coding-agent runtime output (session logs, persisted sessions, metrics)
 .harness-pi/
+
+# 研究产物(放 ~/Dev/coding/reports 或本地;不入源码库,避免 git add -A 误扫)
+reports/

--- a/apps/coding-agent/src/__tests__/cli-args.test.ts
+++ b/apps/coding-agent/src/__tests__/cli-args.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
-import { isMainModule, parseArgs } from "../cli.js";
+import { isMainModule, parseArgs, sessionExitNotice } from "../cli.js";
 
 describe("parseArgs — v0.1.0 flags", () => {
   it("defaults: no tui/repl/version/list flags set", () => {
@@ -79,6 +79,26 @@ describe("parseArgs — v0.1.0 flags", () => {
 
   it("rejects unknown options", () => {
     expect(() => parseArgs(["--nope"])).toThrow(/Unknown option/);
+  });
+
+  // #30:TUI 退出消息——落盘失败时不谎称 persisted。
+  it("sessionExitNotice: persistenceErrorRuns>0 → warn + FAILED + run 数", () => {
+    const n = sessionExitNotice("abc", 2);
+    expect(n?.level).toBe("warn");
+    expect(n?.text).toContain("FAILED on 2 run(s)");
+    expect(n?.text).toContain("--resume abc");
+    expect(n?.text).toContain("incomplete");
+  });
+  it("sessionExitNotice: 0 失败 → log + persisted", () => {
+    const n = sessionExitNotice("abc", 0);
+    expect(n?.level).toBe("log");
+    expect(n?.text).toContain("persisted");
+    expect(n?.text).toContain("--resume abc");
+    expect(n?.text).not.toContain("FAILED");
+  });
+  it("sessionExitNotice: 无 sessionId(非 TUI 落盘)→ null", () => {
+    expect(sessionExitNotice(undefined, 0)).toBeNull();
+    expect(sessionExitNotice(undefined, 3)).toBeNull();
   });
 
   it("ignores a leading `--` (pnpm separator) and still parses following flags", () => {

--- a/apps/coding-agent/src/__tests__/output.test.ts
+++ b/apps/coding-agent/src/__tests__/output.test.ts
@@ -41,6 +41,27 @@ describe("renderRunReport — failure & overflow surfacing", () => {
     expect(out).toContain("abort reason: watchdog:timeout");
   });
 
+  it("surfaces persistenceErrors（否则「done 但 transcript 不全」被静默吞掉）", () => {
+    const out = renderRunReport(
+      report({
+        reason: "error",
+        persistenceErrors: ["appendEntry(message): boom", "appendEntry(terminal): boom"],
+      }),
+    );
+    expect(out).toContain("persistence errors (2)");
+    expect(out).toContain("appendEntry(message): boom");
+    expect(out).toContain("appendEntry(terminal): boom");
+  });
+
+  it("无 persistenceErrors 时不打该行", () => {
+    expect(renderRunReport(report({ reason: "done" }))).not.toContain("persistence errors");
+  });
+
+  it("单条 persistenceError → (1) 计数 + 该条文案(钉住计数与分隔符渲染)", () => {
+    const out = renderRunReport(report({ reason: "error", persistenceErrors: ["appendEntry(terminal): boom"] }));
+    expect(out).toContain("persistence errors (1): appendEntry(terminal): boom");
+  });
+
   it("warns when the answer was truncated by the context/output limit (stopReason length)", () => {
     const out = renderRunReport(report({ reason: "done", stopReason: "length" }));
     expect(out).toMatch(/Warnings/);

--- a/apps/coding-agent/src/__tests__/strict-persistence.test.ts
+++ b/apps/coding-agent/src/__tests__/strict-persistence.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { MemorySessionStore, type SessionEntry, type StoredEntry } from "@harness-pi/core";
+import { createFakeModel } from "@harness-pi/core/testing";
+import { createCodingAgent, resumeCodingAgent, runAgentPrompt } from "../agent.js";
+import { renderRunReport } from "../output.js";
+
+/**
+ * #30：coding-agent 必须能把 core 的 strict persistence 接进来,并把 persistenceErrors 暴露出来。
+ * 这些测试证明 `strictPersistence` 选项经 createCodingAgent / resumeCodingAgent 流到内核,
+ * 且失败被如实暴露(而非「done 但 transcript 不全」静默吞掉)。
+ */
+class FailingStore extends MemorySessionStore {
+  override async appendEntry(_sessionId: string, _entry: SessionEntry): Promise<StoredEntry> {
+    throw new Error("disk on fire");
+  }
+}
+
+const dirs: string[] = [];
+afterEach(async () => {
+  while (dirs.length) {
+    const d = dirs.pop();
+    if (d) await rm(d, { recursive: true, force: true });
+  }
+});
+async function tmp(): Promise<string> {
+  const d = await mkdtemp(join(tmpdir(), "hpi-strict-"));
+  dirs.push(d);
+  return d;
+}
+const oneText = () => createFakeModel([{ content: [{ type: "text", text: "hi" }] }]);
+
+describe("coding-agent strict persistence 接线 (#30)", () => {
+  it("strictPersistence:true + 落盘失败 → reason 提级 error + persistenceErrors 暴露", async () => {
+    const cwd = await tmp();
+    const agent = createCodingAgent({
+      cwd,
+      model: oneText(),
+      strictPersistence: true,
+      persistence: { store: new FailingStore(), sessionId: "s1" },
+    });
+    const report = await runAgentPrompt(agent, "go");
+    expect(report.summary.reason).toBe("error"); // strict 把「落盘不全的 done」提级
+    expect(report.summary.persistenceErrors!.length).toBeGreaterThan(0);
+    expect(report.summary.error!.message).toContain("strict persistence failed"); // 填的是 strict 失败原因
+    expect(renderRunReport(report)).toContain("persistence errors"); // 报告里可见
+  });
+
+  it("默认(不传 strictPersistence)+ 落盘失败 → best-effort,reason 不变但 persistenceErrors 仍暴露", async () => {
+    const cwd = await tmp();
+    const agent = createCodingAgent({
+      cwd,
+      model: oneText(),
+      persistence: { store: new FailingStore(), sessionId: "s1" },
+    });
+    const report = await runAgentPrompt(agent, "go");
+    expect(report.summary.reason).toBe("done"); // best-effort 不劫持终态
+    expect(report.summary.persistenceErrors!.length).toBeGreaterThan(0); // 但失败如实暴露
+  });
+
+  it("健康 store + strict → 不误伤(reason done,无 persistenceErrors)", async () => {
+    const cwd = await tmp();
+    const agent = createCodingAgent({
+      cwd,
+      model: oneText(),
+      strictPersistence: true,
+      persistence: { store: new MemorySessionStore(), sessionId: "s1" },
+    });
+    const report = await runAgentPrompt(agent, "go");
+    expect(report.summary.reason).toBe("done");
+    expect(report.summary.persistenceErrors).toBeUndefined();
+  });
+
+  it("resumeCodingAgent 也透传 strict(resume 是崩溃恢复路径,默认应 strict)", async () => {
+    const cwd = await tmp();
+    // 空历史 resume(store 无该 session)足以验证 strict 透传:续跑落盘失败 → reason error。
+    const agent = await resumeCodingAgent({
+      cwd,
+      model: oneText(),
+      strictPersistence: true,
+      persistence: { store: new FailingStore(), sessionId: "s1" },
+    });
+    const report = await runAgentPrompt(agent, "go");
+    expect(report.summary.reason).toBe("error");
+    expect(report.summary.persistenceErrors!.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/coding-agent/src/agent.ts
+++ b/apps/coding-agent/src/agent.ts
@@ -89,6 +89,14 @@ export interface CreateCodingAgentOptions {
    */
   persistence?: { store: SessionStore; sessionId: string };
   /**
+   * 严格持久化（透传给内核 `AgentSession.strictPersistence`）。true ⇒ run 结束时若落盘未真正完成
+   * （最终 flush / terminal append 失败），把 `RunSummary.reason` 改写为 "error" 并填 error，避免
+   * 「done 但 transcript 不全」被当成功。两种模式下 `RunSummary.persistenceErrors` 都如实暴露。
+   * TUI / resume（崩溃恢复路径）应默认开启——那正是 strict 存在的理由。createCodingAgent 与
+   * resumeCodingAgent 共用 buildAgentContext，故经 `deps` 一处接线即两路通吃。
+   */
+  strictPersistence?: boolean;
+  /**
    * 启用 compaction（compactSummarize view-transform：超阈值时把早期消息换成模型生成的摘要喂给 LLM，
    * 不毁原始历史）。给了即挂 hook；`maxMessages` 不给 = 阈值设为大哨兵（在位但不自动触发），靠
    * `requestCompaction()`（TUI 的 `/compact`）临时降阈强制压缩。one-shot 模式不传本项即完全不挂。
@@ -382,6 +390,8 @@ function buildAgentContext(opts: CreateCodingAgentOptions): AgentContext {
   };
   if (opts.maxTurns !== undefined) deps.maxTurns = opts.maxTurns;
   if (opts.llmOptions !== undefined) deps.llmOptions = opts.llmOptions;
+  // 单点接线：deps 流向 createCodingAgent({...deps}) 与 resumeCodingAgent(AgentSession.resume(...,deps)) 两路。
+  if (opts.strictPersistence !== undefined) deps.strictPersistence = opts.strictPersistence;
 
   return {
     deps,

--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -65,6 +65,27 @@ export function emitStartupWarnings(
   if (agent.harnessPiWarning) write(`⚠️  ${agent.harnessPiWarning}\n`);
 }
 
+/**
+ * TUI 退出时给的会话落盘提示。抽成纯函数便于直测。`persistenceErrorRuns>0` ⇒ 本会话有 run 落盘失败,
+ * 不能谎称 "persisted",改为告警 resume 可能不全;否则给正常 resume 句柄。无 sessionId(非 TUI 落盘)⇒ null。
+ */
+export function sessionExitNotice(
+  sessionId: string | undefined,
+  persistenceErrorRuns: number,
+): { level: "warn" | "log"; text: string } | null {
+  if (!sessionId) return null;
+  if (persistenceErrorRuns > 0) {
+    return {
+      level: "warn",
+      text: `⚠ Session persistence FAILED on ${persistenceErrorRuns} run(s) — --resume ${sessionId} may restore incomplete state (see warnings above).`,
+    };
+  }
+  return {
+    level: "log",
+    text: `Session persisted (process-crash recoverable). Resume with: --resume ${sessionId}`,
+  };
+}
+
 /** 该会话的 persistence 子对象（store + id 捆一起，对齐 createCodingAgent.persistence）。 */
 function persistenceFor(
   cwd: string,
@@ -213,11 +234,13 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     agent = await resumeCodingAgent({
       ...createOptions,
       persistence: persistenceFor(args.cwd, sessionId),
+      strictPersistence: true, // resume = 崩溃恢复路径，默认 strict：落盘不全则 reason→error + 显式告警
     });
   } else {
     if (args.tui) {
       sessionId = randomUUID();
       createOptions.persistence = persistenceFor(args.cwd, sessionId);
+      createOptions.strictPersistence = true; // TUI 默认落盘 → 默认 strict（同 resume 理由）
     }
     agent = createCodingAgent(createOptions);
   }
@@ -260,11 +283,9 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
       await app.run(); // 直到用户 Ctrl-C 退出
       // 退出后告知 resume 句柄。落盘每 turn 用 appendFileSync（无 fsync）——进程崩溃可恢复，
       // 但断电/内核 panic 下最后一次写可能丢，故措辞为"process-crash recoverable"而非"saved"。
-      if (sessionId) {
-        console.log(
-          `Session persisted (process-crash recoverable). Resume with: --resume ${sessionId}`,
-        );
-      }
+      // 本会话出现过 persistenceErrors（strict 默认开）则不谎称 persisted——见 sessionExitNotice。
+      const notice = sessionExitNotice(sessionId, app.persistenceErrorRuns());
+      if (notice) (notice.level === "warn" ? console.warn : console.log)(notice.text);
       return;
     }
 

--- a/apps/coding-agent/src/output.ts
+++ b/apps/coding-agent/src/output.ts
@@ -34,6 +34,12 @@ export function renderRunReport(report: RunReport): string {
   // 失败终态把原因打出来——否则只剩 "reason: error"，piped/captured 的报告完全丢失原因。
   if (report.summary.error) lines.push(`error: ${report.summary.error.message}`);
   if (report.summary.abortReason) lines.push(`abort reason: ${report.summary.abortReason}`);
+  // 持久化失败如实暴露（两种模式都填）——否则「done 但 transcript 不全」会被静默吞掉，resume 拿残缺状态。
+  if (report.summary.persistenceErrors?.length) {
+    lines.push(
+      `persistence errors (${report.summary.persistenceErrors.length}): ${report.summary.persistenceErrors.join("; ")}`,
+    );
+  }
   lines.push(`turns: ${report.summary.turns}`);
   lines.push(`continuations: ${report.summary.continuations}`);
   lines.push(`run wall time: ${formatMs(report.wallTimeMs)}`);

--- a/apps/coding-agent/src/tui/__tests__/app.smoke.test.ts
+++ b/apps/coding-agent/src/tui/__tests__/app.smoke.test.ts
@@ -141,6 +141,36 @@ describe("TUI app smoke (headless, dual-track via fake terminal)", () => {
     expect(out.split("All good.").length - 1).toBe(1); // 只出现一次
   });
 
+  const failSummary: RunSummary = {
+    turns: 1,
+    continuations: 0,
+    reason: "error",
+    usage: { ...ZERO },
+    persistenceErrors: ["appendEntry(message): boom"],
+  };
+
+  it("finalize: summary.persistenceErrors → 渲染醒目告警 + persistenceErrorRuns()===1", async () => {
+    const app = makeApp(scriptedSession([{ coarse: { type: "session-end", summary: failSummary } }], failSummary));
+    await app.submit("go");
+    const out = strip(app.tui.render(80).join("\n"));
+    expect(out).toContain("持久化失败"); // 落盘失败当场可见(崩溃恢复路径)
+    expect(out).toContain("appendEntry(message): boom"); // 具体错误
+    expect(app.persistenceErrorRuns()).toBe(1);
+  });
+
+  it("persistenceErrorRuns 跨多轮累积:两轮都失败 → 2", async () => {
+    const app = makeApp(scriptedSession([{ coarse: { type: "session-end", summary: failSummary } }], failSummary));
+    await app.submit("a");
+    await app.submit("b");
+    expect(app.persistenceErrorRuns()).toBe(2);
+  });
+
+  it("干净 run 不自增 persistenceErrorRuns(无假阳性)", async () => {
+    const app = makeApp(scriptedSession([{ coarse: { type: "session-end", summary } }], summary));
+    await app.submit("go");
+    expect(app.persistenceErrorRuns()).toBe(0);
+  });
+
   it("ignores empty submits (no user bubble added)", async () => {
     const app = makeApp(scriptedSession([{ coarse: { type: "session-end", summary } }], summary));
     const before = app.tui.render(80).join("\n");

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -98,6 +98,8 @@ export interface TuiApp {
   /** start() 并返回一个直到用户退出（Ctrl-C）才 resolve 的 promise——CLI 用它驱动生命周期。 */
   run(): Promise<void>;
   isRunning(): boolean;
+  /** 本会话累计出现 persistenceErrors 的 run 次数（>0 ⇒ 落盘有失败，resume 可能不全）。CLI 退出消息据此告警。 */
+  persistenceErrorRuns(): number;
 }
 
 interface StatsView {
@@ -108,6 +110,7 @@ interface StatsView {
 
 export function createTuiApp(opts: TuiAppOptions): TuiApp {
   const tui = new TUI(opts.terminal);
+  let persistenceErrorRuns = 0; // 累计落盘失败的 run 次数（finalize 据 summary.persistenceErrors 自增）
   const messages = new Container();
   const status = new Loader(tui, color.cyan, color.dim, "");
   status.stop(); // Loader 构造即开始动画；空闲时停掉，避免启动后 ~12fps 空转 churn（run 时再 start）。
@@ -275,6 +278,19 @@ export function createTuiApp(opts: TuiAppOptions): TuiApp {
   function finalize(summary: RunSummary): void {
     stats.input = summary.usage.input;
     stats.output = summary.usage.output;
+    // 落盘失败显著告警（崩溃恢复路径上,「done 但 transcript 不全」必须让用户当场看到,而非静默）。
+    if (summary.persistenceErrors?.length) {
+      persistenceErrorRuns++;
+      append(
+        new Text(
+          color.red(
+            `⚠ 持久化失败（resume 可能不全）: ${summary.persistenceErrors.join("; ")}`,
+          ),
+          0,
+          0,
+        ),
+      );
+    }
     const est = opts.agent.getCostEstimate?.();
     if (est) {
       stats.costText =
@@ -570,5 +586,5 @@ export function createTuiApp(opts: TuiAppOptions): TuiApp {
     return done;
   }
 
-  return { tui, submit, start, stop, run, isRunning: () => running };
+  return { tui, submit, start, stop, run, isRunning: () => running, persistenceErrorRuns: () => persistenceErrorRuns };
 }


### PR DESCRIPTION
Closes #30。把 core 的 strict persistence(#11.3)接进 coding-agent 最该用它的崩溃恢复路径。

- agent.ts:CreateCodingAgentOptions 加 `strictPersistence?`,经 `buildAgentContext` deps 单点接线 → create/resume 两路通吃。
- cli.ts:TUI 新会话 + `--resume` 默认 `strictPersistence:true`;退出消息抽成纯函数 `sessionExitNotice`——有失败则告警「may restore incomplete state」,不再谎称 persisted。
- output.ts:renderRunReport 渲染 `persistenceErrors`。tui/app.ts:finalize 据 `persistenceErrors` append 醒目告警 + `persistenceErrorRuns()` 计数,当场可见。
- 测试:agent strict 透传四不变量、output 渲染、TUI 渲染+跨轮计数、sessionExitNotice 三分支(coding-agent 240 ✅)。
- reports/ 加进 .gitignore(防研究产物误入源码库)。

三审:code 8.9 ✅ / test 8.28 ✅ / linus "Looks reasonable." ✅。base=dev(新 dev→main 流程)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)