### PR TITLE
docs: sync design docs to shipped mechanisms (#32)

### DIFF
--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -149,7 +149,7 @@ Hot path 上的 plugin **只允许同步操作或 push-to-queue**。需要持久
 
 详见 [roadmap](roadmap.md)。
 
-当前风险：尚无外部 production 用户；`message_update` / streaming thinking、完整 auto-compaction、PG metrics sink、`ctx.state` hardening 仍是后续工作。
+当前风险：核心机制已实现并有测试覆盖（`message_update` 渐进式 streaming、auto-compaction、PG metrics sink、`ctx.state` slot API 均已落地），但**尚无外部 production 用户**——真 LLM provider 的 streaming/error/overflow smoke、`bidding-agent` 真实迁移 spike 都还没做（成熟度三层详见 [README](../README.md)「当前状态」）。
 
 ## 8. 下一步
 

--- a/docs/06-controllers.md
+++ b/docs/06-controllers.md
@@ -214,44 +214,34 @@ export interface WorkPoolOptions<I extends WorkItem> {
   maxConcurrency?: number;
   /** 单 group 完成时回调（用于 progress UI / metric）。 */
   onGroupComplete?: (groupId: string, summary: RunSummary) => void;
+  /** 单 group 失败（factory 抛或 run 抛）回调。 */
+  onGroupError?: (groupId: string, err: Error) => void;
+  /** abort 时未启动的 group 被跳过的回调（与 complete/error 对称，保证每个 group 都有终态信号）。 */
+  onGroupSkipped?: (groupId: string, reason: "aborted") => void;
 }
 
 export interface WorkPoolResult {
-  groups: Array<{ id: string; summary: RunSummary }>;
+  /** 每个 group 恰一条终态：summary（完成）/ error（失败）/ skipped（abort 时未启动）。 */
+  groups: Array<{ id: string; summary?: RunSummary; error?: Error; skipped?: "aborted" }>;
   totalItems: number;
+  completedGroups: number;
+  failedGroups: number;
+  /** abort 时未启动而被给终态的 group 数。completed+failed+skipped === groups 总数。 */
+  skippedGroups: number;
 }
 
 export class WorkPool<I extends WorkItem> {
   constructor(private opts: WorkPoolOptions<I>) {}
 
   async start(signal?: AbortSignal): Promise<WorkPoolResult> {
-    const groups = this.opts.partition(this.opts.items);
-    const concurrency = this.opts.maxConcurrency ?? groups.length;
-
-    const results: Array<{ id: string; summary: RunSummary }> = [];
-    const queue = [...groups];
-    const running = new Set<Promise<void>>();
-
-    while (queue.length > 0 || running.size > 0) {
-      if (signal?.aborted) break;
-      while (running.size < concurrency && queue.length > 0) {
-        const group = queue.shift()!;
-        const task = this.runGroup(group, signal).then(summary => {
-          results.push({ id: group.id, summary });
-          this.opts.onGroupComplete?.(group.id, summary);
-        });
-        running.add(task);
-        task.finally(() => running.delete(task));
-      }
-      await Promise.race(running);
-    }
-
-    return { groups: results, totalItems: this.opts.items.length };
-  }
-
-  private async runGroup(group: { id: string; items: I[] }, signal?: AbortSignal): Promise<RunSummary> {
-    const { session, prompt } = await this.opts.workerFactory(group);
-    return session.run(prompt, { signal });
+    // 实现要点（已发布）：
+    // 1. partition → groups；queue = [...groups]；running = Set<Promise>。
+    // 2. while (queue 或 running 非空)：abort 则 break；否则把 queue 填到 maxConcurrency 并发跑。
+    //    每个 group：factory → session.run → push {summary} + onGroupComplete；抛错 → push {error} + onGroupError。
+    // 3. **abort 必给终态**：break 后先 allSettled drain 在跑的 worker（否则 caller 拿到不一致快照），
+    //    再 sweep queue 里未启动的 group → push {skipped:"aborted"} + skippedGroups++ + onGroupSkipped。
+    //    每个 group 恰一条终态；守恒：completedGroups + failedGroups + skippedGroups === groups 总数。
+    // ……见 packages/plugins/src/controllers/work-pool.ts。
   }
 }
 ```
@@ -366,30 +356,35 @@ export interface LeaseQueueOptions<I extends QueueItem> {
 }
 
 export interface LeaseQueueResult {
+  totalItems: number;
   completed: number;
   failed: number;
-  totalItems: number;
+  conflicted: number;
+  /** abort 后从未派发（或 abort 时回退）而被给终态的 item 数。 */
+  skipped: number;
 }
 
 export class LeaseQueue<I extends QueueItem> {
   constructor(private opts: LeaseQueueOptions<I>) {}
 
   async start(signal?: AbortSignal): Promise<LeaseQueueResult> {
-    // 实现要点：
-    // 1. pending queue + leases map
-    // 2. K 个 worker promise 并发
-    // 3. 每个 worker: while (queue 非空 && !signal.aborted)
-    //      lease = leaseNext()
+    // 实现要点（已发布）：
+    // 1. pending queue（单线程 event loop 下 shift/splice 在 await 之间原子，K worker 不竞态）
+    // 2. K 个 worker promise 并发：while (pending 非空 && !signal.aborted)
+    //      lease = 取队首 + attempts 计数
     //      session = factory(item, lease, { releaseLease })
-    //      summary = await session.run(prompt)
-    //      根据 summary + plugin 调用 releaseLease 的情况决定计数
-    // 4. 全部 worker exit → 返回汇总
-    throw new Error("TODO");
+    //      summary = await session.run(prompt, { signal })
+    //      status = releaseLease 优先；否则 summary.reason==="done" → done / 其余 → error
+    //      非 done 且 attempt < maxAttempts → 回退队尾重试；否则 finalize（单点裁决）
+    // 3. **abort 必给终态**：全部 worker exit 后，sweep pending 里残留的 item（从未派发 + abort
+    //    时回退的）统一 finalize 成 "skipped" —— 每个 item 恰 finalize 一次（worker 与 sweep 互斥）。
+    //    守恒：completed + failed + conflicted + skipped === totalItems，work item 不静默消失。
+    // ……见 packages/plugins/src/controllers/lease-queue.ts。
   }
 }
 ```
 
-完整实现参考 bidding-agent `question-pool.ts`（326 行）。
+完整实现见 `packages/plugins/src/controllers/lease-queue.ts`（abort 必给终态 + 守恒，已被 `controllers.test.ts` 的混合终态/守恒用例覆盖）。
 
 ### 5.5 跟 plugin 配合用法
 

--- a/docs/09-bidding-core-parity-design.md
+++ b/docs/09-bidding-core-parity-design.md
@@ -266,7 +266,7 @@ roadmap 已列 `sideQuestion` controller + `subAgent` tool factory。给 Hybrid 
 - ✅ #6 overflow 事件（`onContextOverflow`）+ #10 `compactRestartFresh`
 - ✅ #5 steering（`AgentSession.steer()` + `onSteer`，turn-start drain）
 - ✅ #7 fail-closed 分类 + #9 `permissionGate`（规则引擎骨架，domain 谓词由调用方给）
-- 🟡 #4 `PostgresSessionStore` ✅ ；**lifecycleRestart 从 store resume ⬜**（`AgentSession.resume()` 原语在，但没有 controller 把它接进「重启即续跑」流程——是 harness-pi 这边唯一未接的机制 glue）
+- ✅ #4 `PostgresSessionStore` ＋ **lifecycleRestart 从 store resume**（`LifecycleRestart` 的 `resume` 模式：每次（重）启走 `AgentSession.resume(store, sessionId, deps)` 从落盘历史续跑——「重启即续跑」已接通，与内存 `sessionFactory` 模式二选一）
 - ✅ #9 杂项：ctx.state slot API（TypedStateMap）、around-hook 超时（结论：不加内核机制，协作式 abort）、去 `questionId` domain 默认（lease-decision argField 必填）
 
 **Phase 3 — Hybrid 闭环**


### PR DESCRIPTION
## 问题(#32,doc drift,P3)

设计文档落后于已发布代码,出现"文档撒谎"的漂移点。

## 修复(逐条核对源码后据实改写)

- **docs/09**:`lifecycleRestart 从 store resume ⬜ → ✅`——`LifecycleRestart` 的 `resume` 模式已落地(`lifecycle-restart.ts:78-87/121-128` 走 `AgentSession.resume(store, sessionId, deps)`,重启即从落盘历史续跑,与内存 `sessionFactory` 二选一)。
- **docs/00**:把 `message_update` 渐进式 streaming、auto-compaction、PG metrics sink、`ctx.state` slot API 从「后续工作」移出(均已实现+测试);剩余风险据实改为「尚无外部 production 用户;真 provider smoke + bidding 迁移 spike 未做」,指向 README 成熟度三层。
- **docs/06**:LeaseQueue/WorkPool 伪代码去掉 `throw new Error("TODO")` 桩;`LeaseQueueResult` 补 `conflicted`/`skipped`,`WorkPoolResult` 补 `completedGroups`/`failedGroups`/`skippedGroups` 及 `onGroupError`/`onGroupSkipped`;`start()` 注释反映已发布的「abort 必给终态 + 守恒」(#31);过时的「参考 bidding-agent question-pool.ts」改指 `packages/plugins/src/controllers/`。

## 验证

纯文档,无代码/测试改动。文档同步审核(逐条把每个论断对照已发布源码核验 + linus)双闸全过:准确性 17/17 claim 一致、零 inaccuracy;linus "Looks reasonable.",无 blocking。

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>