### PR TITLE
fix(plugins): LeaseQueue/WorkPool abort must-settle pending work (#31)

### DIFF
--- a/packages/plugins/src/__tests__/controllers.test.ts
+++ b/packages/plugins/src/__tests__/controllers.test.ts
@@ -15,6 +15,7 @@ import {
   LifecycleRestart,
   WorkPool,
   LeaseQueue,
+  type LeaseStatus,
 } from "../controllers/index.js";
 
 /* ──────────────── LifecycleRestart ──────────────── */
@@ -279,6 +280,7 @@ describe("WorkPool", () => {
       text: "x",
     }));
     const ac = new AbortController();
+    const onSkip = vi.fn();
     const pool = new WorkPool<Item>({
       items,
       partition: (its) => its.map((it) => ({ id: it.id, items: [it] })),
@@ -293,13 +295,146 @@ describe("WorkPool", () => {
         ]);
         return { session: new AgentSession({ model, tools: [] }), prompt: "x" };
       },
+      onGroupSkipped: onSkip,
     });
     setTimeout(() => ac.abort(), 20);
     const res = await pool.start(ac.signal);
     // 关键：start() 返回时，inflight 一定是 0（已 drain）
     expect(inflight.count).toBe(0);
-    // result 反映已完成的 group 数（应该是当时 in-flight 的 3 个）
-    expect(res.completedGroups + res.failedGroups).toBe(inflight.peak);
+    // #31:未启动的 group 不再静默消失——进 results 标 skipped、计入 skippedGroups、触发 onGroupSkipped。
+    // 守恒:每个 group 都有终态,三类计数之和 === group 总数;results 也覆盖全部 group。
+    expect(res.completedGroups + res.failedGroups + res.skippedGroups).toBe(5);
+    expect(res.groups).toHaveLength(5);
+    expect(res.skippedGroups).toBe(2); // 并发 3 先启动,abort 在任一完成前触发 → 剩 2 个从未启动
+    expect(onSkip).toHaveBeenCalledTimes(2);
+    expect(res.groups.filter((g) => g.skipped === "aborted")).toHaveLength(2);
+  });
+
+  it("pre-aborted signal:全部 group 直接 skipped、不启动 worker、onGroupSkipped 全触发", async () => {
+    const onSkip = vi.fn();
+    const ac = new AbortController();
+    ac.abort(); // 启动前就已 abort
+    const items: Item[] = [
+      { id: "a", text: "x" },
+      { id: "b", text: "y" },
+    ];
+    const pool = new WorkPool<Item>({
+      items,
+      partition: (its) => its.map((it) => ({ id: it.id, items: [it] })),
+      workerFactory: async () => {
+        throw new Error("workerFactory must not run under pre-aborted signal");
+      },
+      onGroupSkipped: onSkip,
+    });
+    const res = await pool.start(ac.signal);
+    expect(res.completedGroups).toBe(0);
+    expect(res.failedGroups).toBe(0);
+    expect(res.skippedGroups).toBe(2);
+    expect(res.groups).toHaveLength(2);
+    expect(onSkip).toHaveBeenCalledTimes(2);
+  });
+
+  it("abort 时全部 in-flight(items <= 并发):无未启动 group → skippedGroups 0、不误触发 onGroupSkipped", async () => {
+    const onSkip = vi.fn();
+    const ac = new AbortController();
+    const items: Item[] = Array.from({ length: 3 }, (_, i) => ({ id: `i${i}`, text: "x" }));
+    const pool = new WorkPool<Item>({
+      items,
+      partition: (its) => its.map((it) => ({ id: it.id, items: [it] })),
+      maxConcurrency: 3, // 全部一次性启动,queue 为空
+      workerFactory: async () => {
+        await new Promise<void>((r) => setTimeout(r, 50));
+        const model = createFakeModel([{ content: [{ type: "text", text: "ok" }] }]);
+        return { session: new AgentSession({ model, tools: [] }), prompt: "x" };
+      },
+      onGroupSkipped: onSkip,
+    });
+    setTimeout(() => ac.abort(), 20);
+    const res = await pool.start(ac.signal);
+    expect(res.skippedGroups).toBe(0); // queue 空,无未启动 group
+    expect(onSkip).not.toHaveBeenCalled();
+    expect(res.completedGroups + res.failedGroups).toBe(3); // 守恒:全是已启动的
+  });
+
+  it("混合终态(串行 maxConcurrency=1):已跑完的 group 仍 completed,未启动的 skipped,二者共存且守恒", async () => {
+    // 钉死非退化(并非全 skipped)的守恒:abort 不会把已 completed 的 group 误判/回收成 skipped。
+    // 串行下 g0 正常跑完 → onGroupComplete 内触发 abort → loop 顶部见 aborted 退出 → g1/g2 从未启动 → sweep skipped。
+    const ac = new AbortController();
+    const items: Item[] = Array.from({ length: 3 }, (_, i) => ({ id: `i${i}`, text: "x" }));
+    const completedIds: string[] = [];
+    const pool = new WorkPool<Item>({
+      items,
+      partition: (its) => its.map((it) => ({ id: it.id, items: [it] })),
+      maxConcurrency: 1, // 串行,一次只跑一个
+      workerFactory: async () => {
+        const model = createFakeModel([{ content: [{ type: "text", text: "ok" }] }]);
+        return { session: new AgentSession({ model, tools: [] }), prompt: "x" };
+      },
+      onGroupComplete: (id) => {
+        completedIds.push(id);
+        if (id === "i0") ac.abort(); // g0 收尾后立刻 abort,后续 group 应一个都不启动
+      },
+    });
+    const res = await pool.start(ac.signal);
+    expect(res.completedGroups).toBe(1); // g0 真完成,未被 abort 回收
+    expect(res.skippedGroups).toBe(2); // g1/g2 从未启动
+    expect(res.failedGroups).toBe(0);
+    expect(res.completedGroups + res.failedGroups + res.skippedGroups).toBe(3); // 守恒,非退化(completed≥1 且 skipped≥1)
+    expect(completedIds).toEqual(["i0"]); // 串行:abort 后没有第二个 group 被启动
+    expect(res.groups.filter((g) => g.skipped === "aborted")).toHaveLength(2);
+  });
+
+  it("混合终态(串行):in-flight group factory 抛错(failed)与未启动 group(skipped)共存", async () => {
+    // failedGroups≥1 && skippedGroups≥1 同时出现:证明 abort sweep 不吞掉真实失败、失败也不污染 skipped 计数。
+    const ac = new AbortController();
+    const items: Item[] = Array.from({ length: 3 }, (_, i) => ({ id: `i${i}`, text: "x" }));
+    const onErr = vi.fn();
+    const onSkip = vi.fn();
+    const pool = new WorkPool<Item>({
+      items,
+      partition: (its) => its.map((it) => ({ id: it.id, items: [it] })),
+      maxConcurrency: 1, // 串行:只有 g0 启动
+      workerFactory: async (g) => {
+        if (g.id === "i0") {
+          ac.abort(); // g0 跑时 abort:其失败收尾后 loop 退出,g1/g2 不启动
+          throw new Error("boom");
+        }
+        const model = createFakeModel([{ content: [{ type: "text", text: "ok" }] }]);
+        return { session: new AgentSession({ model, tools: [] }), prompt: "x" };
+      },
+      onGroupError: onErr,
+      onGroupSkipped: onSkip,
+    });
+    const res = await pool.start(ac.signal);
+    expect(res.failedGroups).toBe(1); // g0 factory 抛错 → failed,不被 sweep 误判成 skipped
+    expect(res.skippedGroups).toBe(2); // g1/g2 从未启动
+    expect(res.completedGroups).toBe(0);
+    expect(res.failedGroups + res.skippedGroups).toBe(3); // 守恒,失败与跳过两类共存
+    expect(onErr).toHaveBeenCalledOnce();
+    expect(onSkip).toHaveBeenCalledTimes(2);
+  });
+
+  it("空 items + 已 abort:直接全零返回,不启动 worker、不误触发 onGroupSkipped", async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const onSkip = vi.fn();
+    const pool = new WorkPool<Item>({
+      items: [],
+      partition: () => [],
+      workerFactory: async () => {
+        throw new Error("should not be called");
+      },
+      onGroupSkipped: onSkip,
+    });
+    const res = await pool.start(ac.signal);
+    expect(res).toMatchObject({
+      totalItems: 0,
+      completedGroups: 0,
+      failedGroups: 0,
+      skippedGroups: 0,
+    });
+    expect(res.groups).toEqual([]);
+    expect(onSkip).not.toHaveBeenCalled();
   });
 
   it("maxConcurrency truly caps concurrent groups", async () => {
@@ -434,6 +569,160 @@ describe("LeaseQueue", () => {
     });
     const res = await queue.start();
     expect(res.conflicted).toBe(1);
+  });
+
+  it("aborted mid-flight: 未派发的 item 必给 skipped 终态(不静默消失)", async () => {
+    // 5 items / 并发 2:abort 时 2 个 in-flight、3 个从未派发。#31 要求残留的 3 个也得终态。
+    const statuses: string[] = [];
+    const items: Item[] = Array.from({ length: 5 }, (_, i) => ({ id: `i${i}` }));
+    const ac = new AbortController();
+    const queue = new LeaseQueue<Item>({
+      items,
+      concurrency: 2,
+      workerFactory: async (item) => {
+        await new Promise<void>((r) => setTimeout(r, 50)); // 让 abort 能在派发后、跑完前触发
+        const model = createFakeModel([{ content: [{ type: "text", text: `d-${item.id}` }] }]);
+        return { session: new AgentSession({ model, tools: [] }), prompt: "go" };
+      },
+      onItemComplete: (_item, status) => statuses.push(status),
+    });
+    setTimeout(() => ac.abort(), 20);
+    const res = await queue.start(ac.signal);
+
+    // 守恒:每个 item 恰一条终态。
+    expect(res.totalItems).toBe(5);
+    expect(res.completed + res.failed + res.conflicted + res.skipped).toBe(5);
+    expect(res.skipped).toBe(3); // 并发 2 先派发 2,剩 3 个从未派发 → skipped
+    expect(statuses).toHaveLength(5); // onItemComplete 为每个 item 触发(含 skipped),无静默消失
+    expect(statuses.filter((s) => s === "skipped")).toHaveLength(3);
+  });
+
+  it("abort × retry 交错(maxAttempts>1):回退重试的 item 与未派发的都给 skipped、各恰一次", async () => {
+    // 钉死「abort 时回退重试的 item 也给终态」这条注释承诺、却最易漏测的路径。
+    // 并发 1 / maxAttempts 3:i0 跑时 abort → 其 run 以 aborted 收尾(reason!=done)→ attempt1<3 → 回退进 pending;
+    // 下一轮 loop 见 aborted 退出 → i0(回退)+ i1/i2(从未派发)都由末尾 sweep finalize 成 skipped。
+    const statuses: string[] = [];
+    const ac = new AbortController();
+    let firstCall = true;
+    const queue = new LeaseQueue<Item>({
+      items: [{ id: "i0" }, { id: "i1" }, { id: "i2" }],
+      concurrency: 1,
+      maxAttempts: 3,
+      workerFactory: async (item) => {
+        if (firstCall) {
+          firstCall = false;
+          ac.abort(); // i0 跑时触发:其 session.run 以 aborted 收尾 → status error → 回退重试
+        }
+        const model = createFakeModel([{ content: [{ type: "text", text: `d-${item.id}` }] }]);
+        return { session: new AgentSession({ model, tools: [] }), prompt: "go" };
+      },
+      onItemComplete: (_item, status) => statuses.push(status),
+    });
+    const res = await queue.start(ac.signal);
+    expect(res.completed + res.failed + res.conflicted + res.skipped).toBe(3); // 守恒
+    expect(res.skipped).toBe(3); // i0(回退)+ i1/i2(未派发)
+    expect(statuses).toHaveLength(3); // 每个 item 恰 finalize 一次,无双计/漏计
+    expect(statuses.every((s) => s === "skipped")).toBe(true);
+  });
+
+  it("pre-aborted signal:全部 item 直接 skipped、不调 workerFactory、onItemComplete 全触发", async () => {
+    const statuses: string[] = [];
+    const ac = new AbortController();
+    ac.abort();
+    const queue = new LeaseQueue<Item>({
+      items: [{ id: "a" }, { id: "b" }],
+      concurrency: 2,
+      workerFactory: async () => {
+        throw new Error("workerFactory must not run under pre-aborted signal");
+      },
+      onItemComplete: (_item, status) => statuses.push(status),
+    });
+    const res = await queue.start(ac.signal);
+    expect(res.completed).toBe(0);
+    expect(res.skipped).toBe(2);
+    expect(statuses).toEqual(["skipped", "skipped"]);
+  });
+
+  it("混合终态:abort 时部分 item 真完成、部分失败、剩余 skipped,三类共存且守恒", async () => {
+    // 钉死非退化守恒(并非全 skipped):并发 1 串行下,i0 正常 done、i1 在跑时 abort 收尾成 error(failed),
+    // i2/i3 从未派发 → sweep skipped。completed≥1 && skipped≥1 同时成立,且四类之和仍 === totalItems。
+    const statuses: LeaseStatus[] = [];
+    const ac = new AbortController();
+    let call = 0;
+    const queue = new LeaseQueue<Item>({
+      items: [{ id: "i0" }, { id: "i1" }, { id: "i2" }, { id: "i3" }],
+      concurrency: 1, // 串行:i0 先跑完,再派 i1
+      maxAttempts: 1, // i1 abort 收尾后不重试 → 直接 error(failed)
+      workerFactory: async (item) => {
+        call++;
+        if (call === 2) ac.abort(); // 第 2 次派发(i1)时 abort:i0 已 done,i1 以 aborted 收尾
+        const model = createFakeModel([{ content: [{ type: "text", text: `d-${item.id}` }] }]);
+        return { session: new AgentSession({ model, tools: [] }), prompt: "go" };
+      },
+      onItemComplete: (_item, status) => statuses.push(status),
+    });
+    const res = await queue.start(ac.signal);
+    expect(res.totalItems).toBe(4);
+    expect(res.completed).toBe(1); // i0
+    expect(res.failed).toBe(1); // i1(abort 收尾,maxAttempts 1 不重试)
+    expect(res.skipped).toBe(2); // i2/i3 从未派发
+    expect(res.completed + res.failed + res.conflicted + res.skipped).toBe(4); // 守恒
+    expect(res.completed).toBeGreaterThanOrEqual(1);
+    expect(res.skipped).toBeGreaterThanOrEqual(1);
+    expect(statuses).toHaveLength(4); // 每个 item 恰 finalize 一次
+    expect(statuses.filter((s) => s === "done")).toHaveLength(1);
+    expect(statuses.filter((s) => s === "skipped")).toHaveLength(2);
+  });
+
+  it("conflict × abort 交错:worker 已 releaseLease('conflict') 的 item 终态是 conflict,不被 sweep 误判 skipped", async () => {
+    // i0 在 worker 内主动 releaseLease('conflict') 并 abort → 其终态应由 worker 裁成 conflict(优先于 sweep);
+    // 未派发的 i1/i2 才进 sweep 成 skipped。验证 conflict 与 skipped 互不串味、守恒成立。
+    const statuses: LeaseStatus[] = [];
+    const ac = new AbortController();
+    const queue = new LeaseQueue<Item>({
+      items: [{ id: "i0" }, { id: "i1" }, { id: "i2" }],
+      concurrency: 1,
+      maxAttempts: 1,
+      workerFactory: async (item, _lease, ctx) => {
+        if (item.id === "i0") {
+          ctx.releaseLease("conflict"); // worker 主动裁定 conflict
+          ac.abort(); // 同时 abort:i1/i2 将从未派发
+        }
+        const model = createFakeModel([{ content: [{ type: "text", text: `d-${item.id}` }] }]);
+        return { session: new AgentSession({ model, tools: [] }), prompt: "go" };
+      },
+      onItemComplete: (_item, status) => statuses.push(status),
+    });
+    const res = await queue.start(ac.signal);
+    expect(res.conflicted).toBe(1); // i0:worker 裁定 conflict 优先,不被末尾 sweep 改写
+    expect(res.skipped).toBe(2); // i1/i2 从未派发
+    expect(res.completed + res.failed + res.conflicted + res.skipped).toBe(3); // 守恒
+    expect(statuses[0]).toBe("conflict"); // i0 由 worker 先 finalize 成 conflict
+    expect(statuses.filter((s) => s === "skipped")).toHaveLength(2);
+  });
+
+  it("空 items + 已 abort:直接全零返回,不调 workerFactory", async () => {
+    // LeaseQueue 此前完全没有空 items 用例。空 + 已 abort 是 sweep 与 workerCount=0 的退化边界。
+    const ac = new AbortController();
+    ac.abort();
+    const onComplete = vi.fn();
+    const queue = new LeaseQueue<Item>({
+      items: [],
+      concurrency: 2,
+      workerFactory: async () => {
+        throw new Error("workerFactory must not run with empty items");
+      },
+      onItemComplete: onComplete,
+    });
+    const res = await queue.start(ac.signal);
+    expect(res).toEqual({
+      totalItems: 0,
+      completed: 0,
+      failed: 0,
+      conflicted: 0,
+      skipped: 0,
+    });
+    expect(onComplete).not.toHaveBeenCalled();
   });
 
   it("throws on bad concurrency", () => {

--- a/packages/plugins/src/controllers/lease-queue.ts
+++ b/packages/plugins/src/controllers/lease-queue.ts
@@ -4,6 +4,10 @@
  * 跟 WorkPool 的区别：动态领单，适合 item 完成时间分布极不均的场景。
  * 失败的 item 可重试（attempt 计数 + maxAttempts 兜底）。
  *
+ * **abort 必给终态**：abort 时正在跑的 item 由内核 abort 收尾，残留(从未派发 / abort 时回退)的 item
+ * 在 `start()` 末尾统一 finalize 成 `skipped` 并触发 `onItemComplete`——保证每个 item 都有终态,
+ * `completed + failed + conflicted + skipped === totalItems`,不让 work item 静默消失。
+ *
  * **并发安全前提**：依赖 Node.js 单线程 event loop——`pending.shift()` / `pending.splice()`
  * 在 await 之间是原子的，K 个 worker 不会竞态。任何修改请保持此契约（shift/splice 跟 length
  * 检查之间禁止插入 await）。
@@ -23,7 +27,7 @@ export interface QueueLease {
   attempt: number;
 }
 
-export type LeaseStatus = "done" | "error" | "conflict";
+export type LeaseStatus = "done" | "error" | "conflict" | "skipped";
 
 export interface LeaseQueueOptions<I extends QueueItem> {
   items: I[];
@@ -52,6 +56,8 @@ export interface LeaseQueueResult {
   completed: number;
   failed: number;
   conflicted: number;
+  /** abort 后从未派发(或 abort 时回退)而被给终态的 item 数。completed+failed+conflicted+skipped === totalItems。 */
+  skipped: number;
 }
 
 const DEFAULT_MAX_ATTEMPTS = 1;
@@ -71,6 +77,21 @@ export class LeaseQueue<I extends QueueItem> {
     let completed = 0;
     let failed = 0;
     let conflicted = 0;
+    let skipped = 0;
+
+    // 单点终态裁决:worker 与下面的 abort 兜底 sweep 共用,保证每个 item 恰被 finalize 一次。
+    const finalize = (
+      item: I,
+      status: LeaseStatus,
+      summary?: RunSummary,
+      error?: Error,
+    ): void => {
+      if (status === "done") completed++;
+      else if (status === "conflict") conflicted++;
+      else if (status === "skipped") skipped++;
+      else failed++;
+      this.opts.onItemComplete?.(item, status, summary, error);
+    };
 
     const workerCount = Math.min(
       this.opts.concurrency,
@@ -79,31 +100,28 @@ export class LeaseQueue<I extends QueueItem> {
     const workers: Promise<void>[] = [];
 
     for (let i = 0; i < workerCount; i++) {
-      const workerId = `worker-${i}`;
       workers.push(
-        this._workerLoop(
-          workerId,
-          pending,
-          attempts,
-          maxAttempts,
-          signal,
-          (item, status, summary, error) => {
-            if (status === "done") completed++;
-            else if (status === "conflict") conflicted++;
-            else failed++;
-            this.opts.onItemComplete?.(item, status, summary, error);
-          },
-        ),
+        this._workerLoop(`worker-${i}`, pending, attempts, maxAttempts, signal, finalize),
       );
     }
 
     await Promise.all(workers);
+
+    // abort 后 pending 里残留的 item(从未派发 + abort 时回退重试的)必须给终态——否则「work item
+    // 无终态、静默消失」,正是新原语要消灭却从旧 controller 旁路回来的问题(#31)。每个 item 至此恰
+    // finalize 一次:派发并跑完的在 worker 里 finalize、未跑完的回退进 pending 在此 sweep,二者互斥。
+    while (pending.length > 0) {
+      const item = pending.shift()!;
+      attempts.delete(item.id);
+      finalize(item, "skipped");
+    }
 
     return {
       totalItems: this.opts.items.length,
       completed,
       failed,
       conflicted,
+      skipped,
     };
   }
 

--- a/packages/plugins/src/controllers/work-pool.ts
+++ b/packages/plugins/src/controllers/work-pool.ts
@@ -4,6 +4,10 @@
  * 跟 LeaseQueue 的区别：WorkPool 把 items 静态分组（如按 heading），每 group
  * 一个 worker 跑完；LeaseQueue 是动态领单制，worker 持 lease 完了领下一题。
  *
+ * **abort 必给终态**：abort 时 in-flight group drain 收尾，未启动的 group 进 `results` 标
+ * `skipped:"aborted"` 并触发 `onGroupSkipped`——每个 group 都有终态,
+ * `completedGroups + failedGroups + skippedGroups === groups 总数`,不静默丢 group。
+ *
  * 详见 docs/06-controllers.md §4。
  */
 
@@ -32,13 +36,18 @@ export interface WorkPoolOptions<I extends WorkItem> {
   onGroupComplete?: (groupId: string, summary: RunSummary) => void;
   /** 单 group 失败回调（factory 抛或 run 抛）。 */
   onGroupError?: (groupId: string, err: Error) => void;
+  /** abort 时未启动的 group 被跳过的回调（与 complete/error 对称,保证每个 group 都有终态信号,不静默消失）。 */
+  onGroupSkipped?: (groupId: string, reason: "aborted") => void;
 }
 
 export interface WorkPoolResult {
-  groups: Array<{ id: string; summary?: RunSummary; error?: Error }>;
+  /** 每个 group 恰一条终态：summary（完成）/ error（失败）/ skipped（abort 时未启动）。 */
+  groups: Array<{ id: string; summary?: RunSummary; error?: Error; skipped?: "aborted" }>;
   totalItems: number;
   completedGroups: number;
   failedGroups: number;
+  /** abort 时未启动而被给终态的 group 数。completed+failed+skipped === groups 总数。 */
+  skippedGroups: number;
 }
 
 export class WorkPool<I extends WorkItem> {
@@ -52,6 +61,7 @@ export class WorkPool<I extends WorkItem> {
         totalItems: this.opts.items.length,
         completedGroups: 0,
         failedGroups: 0,
+        skippedGroups: 0,
       };
     }
 
@@ -65,10 +75,12 @@ export class WorkPool<I extends WorkItem> {
       id: string;
       summary?: RunSummary;
       error?: Error;
+      skipped?: "aborted";
     }> = [];
     const running = new Set<Promise<void>>();
     let completed = 0;
     let failed = 0;
+    let skippedGroups = 0;
 
     const runGroup = (g: WorkGroup<I>): Promise<void> =>
       (async () => {
@@ -106,11 +118,21 @@ export class WorkPool<I extends WorkItem> {
       await Promise.allSettled([...running]);
     }
 
+    // abort 后 queue 里未启动的 group 必须给终态(进 results + 计数 + 回调)——否则它们静默消失,
+    // 调用方按 group 归账时漏项(#31)。每个 group 至此恰一条终态:跑过的在 runGroup 里 push、未启动的在此。
+    while (queue.length > 0) {
+      const g = queue.shift()!;
+      results.push({ id: g.id, skipped: "aborted" });
+      skippedGroups++;
+      this.opts.onGroupSkipped?.(g.id, "aborted");
+    }
+
     return {
       groups: results,
       totalItems: this.opts.items.length,
       completedGroups: completed,
       failedGroups: failed,
+      skippedGroups,
     };
   }
 }


### PR DESCRIPTION
## 问题(#31)

controller abort 时,**未派发 / 回退重试**的 work item / group 会**静默消失**——既不计数、也不回调,调用方按 item 归账时漏项。这正是新原语要消灭、却从旧 controller 旁路回来的问题。

## 修复(根因,非绕过)

**LeaseQueue**(`lease-queue.ts`)
- `LeaseStatus` 加 `"skipped"`;`LeaseQueueResult` 加 `skipped`。
- 终态裁决抽成单点 `finalize`,**worker 与末尾 sweep 共用**:派发并跑完的在 worker 里 finalize、未跑完(从未派发 + abort 时回退)的在 `Promise.all` 后 sweep——二者互斥,每个 item 恰 finalize 一次。
- 守恒:`completed + failed + conflicted + skipped === totalItems`。

**WorkPool**(`work-pool.ts`)
- `WorkPoolResult.groups` 项加 `skipped: "aborted"`,加 `skippedGroups`;新增 `onGroupSkipped` 回调(与 complete/error 对称)。
- drain in-flight 后 sweep 未启动的 queue → 进 results 标 skipped + 计数 + 回调。
- 守恒:`completedGroups + failedGroups + skippedGroups === groups 总数`。

## 测试

`controllers.test.ts` 覆盖:
- **混合终态(非退化守恒)**:abort 时部分真 done / 部分 failed / 剩余 skipped 共存,断言 `completed≥1 && skipped≥1` 且四类之和 === total——证明 sweep 不把已完成项误判成 skipped。
- **conflict × abort 交错**:worker `releaseLease('conflict')` 的 item 终态保持 conflict,不被 sweep 改写。
- **空 items + 已 abort** 退化边界(LeaseQueue/WorkPool)。
- abort × retry 交错、pre-aborted、in-flight drain 等既有用例保留强化。

## 验证

- 全仓 `build` → `typecheck` → `test` 全绿:plugins 233(controllers 27)、coding-agent 240、adapters 61(+18 PG 集成 env-gated)、core 256、tools 51。
- 三审(devkit code-review + test-review + linus)全过:code 8.85 / test 8.3 / linus "Looks reasonable.",无 Critical/blocking。

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>