### PR TITLE
feat(core): LLM seam — makeOpenAICompatibleModel + typed LlmOptions (#38, #39)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,17 +10,25 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - **L1 `@earendil-works/pi-ai`**:统一 LLM API + tool spec + event stream。我们是它的**消费者,不动它一行**。
 - **L2 `@harness-pi/core`**:自己写的 agent 内核。**故意不基于 `pi-agent-core`**——换来 **hook 作为一等公民**。
-- **L3 `@harness-pi/plugins` / `/adapters` / `/tools`** + app `@harness-pi/coding-agent`。
+- **L3 `@harness-pi/plugins` / `/adapters` / `/tools`** + apps `@harness-pi/coding-agent`（CLI dogfood）、`@harness-pi/lark-bot`（飞书机器人，多轮 LRU session cache）。
 
 不是 `pi-coding-agent` 的 fork(那是终端 UX 扩展);方向是服务端 agent 运行时。详见 `docs/00-overview.md`、`docs/01-architecture.md`。
+
+> **L1 不变量「不动它一行」仍然成立,但允许「在消费面之上收口」。** `@harness-pi/core` 可提供薄 DX seam——把自定义 Model 构造与 provider options 的人体工学集中到内核一侧,而**完全不碰 pi-ai 源码**:
+> - `makeOpenAICompatibleModel(spec)`(`packages/core/src/llm-model.ts`):造 OpenAI-compatible 自定义 Model,**零 `as Model` cast、无 `cost:{0,0,0,0}` 占位**(返回窄类型 `Model<"openai-completions">` 让条件 `compat` 字段正确解析)。
+> - `LlmOptions` + `resolveLlmOptions()`:`AgentSessionOptions.llmOptions` 的 typed 形态(`Omit<StreamOptions,"signal"> & { providerExtras }`),`{apikey}` typo 编译期失败;provider 专属键走 `providerExtras` 逃生口。
+>
+> 这是「在咽喉点封装上游公共面」,不是改 L1。下游(coding-agent / engram / bidding-agent)应从 `@harness-pi/core` 拿这两个,**别直接 import `@earendil-works/pi-ai`**——seam 是单一咽喉点,上游 churn `Model` 类型时只动 `llm-model.ts` + `index.ts` re-export。
+>
+> **若将来真需改 L1 行为**,升级阶梯是:`pnpm patch`(软 fork,留在 version train、自动重应用;但 tarball 只发 `dist`,只能 patch 编译产物)→ 硬 fork+vendor(仅当 patch 做不到且需跨多 release 持续,如未用 provider SDK 瘦身)作最终储备。上游(`github.com/earendil-works/pi-mono`, MIT)当前健康,fork 期权永不过期,**现在不 fork**。
 
 ## 架构大图(读多个文件才能拼出的部分)
 
 **内核极简 + 一切皆 hook。** `@harness-pi/core` 只做两件事:跑 pi-ai 的 LLM-tool 循环 + 派发 hook。**无** metric / watchdog / pool / DB / frontend——这些全是 `@harness-pi/plugins` 里的 hook 实例。改内核前先问:这能不能做成 hook?
 
 **三个概念别混(`docs/05/06/07`):**
-- **Plugin**:钩 loop 事件的装饰器(watchdog / metrics / trimHistory / toolOutputBuffer / sessionLog / emptyRunGuard / repeatedCallGuard / costTracker / autoCompaction / compactSummarize / permissionGate)。
-- **Controller**:编排一/多个 session(workPool、lifecycleRestart、forkSession)。
+- **Plugin**:钩 loop 事件的装饰器(watchdog / metrics / trimHistory / toolOutputBuffer / sessionLog / emptyRunGuard / repeatedCallGuard / costTracker / autoCompaction / compactSummarize / permissionGate / tokenBudget / systemReminder / batchCounter / leaseDecision / toolStats)。
+- **Controller**:编排一/多个 session(workPool / lifecycleRestart / forkSession / leaseQueue / parallel / pipeline / compactOnOverflow / compactRestartFresh / gapExplorer / subAgentTool)。
 - **Adapter**:plugin 的 I/O 后端(metric sink、log sink、`SessionStore`)。**走接口 + peerDep,不强加具体 driver**;自定义 metric kind 用 TS module augmentation,不改内核。
 
 **`AgentSession`(`packages/core/src/session.ts`,本仓库最重的文件)**:`run`/`continue` → turn loop →三段式 phase(`_phaseLlmCall` → `_phaseToolBatch` → `_phaseTurnEnd`)。几个**必须知道、否则会改错**的不变量:

--- a/apps/coding-agent/src/agent.ts
+++ b/apps/coding-agent/src/agent.ts
@@ -4,6 +4,7 @@ import {
   type Api,
   type HarnessTool,
   type Hook,
+  type LlmOptions,
   type Model,
   type RunSummary,
   type SessionEvent,
@@ -72,7 +73,7 @@ export interface CreateCodingAgentOptions {
   metricsFile?: string;
   systemPrompt?: string;
   toolsOptions?: ToolsOptions;
-  llmOptions?: Record<string, unknown>;
+  llmOptions?: LlmOptions;
   maxTurns?: number;
   costModel?: CostTrackerOptions["costModel"];
   /**
@@ -141,7 +142,7 @@ export interface RunAgentPromptOptions {
 
 export interface ResolvedModelRuntime {
   model: Model<Api>;
-  llmOptions?: Record<string, unknown>;
+  llmOptions?: LlmOptions;
 }
 
 const DEFAULT_SYSTEM_PROMPT = [
@@ -596,7 +597,7 @@ function cloneToolStats(stats: ToolStats): ToolStats {
 
 function createDashScopeCostAccumulator(
   model: Model<Api>,
-  llmOptions: Record<string, unknown> | undefined,
+  llmOptions: LlmOptions | undefined,
 ):
   | {
       hook: Hook;
@@ -607,7 +608,9 @@ function createDashScopeCostAccumulator(
 
   let total = 0;
   let source: string | undefined;
-  const thinking = typeof llmOptions?.["reasoningEffort"] === "string";
+  // reasoningEffort 是 openai-completions 的 provider 专属选项，经 LlmOptions.providerExtras 透传。
+  const thinking =
+    typeof llmOptions?.providerExtras?.["reasoningEffort"] === "string";
   return {
     hook: {
       name: "dashscope-cost-estimator",

--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -116,7 +116,7 @@ function assistantText(msg: { content: unknown } | undefined): string {
 export function makeReadOnlySubAgentSpawner(
   cwd: string,
   model: ReturnType<typeof resolveModelRuntime>["model"],
-  llmOptions: Record<string, unknown> | undefined,
+  llmOptions: ReturnType<typeof resolveModelRuntime>["llmOptions"],
 ): (task: string, signal: AbortSignal) => Promise<{ ok: boolean; text: string }> {
   return async (task, signal) => {
     const subOpts: Parameters<typeof createCodingAgent>[0] = {

--- a/apps/coding-agent/src/compaction.ts
+++ b/apps/coding-agent/src/compaction.ts
@@ -6,10 +6,16 @@
  * `summarize(earlyMessages) => string`，用 pi-ai 的 complete() 跑一次无工具的总结调用。
  */
 
-import { complete, type Context } from "@earendil-works/pi-ai";
+import {
+  complete,
+  type Context,
+  type ProviderStreamOptions,
+} from "@earendil-works/pi-ai";
 import {
   createUserMessage,
+  resolveLlmOptions,
   type Api,
+  type LlmOptions,
   type Message,
   type Model,
 } from "@harness-pi/core";
@@ -47,7 +53,7 @@ function assistantText(message: { content: Message["content"] }): string {
  */
 export function createModelSummarizer(
   model: Model<Api>,
-  llmOptions?: Record<string, unknown>,
+  llmOptions?: LlmOptions,
 ): (earlyMessages: Message[], signal?: AbortSignal) => Promise<string> {
   return async (earlyMessages, signal) => {
     const context: Context = {
@@ -55,7 +61,7 @@ export function createModelSummarizer(
       tools: [],
       systemPrompt: SUMMARY_SYSTEM,
     };
-    const options: Record<string, unknown> = { ...llmOptions };
+    const options: ProviderStreamOptions = resolveLlmOptions(llmOptions);
     if (signal) options.signal = signal;
     const result = await complete(model, context, options);
     const text = assistantText(result);

--- a/apps/coding-agent/src/providers/dashscope.ts
+++ b/apps/coding-agent/src/providers/dashscope.ts
@@ -1,4 +1,5 @@
-import type { Api, Model, Usage } from "@harness-pi/core";
+import { makeOpenAICompatibleModel } from "@harness-pi/core";
+import type { Api, LlmOptions, Model, Usage } from "@harness-pi/core";
 
 export interface DashScopeEnv {
   DASHSCOPE_API_KEY?: string | undefined;
@@ -7,7 +8,7 @@ export interface DashScopeEnv {
 
 export interface DashScopeResolvedModelRuntime {
   model: Model<Api>;
-  llmOptions: Record<string, unknown>;
+  llmOptions: LlmOptions;
 }
 
 export interface DashScopePricingTier {
@@ -244,17 +245,15 @@ export function resolveDashScopeModel(
 
   const metadata = getDashScopeModelMetadata(modelId);
   return {
-    model: {
+    // pi-ai Model.cost is USD per million tokens; DashScope docs publish CNY, so cost stays at the
+    // factory's zero default and CNY estimation is kept in this adapter (createDashScopeCostAccumulator).
+    model: makeOpenAICompatibleModel({
       id: modelId,
       name: `DashScope ${modelId}`,
-      api: "openai-completions",
       provider: "dashscope",
       baseUrl: DASHSCOPE_BASE_URL,
       reasoning: metadata.reasoning,
       input: metadata.input,
-      // pi-ai Model.cost is USD per million tokens. DashScope docs publish CNY;
-      // CNY estimation is kept in this adapter so the shared USD report stays honest.
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       contextWindow: metadata.contextWindow,
       maxTokens: metadata.maxTokens,
       compat: {
@@ -266,7 +265,7 @@ export function resolveDashScopeModel(
         thinkingFormat: "qwen",
         supportsStrictMode: false,
       },
-    } satisfies Model<"openai-completions">,
+    }),
     llmOptions: { apiKey },
   };
 }

--- a/apps/lark-bot/package.json
+++ b/apps/lark-bot/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@harness-pi/lark-bot",
   "version": "0.1.0",
+  "private": true,
   "description": "Feishu/Lark personal Agent-OS bot built on the harness-pi kernel (deepseek-v4-flash brain, lark-cli toolbelt)",
   "license": "MIT",
   "repository": {

--- a/packages/core/src/__tests__/llm-model.test.ts
+++ b/packages/core/src/__tests__/llm-model.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  makeOpenAICompatibleModel,
+  resolveLlmOptions,
+  type Model,
+  type Api,
+} from "../index.js";
+
+describe("makeOpenAICompatibleModel (#38)", () => {
+  it("builds a valid openai-completions Model with sane defaults — no cast, no cost placeholder", () => {
+    const model = makeOpenAICompatibleModel({
+      id: "qwen-plus",
+      baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      provider: "dashscope",
+      contextWindow: 131072,
+      maxTokens: 8192,
+    });
+
+    expect(model.api).toBe("openai-completions");
+    expect(model.id).toBe("qwen-plus");
+    expect(model.provider).toBe("dashscope");
+    expect(model.name).toBe("dashscope qwen-plus");
+    expect(model.reasoning).toBe(false);
+    expect(model.input).toEqual(["text"]);
+    expect(model.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+    // compat 未传 → 省略，交给 pi-ai 按 baseUrl 自动探测。
+    expect(model.compat).toBeUndefined();
+
+    // 关键:返回值隐式 widen 到 Model<Api> 无需 cast(编译能过即证明 #38 的 cast 已消除)。
+    const widened: Model<Api> = model;
+    expect(widened.api).toBe("openai-completions");
+  });
+
+  it("defaults provider to the baseUrl hostname when omitted", () => {
+    const model = makeOpenAICompatibleModel({
+      id: "local-model",
+      baseUrl: "http://localhost:8000/v1",
+      contextWindow: 8192,
+      maxTokens: 2048,
+    });
+    expect(model.provider).toBe("localhost");
+    expect(model.name).toBe("localhost local-model");
+  });
+
+  it("passes explicit cost and compat through when given", () => {
+    const model = makeOpenAICompatibleModel({
+      id: "qwen-plus",
+      baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      provider: "dashscope",
+      reasoning: true,
+      contextWindow: 131072,
+      maxTokens: 8192,
+      cost: { input: 1, output: 2, cacheRead: 0.2, cacheWrite: 0 },
+      compat: { thinkingFormat: "qwen", maxTokensField: "max_tokens" },
+    });
+    expect(model.reasoning).toBe(true);
+    expect(model.cost.input).toBe(1);
+    expect(model.compat?.thinkingFormat).toBe("qwen");
+    expect(model.compat?.maxTokensField).toBe("max_tokens");
+  });
+
+  it("throws fail-loud on a malformed baseUrl when provider is derived", () => {
+    expect(() =>
+      makeOpenAICompatibleModel({
+        id: "x",
+        baseUrl: "not-a-url",
+        contextWindow: 1,
+        maxTokens: 1,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("resolveLlmOptions (#39)", () => {
+  it("returns empty object for undefined", () => {
+    expect(resolveLlmOptions(undefined)).toEqual({});
+  });
+
+  it("flattens providerExtras back to the top level for pi-ai", () => {
+    const resolved = resolveLlmOptions({
+      apiKey: "sk-test",
+      temperature: 0.2,
+      providerExtras: { reasoningEffort: "high" },
+    });
+    expect(resolved.apiKey).toBe("sk-test");
+    expect(resolved.temperature).toBe(0.2);
+    expect((resolved as Record<string, unknown>).reasoningEffort).toBe("high");
+    // providerExtras 本身不应作为一个键泄漏到 pi-ai 选项里。
+    expect((resolved as Record<string, unknown>).providerExtras).toBeUndefined();
+  });
+});

--- a/packages/core/src/__tests__/llm-options.test.ts
+++ b/packages/core/src/__tests__/llm-options.test.ts
@@ -74,8 +74,9 @@ describe("AgentSession llmOptions", () => {
         tools: [],
         llmOptions: {
           temperature: 0.2,
-          customOption: "kept",
-          signal: callerSignal,
+          // provider 专属 / 非 StreamOptions 键走 providerExtras 逃生口；摊平后回到顶层透传。
+          // signal 经 providerExtras「偷传」也应被 kernel 覆盖（文档承诺的不变量）。
+          providerExtras: { customOption: "kept", signal: callerSignal },
         },
       });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,6 +67,10 @@ export type {
   LiveEvent,
 } from "./session.js";
 
+// ─────────── LLM seam（自定义 Model 构造 + typed llmOptions，收口 pi-ai 公共面） ───────────
+export { makeOpenAICompatibleModel, resolveLlmOptions } from "./llm-model.js";
+export type { OpenAICompatibleModelSpec, LlmOptions } from "./llm-model.js";
+
 // ─────────── HookContextImpl 实例类型（plugin / controller 偶尔需要） ───────────
 export type { HookContextImpl, HookContextDeps } from "./context.js";
 // 注意：getKernelInternals / KERNEL_INTERNALS_BAG 故意不导出——它们是 kernel-internal API。
@@ -85,6 +89,7 @@ export type {
   Usage,
   StopReason,
   Context,
+  OpenAICompletionsCompat,
 } from "@earendil-works/pi-ai";
 export { Type } from "@earendil-works/pi-ai";
 export type { Static, TSchema } from "@earendil-works/pi-ai";

--- a/packages/core/src/llm-model.ts
+++ b/packages/core/src/llm-model.ts
@@ -1,0 +1,143 @@
+/**
+ * LLM seam：在 pi-ai 公共面**之上**收口两个人体工学缺口，让消费者(engram / bidding-agent /
+ * coding-agent)无需直接 import `@earendil-works/pi-ai`、也无需手写 Model 字面量或裸 `Record` options。
+ *
+ * 这层**不改 pi-ai 一行**(架构不变量 L1 仍成立)——只是在内核侧把「自定义 Model 构造」与「provider
+ * options 类型」集中到一个咽喉点。pi-ai 将来 churn `Model` 类型时只动本文件 + index re-export。
+ *
+ * 解决两个 issue：
+ *   #38 `makeOpenAICompatibleModel()`：自定义 OpenAI-compatible model 不再需要手写字面量 + `as Model` cast +
+ *       无意义的 `cost:{0,0,0,0}` 占位。
+ *   #39 `LlmOptions`：把 `AgentSessionOptions.llmOptions` 从 `Record<string,unknown>` 收紧成 typed shape，
+ *       `{apikey}` 这类 typo 在编译期失败；真·provider 私有键走具名 `providerExtras` 逃生口。
+ */
+
+import type {
+  Model,
+  StreamOptions,
+  ProviderStreamOptions,
+  OpenAICompletionsCompat,
+} from "@earendil-works/pi-ai";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #39 — typed llmOptions
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 透传给 pi-ai `stream()`/`complete()` 的跨-provider 选项，typed 版。
+ *
+ * 锚定 pi-ai 已导出的 `StreamOptions`(apiKey / temperature / maxTokens / headers / timeoutMs /
+ * maxRetries / metadata / …)，这是**所有 provider 共有**的基底。两处偏离：
+ *
+ * - **去掉 `signal`**：它是 kernel 保留字段(session 用自己的 AbortSignal)，传了也会被覆盖。
+ *   Omit 让「传 signal」直接变编译错误，把保留语义写进类型而不是注释。
+ * - **加具名 `providerExtras`**：pi-ai 的 provider 专属选项(如 openai-completions 的 `reasoningEffort`、
+ *   anthropic 的 thinking 配置)不在公共 `StreamOptions` 里。它们走这个**显式逃生口**，而不是把整个对象
+ *   放松成 `Record<string,unknown>`——后者会顺带丢掉 `{apikey}` 的 typo 检查(#39 的核心诉求)。
+ *
+ * 注意 `baseUrl` **不在这里**——它是 Model 的字段(见 {@link makeOpenAICompatibleModel})，不是 per-call option。
+ */
+export type LlmOptions = Omit<StreamOptions, "signal"> & {
+  /**
+   * Provider 专属、不在公共 `StreamOptions` 里的选项(如 openai-completions 的 `reasoningEffort`)。
+   * 原样 spread 到顶层透传。
+   *
+   * **优先级**:`resolveLlmOptions` 把 providerExtras 在 typed 字段**之后** spread(`{...rest, ...providerExtras}`),
+   * 故同名键以 providerExtras 为准——这是有意的逃生口语义(能覆盖任何 typed 字段)。`signal` 例外:始终被
+   * kernel 的 AbortSignal 覆盖。别把已 typed 的键(如 `apiKey`)塞进 providerExtras——那会绕过 #39 的 typo 检查。
+   */
+  providerExtras?: Record<string, unknown>;
+};
+
+/**
+ * 把 {@link LlmOptions} 摊平成 pi-ai `stream()`/`complete()` 实际吃的 `ProviderStreamOptions`：
+ * 把 `providerExtras` spread 回顶层。**不**注入 signal —— 调用方(kernel / compaction)各自负责。
+ *
+ * kernel(session.ts)与 coding-agent 的 compaction 都直连 pi-ai，复用同一份摊平逻辑避免漂移。
+ */
+export function resolveLlmOptions(
+  opts: LlmOptions | undefined,
+): ProviderStreamOptions {
+  if (!opts) return {};
+  const { providerExtras, ...rest } = opts;
+  return { ...rest, ...providerExtras };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #38 — custom OpenAI-compatible Model 工厂
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 构造一个 OpenAI-compatible(`api: "openai-completions"`)自定义 Model 的输入。
+ * 覆盖 DashScope/Qwen、Moonshot、本地 vLLM、任意 OpenAI 兼容端点。
+ */
+export interface OpenAICompatibleModelSpec {
+  /** Provider 侧的 model id，如 `"qwen-plus"`。 */
+  id: string;
+  /** OpenAI 兼容端点 baseUrl，如 `"https://dashscope.aliyuncs.com/compatible-mode/v1"`。 */
+  baseUrl: string;
+  /** Provider 名(影响 cost 归类 / 展示)。默认取 `baseUrl` 的 hostname。 */
+  provider?: string;
+  /** 展示名。默认 `${provider} ${id}`。 */
+  name?: string;
+  /** 模型是否支持 reasoning/thinking。默认 `false`。 */
+  reasoning?: boolean;
+  /** 输入模态。默认 `["text"]`。 */
+  input?: ("text" | "image")[];
+  /** 上下文窗口 token 数。 */
+  contextWindow: number;
+  /** 单次输出 token 上限。 */
+  maxTokens: number;
+  /**
+   * 价格(USD per million tokens)。默认 `{0,0,0,0}`——自定义 model 通常拿不到官方 USD 价，
+   * 零默认让调用点不必再写无意义占位。若 cost-budget 要精确,显式传。
+   */
+  cost?: { input: number; output: number; cacheRead: number; cacheWrite: number };
+  /**
+   * OpenAI-compatible 兼容性覆盖。**不传则整个省略**，交给 pi-ai 按 baseUrl 自动探测——
+   * 别硬塞默认值，否则对非目标端点(如把 qwen 的 `thinkingFormat` 套到别的 provider)反而是错的。
+   */
+  compat?: OpenAICompletionsCompat;
+}
+
+/** 默认 provider 名：取 baseUrl 的 hostname。baseUrl 非法 URL 会 throw(fail-loud，早于跑模型)。 */
+function providerFromBaseUrl(baseUrl: string): string {
+  return new URL(baseUrl).hostname;
+}
+
+/**
+ * 造一个 OpenAI-compatible 自定义 Model —— **零 `as Model` cast、无 `cost:{0,0,0,0}` 占位**。
+ *
+ * cast 能消除的关键：返回类型标注成**具体 api 字面量** `Model<"openai-completions">`，pi-ai 的条件字段
+ * `compat?: TApi extends "openai-completions" ? OpenAICompletionsCompat : …`(types.d.ts)对窄字面量正确解析为
+ * `OpenAICompletionsCompat`(而非宽联合 `Model<Api>` 下塌成的 `never`)。返回值可隐式 widen 到 `Model<Api>` 供下游用。
+ *
+ * @example
+ * const model = makeOpenAICompatibleModel({
+ *   id: "qwen-plus",
+ *   baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+ *   provider: "dashscope",
+ *   contextWindow: 131072,
+ *   maxTokens: 8192,
+ * });
+ * new AgentSession({ model, tools, llmOptions: { apiKey } });
+ */
+export function makeOpenAICompatibleModel(
+  spec: OpenAICompatibleModelSpec,
+): Model<"openai-completions"> {
+  const provider = spec.provider ?? providerFromBaseUrl(spec.baseUrl);
+  return {
+    id: spec.id,
+    name: spec.name ?? `${provider} ${spec.id}`,
+    api: "openai-completions",
+    provider,
+    baseUrl: spec.baseUrl,
+    reasoning: spec.reasoning ?? false,
+    input: spec.input ?? ["text"],
+    cost: spec.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: spec.contextWindow,
+    maxTokens: spec.maxTokens,
+    // compat 未给则省略 → pi-ai 按 baseUrl 自动探测(exactOptionalPropertyTypes 下不能写 compat:undefined)。
+    ...(spec.compat ? { compat: spec.compat } : {}),
+  };
+}

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -118,6 +118,8 @@ import { createAttachmentMessage } from "./types.js";
 import type { HarnessTool } from "./types.js";
 import type { SessionStore } from "./session-store.js";
 import { defaultIsContextOverflow } from "./context-overflow.js";
+import { resolveLlmOptions } from "./llm-model.js";
+import type { LlmOptions } from "./llm-model.js";
 import { randomUUID } from "node:crypto";
 
 export interface AgentSessionOptions {
@@ -153,10 +155,12 @@ export interface AgentSessionOptions {
    */
   resumedMessageCount?: number;
   /**
-   * 透传给 pi-ai complete() 的 provider options。
-   * `signal` 是 kernel 保留字段：即使传入也会被当前 session 的 AbortSignal 覆盖。
+   * 透传给 pi-ai stream()/complete() 的 provider options（typed，见 {@link LlmOptions}）。
+   * 公共字段（apiKey / temperature / headers / …）类型化，`{apikey}` 这类 typo 编译期失败；
+   * provider 专属键走 `providerExtras` 逃生口。`signal` 是 kernel 保留字段，已从类型 Omit 掉
+   * （即使经 `providerExtras` 偷传也会被当前 session 的 AbortSignal 覆盖）。
    */
-  llmOptions?: Record<string, unknown>;
+  llmOptions?: LlmOptions;
   /** Hook 失败上报通道（metrics plugin 通常 hook 进来）。 */
   hookFailureSink?: HookFailureSink;
   /**
@@ -248,7 +252,7 @@ export class AgentSession {
   readonly systemPrompt: string;
   readonly maxTurns: number;
   readonly maxContinuations: number;
-  private readonly _llmOptions: Record<string, unknown>;
+  private readonly _llmOptions: LlmOptions;
 
   private _messages: Message[];
   private _hooks: Hook[];
@@ -1219,7 +1223,7 @@ export class AgentSession {
       // stream() 而非 complete()：complete() 内部就是 stream().result()，两者结果完全等价，
       // 但 stream 让我们在回合进行中把 delta 作为 live 事件发出（Event Bus）。
       const s = stream(this.model, context, {
-        ...this._llmOptions,
+        ...resolveLlmOptions(this._llmOptions),
         signal: this._abortCtrl.signal,
       });
       for await (const ev of s) {


### PR DESCRIPTION
在 `@earendil-works/pi-ai` 公共面**之上**加一层薄 DX seam(**不改 pi-ai 一行**,L1 不变量「不动它一行」仍成立),收口两个 v0.2.0 消费者人体工学缺口。

## #38 — `makeOpenAICompatibleModel(spec)`
造 OpenAI-compatible 自定义 Model(DashScope/Qwen、Moonshot、本地 vLLM…):
- 返回窄类型 `Model<"openai-completions">` → **消除强制 `as Model` cast**(条件 `compat` 字段对窄字面量正确解析,而非宽联合下塌成 `never`)。
- `cost` 可选、零默认 → 去掉无意义的 `{0,0,0,0}` 占位。
- `compat` 不传则**省略**,交给 pi-ai 按 baseUrl 自动探测(不硬塞默认值)。

## #39 — typed `LlmOptions`
`AgentSessionOptions.llmOptions` 从裸 `Record<string,unknown>` 收紧为 `Omit<StreamOptions,"signal"> & { providerExtras }`:
- `{apikey}` 这类 typo **编译期失败**。
- `signal` 从类型 Omit(kernel 保留,始终被覆盖)。
- provider 专属键(如 openai-completions 的 `reasoningEffort`)走具名 `providerExtras` 逃生口。
- `resolveLlmOptions()` 把它摊平回 `ProviderStreamOptions`,供 kernel(`session.ts`)与 coding-agent compaction 复用。

## 改动
- 新增 `packages/core/src/llm-model.ts`,经 `index.ts` 导出(含 `OpenAICompletionsCompat` re-export)。
- `session.ts`:`llmOptions` 类型 + `stream()` 转发改用 `resolveLlmOptions`。
- coding-agent 采纳 seam:`dashscope.ts` 用工厂重构(去 cost 占位);`agent`/`cli`/`compaction` 内部 `Record` 串接换成 `LlmOptions`;`reasoningEffort` 读取归 `providerExtras`。
- 测试:新增 `llm-model.test.ts`;更新 `llm-options.test.ts`。
- `CLAUDE.md`:seam 脚注 + `seam → pnpm patch → 硬 fork` 升级阶梯。

## 验证
全仓 build → typecheck → test 全绿:core 262 / coding-agent 240 / plugins 233 / adapters 61(+18 PG skip)/ tools 51 / examples 3。

3-gate review(code-review / test-review / linus-review)对 seam 本身一致判**干净**(*"genuine taste — real cast/placeholder removal, invariant encoded in types, no logic drift, honest docs"*);唯一 in-scope nit(`providerExtras` 覆盖优先级)已补 JSDoc。

Closes #38, #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)