### PR TITLE
release: dev → main — LLM seam (#38/#39) + lark-bot + #29/#30/#31 fixes + pi-ai migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ dist/
 
 # coding-agent runtime output (session logs, persisted sessions, metrics)
 .harness-pi/
+
+# 研究产物(放 ~/Dev/coding/reports 或本地;不入源码库,避免 git add -A 误扫)
+reports/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 `harness-pi` 是一个把 pi-ai agent 跑成**后端服务/批处理 worker** 的最小运行时 harness(pnpm + TypeScript monorepo)。三层定位:
 
-- **L1 `@mariozechner/pi-ai`**:统一 LLM API + tool spec + event stream。我们是它的**消费者,不动它一行**。
+- **L1 `@earendil-works/pi-ai`**:统一 LLM API + tool spec + event stream。我们是它的**消费者,不动它一行**。
 - **L2 `@harness-pi/core`**:自己写的 agent 内核。**故意不基于 `pi-agent-core`**——换来 **hook 作为一等公民**。
 - **L3 `@harness-pi/plugins` / `/adapters` / `/tools`** + app `@harness-pi/coding-agent`。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,17 +10,25 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - **L1 `@earendil-works/pi-ai`**:统一 LLM API + tool spec + event stream。我们是它的**消费者,不动它一行**。
 - **L2 `@harness-pi/core`**:自己写的 agent 内核。**故意不基于 `pi-agent-core`**——换来 **hook 作为一等公民**。
-- **L3 `@harness-pi/plugins` / `/adapters` / `/tools`** + app `@harness-pi/coding-agent`。
+- **L3 `@harness-pi/plugins` / `/adapters` / `/tools`** + apps `@harness-pi/coding-agent`（CLI dogfood）、`@harness-pi/lark-bot`（飞书机器人，多轮 LRU session cache）。
 
 不是 `pi-coding-agent` 的 fork(那是终端 UX 扩展);方向是服务端 agent 运行时。详见 `docs/00-overview.md`、`docs/01-architecture.md`。
+
+> **L1 不变量「不动它一行」仍然成立,但允许「在消费面之上收口」。** `@harness-pi/core` 可提供薄 DX seam——把自定义 Model 构造与 provider options 的人体工学集中到内核一侧,而**完全不碰 pi-ai 源码**:
+> - `makeOpenAICompatibleModel(spec)`(`packages/core/src/llm-model.ts`):造 OpenAI-compatible 自定义 Model,**零 `as Model` cast、无 `cost:{0,0,0,0}` 占位**(返回窄类型 `Model<"openai-completions">` 让条件 `compat` 字段正确解析)。
+> - `LlmOptions` + `resolveLlmOptions()`:`AgentSessionOptions.llmOptions` 的 typed 形态(`Omit<StreamOptions,"signal"> & { providerExtras }`),`{apikey}` typo 编译期失败;provider 专属键走 `providerExtras` 逃生口。
+>
+> 这是「在咽喉点封装上游公共面」,不是改 L1。下游(coding-agent / engram / bidding-agent)应从 `@harness-pi/core` 拿这两个,**别直接 import `@earendil-works/pi-ai`**——seam 是单一咽喉点,上游 churn `Model` 类型时只动 `llm-model.ts` + `index.ts` re-export。
+>
+> **若将来真需改 L1 行为**,升级阶梯是:`pnpm patch`(软 fork,留在 version train、自动重应用;但 tarball 只发 `dist`,只能 patch 编译产物)→ 硬 fork+vendor(仅当 patch 做不到且需跨多 release 持续,如未用 provider SDK 瘦身)作最终储备。上游(`github.com/earendil-works/pi-mono`, MIT)当前健康,fork 期权永不过期,**现在不 fork**。
 
 ## 架构大图(读多个文件才能拼出的部分)
 
 **内核极简 + 一切皆 hook。** `@harness-pi/core` 只做两件事:跑 pi-ai 的 LLM-tool 循环 + 派发 hook。**无** metric / watchdog / pool / DB / frontend——这些全是 `@harness-pi/plugins` 里的 hook 实例。改内核前先问:这能不能做成 hook?
 
 **三个概念别混(`docs/05/06/07`):**
-- **Plugin**:钩 loop 事件的装饰器(watchdog / metrics / trimHistory / toolOutputBuffer / sessionLog / emptyRunGuard / repeatedCallGuard / costTracker / autoCompaction / compactSummarize / permissionGate)。
-- **Controller**:编排一/多个 session(workPool、lifecycleRestart、forkSession)。
+- **Plugin**:钩 loop 事件的装饰器(watchdog / metrics / trimHistory / toolOutputBuffer / sessionLog / emptyRunGuard / repeatedCallGuard / costTracker / autoCompaction / compactSummarize / permissionGate / tokenBudget / systemReminder / batchCounter / leaseDecision / toolStats)。
+- **Controller**:编排一/多个 session(workPool / lifecycleRestart / forkSession / leaseQueue / parallel / pipeline / compactOnOverflow / compactRestartFresh / gapExplorer / subAgentTool)。
 - **Adapter**:plugin 的 I/O 后端(metric sink、log sink、`SessionStore`)。**走接口 + peerDep,不强加具体 driver**;自定义 metric kind 用 TS module augmentation,不改内核。
 
 **`AgentSession`(`packages/core/src/session.ts`,本仓库最重的文件)**:`run`/`continue` → turn loop →三段式 phase(`_phaseLlmCall` → `_phaseToolBatch` → `_phaseTurnEnd`)。几个**必须知道、否则会改错**的不变量:

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│   @mariozechner/pi-ai  ——  unified LLM API + tool spec  │  L1 ← 我们站在这上面
+│   @earendil-works/pi-ai —— unified LLM API + tool spec  │  L1 ← 我们站在这上面
 ├──────────────────────────┬──────────────────────────────┤
-│  @mariozechner/          │   @harness-pi/core           │  L2
+│  @earendil-works/        │   @harness-pi/core           │  L2
 │  pi-agent-core           │                              │
 │  (Mario 的 agent 内核)    │   (我们的 agent 内核，         │
 │                          │    hook 系统作为一等公民)      │
 ├──────────────────────────┼──────────────────────────────┤
-│  @mariozechner/          │   @harness-pi/plugins        │  L3
+│  @earendil-works/        │   @harness-pi/plugins        │  L3
 │  pi-coding-agent         │   (watchdog / metrics /      │
 │  (终端编码 agent)         │    trim / buffer / log ...)  │
 │                          │                              │

--- a/apps/coding-agent/package.json
+++ b/apps/coding-agent/package.json
@@ -45,11 +45,10 @@
     "@harness-pi/core": "workspace:*",
     "@harness-pi/plugins": "workspace:*",
     "@harness-pi/tools": "workspace:*",
-    "@mariozechner/pi-ai": "^0.73.1",
-    "@mariozechner/pi-tui": "0.73.1"
+    "@earendil-works/pi-ai": "^0.74.2",
+    "@earendil-works/pi-tui": "0.74.2"
   },
   "devDependencies": {
-    "@mariozechner/pi-coding-agent": "0.73.1",
     "@types/node": "^22.0.0",
     "tsx": "^4.0.0",
     "typescript": "^5.6.0",

--- a/apps/coding-agent/src/__tests__/agent.test.ts
+++ b/apps/coding-agent/src/__tests__/agent.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { type Api, type Model, type Usage } from "@harness-pi/core";
 import { createFakeModel } from "@harness-pi/core/testing";
-import { getProviders } from "@mariozechner/pi-ai";
+import { getProviders } from "@earendil-works/pi-ai";
 import {
   createCodingAgent,
   createPiAiCostModel,

--- a/apps/coding-agent/src/__tests__/cli-args.test.ts
+++ b/apps/coding-agent/src/__tests__/cli-args.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
-import { isMainModule, parseArgs } from "../cli.js";
+import { isMainModule, parseArgs, sessionExitNotice } from "../cli.js";
 
 describe("parseArgs — v0.1.0 flags", () => {
   it("defaults: no tui/repl/version/list flags set", () => {
@@ -79,6 +79,26 @@ describe("parseArgs — v0.1.0 flags", () => {
 
   it("rejects unknown options", () => {
     expect(() => parseArgs(["--nope"])).toThrow(/Unknown option/);
+  });
+
+  // #30:TUI 退出消息——落盘失败时不谎称 persisted。
+  it("sessionExitNotice: persistenceErrorRuns>0 → warn + FAILED + run 数", () => {
+    const n = sessionExitNotice("abc", 2);
+    expect(n?.level).toBe("warn");
+    expect(n?.text).toContain("FAILED on 2 run(s)");
+    expect(n?.text).toContain("--resume abc");
+    expect(n?.text).toContain("incomplete");
+  });
+  it("sessionExitNotice: 0 失败 → log + persisted", () => {
+    const n = sessionExitNotice("abc", 0);
+    expect(n?.level).toBe("log");
+    expect(n?.text).toContain("persisted");
+    expect(n?.text).toContain("--resume abc");
+    expect(n?.text).not.toContain("FAILED");
+  });
+  it("sessionExitNotice: 无 sessionId(非 TUI 落盘)→ null", () => {
+    expect(sessionExitNotice(undefined, 0)).toBeNull();
+    expect(sessionExitNotice(undefined, 3)).toBeNull();
   });
 
   it("ignores a leading `--` (pnpm separator) and still parses following flags", () => {

--- a/apps/coding-agent/src/__tests__/config.test.ts
+++ b/apps/coding-agent/src/__tests__/config.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { getModels } from "@mariozechner/pi-ai";
+import { getModels } from "@earendil-works/pi-ai";
 import {
   detectDefaultModel,
   envVarForProvider,

--- a/apps/coding-agent/src/__tests__/output.test.ts
+++ b/apps/coding-agent/src/__tests__/output.test.ts
@@ -41,6 +41,27 @@ describe("renderRunReport — failure & overflow surfacing", () => {
     expect(out).toContain("abort reason: watchdog:timeout");
   });
 
+  it("surfaces persistenceErrors（否则「done 但 transcript 不全」被静默吞掉）", () => {
+    const out = renderRunReport(
+      report({
+        reason: "error",
+        persistenceErrors: ["appendEntry(message): boom", "appendEntry(terminal): boom"],
+      }),
+    );
+    expect(out).toContain("persistence errors (2)");
+    expect(out).toContain("appendEntry(message): boom");
+    expect(out).toContain("appendEntry(terminal): boom");
+  });
+
+  it("无 persistenceErrors 时不打该行", () => {
+    expect(renderRunReport(report({ reason: "done" }))).not.toContain("persistence errors");
+  });
+
+  it("单条 persistenceError → (1) 计数 + 该条文案(钉住计数与分隔符渲染)", () => {
+    const out = renderRunReport(report({ reason: "error", persistenceErrors: ["appendEntry(terminal): boom"] }));
+    expect(out).toContain("persistence errors (1): appendEntry(terminal): boom");
+  });
+
   it("warns when the answer was truncated by the context/output limit (stopReason length)", () => {
     const out = renderRunReport(report({ reason: "done", stopReason: "length" }));
     expect(out).toMatch(/Warnings/);

--- a/apps/coding-agent/src/__tests__/strict-persistence.test.ts
+++ b/apps/coding-agent/src/__tests__/strict-persistence.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { MemorySessionStore, type SessionEntry, type StoredEntry } from "@harness-pi/core";
+import { createFakeModel } from "@harness-pi/core/testing";
+import { createCodingAgent, resumeCodingAgent, runAgentPrompt } from "../agent.js";
+import { renderRunReport } from "../output.js";
+
+/**
+ * #30：coding-agent 必须能把 core 的 strict persistence 接进来,并把 persistenceErrors 暴露出来。
+ * 这些测试证明 `strictPersistence` 选项经 createCodingAgent / resumeCodingAgent 流到内核,
+ * 且失败被如实暴露(而非「done 但 transcript 不全」静默吞掉)。
+ */
+class FailingStore extends MemorySessionStore {
+  override async appendEntry(_sessionId: string, _entry: SessionEntry): Promise<StoredEntry> {
+    throw new Error("disk on fire");
+  }
+}
+
+const dirs: string[] = [];
+afterEach(async () => {
+  while (dirs.length) {
+    const d = dirs.pop();
+    if (d) await rm(d, { recursive: true, force: true });
+  }
+});
+async function tmp(): Promise<string> {
+  const d = await mkdtemp(join(tmpdir(), "hpi-strict-"));
+  dirs.push(d);
+  return d;
+}
+const oneText = () => createFakeModel([{ content: [{ type: "text", text: "hi" }] }]);
+
+describe("coding-agent strict persistence 接线 (#30)", () => {
+  it("strictPersistence:true + 落盘失败 → reason 提级 error + persistenceErrors 暴露", async () => {
+    const cwd = await tmp();
+    const agent = createCodingAgent({
+      cwd,
+      model: oneText(),
+      strictPersistence: true,
+      persistence: { store: new FailingStore(), sessionId: "s1" },
+    });
+    const report = await runAgentPrompt(agent, "go");
+    expect(report.summary.reason).toBe("error"); // strict 把「落盘不全的 done」提级
+    expect(report.summary.persistenceErrors!.length).toBeGreaterThan(0);
+    expect(report.summary.error!.message).toContain("strict persistence failed"); // 填的是 strict 失败原因
+    expect(renderRunReport(report)).toContain("persistence errors"); // 报告里可见
+  });
+
+  it("默认(不传 strictPersistence)+ 落盘失败 → best-effort,reason 不变但 persistenceErrors 仍暴露", async () => {
+    const cwd = await tmp();
+    const agent = createCodingAgent({
+      cwd,
+      model: oneText(),
+      persistence: { store: new FailingStore(), sessionId: "s1" },
+    });
+    const report = await runAgentPrompt(agent, "go");
+    expect(report.summary.reason).toBe("done"); // best-effort 不劫持终态
+    expect(report.summary.persistenceErrors!.length).toBeGreaterThan(0); // 但失败如实暴露
+  });
+
+  it("健康 store + strict → 不误伤(reason done,无 persistenceErrors)", async () => {
+    const cwd = await tmp();
+    const agent = createCodingAgent({
+      cwd,
+      model: oneText(),
+      strictPersistence: true,
+      persistence: { store: new MemorySessionStore(), sessionId: "s1" },
+    });
+    const report = await runAgentPrompt(agent, "go");
+    expect(report.summary.reason).toBe("done");
+    expect(report.summary.persistenceErrors).toBeUndefined();
+  });
+
+  it("resumeCodingAgent 也透传 strict(resume 是崩溃恢复路径,默认应 strict)", async () => {
+    const cwd = await tmp();
+    // 空历史 resume(store 无该 session)足以验证 strict 透传:续跑落盘失败 → reason error。
+    const agent = await resumeCodingAgent({
+      cwd,
+      model: oneText(),
+      strictPersistence: true,
+      persistence: { store: new FailingStore(), sessionId: "s1" },
+    });
+    const report = await runAgentPrompt(agent, "go");
+    expect(report.summary.reason).toBe("error");
+    expect(report.summary.persistenceErrors!.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/coding-agent/src/__tests__/tui-approval-integration.test.ts
+++ b/apps/coding-agent/src/__tests__/tui-approval-integration.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { Terminal } from "@mariozechner/pi-tui";
+import type { Terminal } from "@earendil-works/pi-tui";
 import { createFakeModel } from "@harness-pi/core/testing";
 import { createCodingAgent } from "../agent.js";
 import { createTuiApp } from "../tui/app.js";

--- a/apps/coding-agent/src/agent.ts
+++ b/apps/coding-agent/src/agent.ts
@@ -45,7 +45,7 @@ import {
   getEnvApiKey,
   getModels,
   getProviders,
-} from "@mariozechner/pi-ai";
+} from "@earendil-works/pi-ai";
 import type { RunReport } from "./output.js";
 import {
   estimateDashScopeCostCny,

--- a/apps/coding-agent/src/agent.ts
+++ b/apps/coding-agent/src/agent.ts
@@ -89,6 +89,14 @@ export interface CreateCodingAgentOptions {
    */
   persistence?: { store: SessionStore; sessionId: string };
   /**
+   * 严格持久化（透传给内核 `AgentSession.strictPersistence`）。true ⇒ run 结束时若落盘未真正完成
+   * （最终 flush / terminal append 失败），把 `RunSummary.reason` 改写为 "error" 并填 error，避免
+   * 「done 但 transcript 不全」被当成功。两种模式下 `RunSummary.persistenceErrors` 都如实暴露。
+   * TUI / resume（崩溃恢复路径）应默认开启——那正是 strict 存在的理由。createCodingAgent 与
+   * resumeCodingAgent 共用 buildAgentContext，故经 `deps` 一处接线即两路通吃。
+   */
+  strictPersistence?: boolean;
+  /**
    * 启用 compaction（compactSummarize view-transform：超阈值时把早期消息换成模型生成的摘要喂给 LLM，
    * 不毁原始历史）。给了即挂 hook；`maxMessages` 不给 = 阈值设为大哨兵（在位但不自动触发），靠
    * `requestCompaction()`（TUI 的 `/compact`）临时降阈强制压缩。one-shot 模式不传本项即完全不挂。
@@ -382,6 +390,8 @@ function buildAgentContext(opts: CreateCodingAgentOptions): AgentContext {
   };
   if (opts.maxTurns !== undefined) deps.maxTurns = opts.maxTurns;
   if (opts.llmOptions !== undefined) deps.llmOptions = opts.llmOptions;
+  // 单点接线：deps 流向 createCodingAgent({...deps}) 与 resumeCodingAgent(AgentSession.resume(...,deps)) 两路。
+  if (opts.strictPersistence !== undefined) deps.strictPersistence = opts.strictPersistence;
 
   return {
     deps,

--- a/apps/coding-agent/src/agent.ts
+++ b/apps/coding-agent/src/agent.ts
@@ -4,6 +4,7 @@ import {
   type Api,
   type HarnessTool,
   type Hook,
+  type LlmOptions,
   type Model,
   type RunSummary,
   type SessionEvent,
@@ -72,7 +73,7 @@ export interface CreateCodingAgentOptions {
   metricsFile?: string;
   systemPrompt?: string;
   toolsOptions?: ToolsOptions;
-  llmOptions?: Record<string, unknown>;
+  llmOptions?: LlmOptions;
   maxTurns?: number;
   costModel?: CostTrackerOptions["costModel"];
   /**
@@ -141,7 +142,7 @@ export interface RunAgentPromptOptions {
 
 export interface ResolvedModelRuntime {
   model: Model<Api>;
-  llmOptions?: Record<string, unknown>;
+  llmOptions?: LlmOptions;
 }
 
 const DEFAULT_SYSTEM_PROMPT = [
@@ -596,7 +597,7 @@ function cloneToolStats(stats: ToolStats): ToolStats {
 
 function createDashScopeCostAccumulator(
   model: Model<Api>,
-  llmOptions: Record<string, unknown> | undefined,
+  llmOptions: LlmOptions | undefined,
 ):
   | {
       hook: Hook;
@@ -607,7 +608,9 @@ function createDashScopeCostAccumulator(
 
   let total = 0;
   let source: string | undefined;
-  const thinking = typeof llmOptions?.["reasoningEffort"] === "string";
+  // reasoningEffort 是 openai-completions 的 provider 专属选项，经 LlmOptions.providerExtras 透传。
+  const thinking =
+    typeof llmOptions?.providerExtras?.["reasoningEffort"] === "string";
   return {
     hook: {
       name: "dashscope-cost-estimator",

--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -116,7 +116,7 @@ function assistantText(msg: { content: unknown } | undefined): string {
 export function makeReadOnlySubAgentSpawner(
   cwd: string,
   model: ReturnType<typeof resolveModelRuntime>["model"],
-  llmOptions: Record<string, unknown> | undefined,
+  llmOptions: ReturnType<typeof resolveModelRuntime>["llmOptions"],
 ): (task: string, signal: AbortSignal) => Promise<{ ok: boolean; text: string }> {
   return async (task, signal) => {
     const subOpts: Parameters<typeof createCodingAgent>[0] = {

--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -24,7 +24,7 @@ import {
 } from "./config.js";
 import { toolNames, type ToolName } from "@harness-pi/tools";
 import { JsonlSessionStore } from "@harness-pi/adapters";
-import { ProcessTerminal } from "@mariozechner/pi-tui";
+import { ProcessTerminal } from "@earendil-works/pi-tui";
 import { createTuiApp } from "./tui/app.js";
 
 interface CliArgs {

--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -65,6 +65,27 @@ export function emitStartupWarnings(
   if (agent.harnessPiWarning) write(`⚠️  ${agent.harnessPiWarning}\n`);
 }
 
+/**
+ * TUI 退出时给的会话落盘提示。抽成纯函数便于直测。`persistenceErrorRuns>0` ⇒ 本会话有 run 落盘失败,
+ * 不能谎称 "persisted",改为告警 resume 可能不全;否则给正常 resume 句柄。无 sessionId(非 TUI 落盘)⇒ null。
+ */
+export function sessionExitNotice(
+  sessionId: string | undefined,
+  persistenceErrorRuns: number,
+): { level: "warn" | "log"; text: string } | null {
+  if (!sessionId) return null;
+  if (persistenceErrorRuns > 0) {
+    return {
+      level: "warn",
+      text: `⚠ Session persistence FAILED on ${persistenceErrorRuns} run(s) — --resume ${sessionId} may restore incomplete state (see warnings above).`,
+    };
+  }
+  return {
+    level: "log",
+    text: `Session persisted (process-crash recoverable). Resume with: --resume ${sessionId}`,
+  };
+}
+
 /** 该会话的 persistence 子对象（store + id 捆一起，对齐 createCodingAgent.persistence）。 */
 function persistenceFor(
   cwd: string,
@@ -213,11 +234,13 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     agent = await resumeCodingAgent({
       ...createOptions,
       persistence: persistenceFor(args.cwd, sessionId),
+      strictPersistence: true, // resume = 崩溃恢复路径，默认 strict：落盘不全则 reason→error + 显式告警
     });
   } else {
     if (args.tui) {
       sessionId = randomUUID();
       createOptions.persistence = persistenceFor(args.cwd, sessionId);
+      createOptions.strictPersistence = true; // TUI 默认落盘 → 默认 strict（同 resume 理由）
     }
     agent = createCodingAgent(createOptions);
   }
@@ -260,11 +283,9 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
       await app.run(); // 直到用户 Ctrl-C 退出
       // 退出后告知 resume 句柄。落盘每 turn 用 appendFileSync（无 fsync）——进程崩溃可恢复，
       // 但断电/内核 panic 下最后一次写可能丢，故措辞为"process-crash recoverable"而非"saved"。
-      if (sessionId) {
-        console.log(
-          `Session persisted (process-crash recoverable). Resume with: --resume ${sessionId}`,
-        );
-      }
+      // 本会话出现过 persistenceErrors（strict 默认开）则不谎称 persisted——见 sessionExitNotice。
+      const notice = sessionExitNotice(sessionId, app.persistenceErrorRuns());
+      if (notice) (notice.level === "warn" ? console.warn : console.log)(notice.text);
       return;
     }
 

--- a/apps/coding-agent/src/compaction.ts
+++ b/apps/coding-agent/src/compaction.ts
@@ -6,7 +6,7 @@
  * `summarize(earlyMessages) => string`，用 pi-ai 的 complete() 跑一次无工具的总结调用。
  */
 
-import { complete, type Context } from "@mariozechner/pi-ai";
+import { complete, type Context } from "@earendil-works/pi-ai";
 import {
   createUserMessage,
   type Api,

--- a/apps/coding-agent/src/compaction.ts
+++ b/apps/coding-agent/src/compaction.ts
@@ -6,10 +6,16 @@
  * `summarize(earlyMessages) => string`，用 pi-ai 的 complete() 跑一次无工具的总结调用。
  */
 
-import { complete, type Context } from "@earendil-works/pi-ai";
+import {
+  complete,
+  type Context,
+  type ProviderStreamOptions,
+} from "@earendil-works/pi-ai";
 import {
   createUserMessage,
+  resolveLlmOptions,
   type Api,
+  type LlmOptions,
   type Message,
   type Model,
 } from "@harness-pi/core";
@@ -47,7 +53,7 @@ function assistantText(message: { content: Message["content"] }): string {
  */
 export function createModelSummarizer(
   model: Model<Api>,
-  llmOptions?: Record<string, unknown>,
+  llmOptions?: LlmOptions,
 ): (earlyMessages: Message[], signal?: AbortSignal) => Promise<string> {
   return async (earlyMessages, signal) => {
     const context: Context = {
@@ -55,7 +61,7 @@ export function createModelSummarizer(
       tools: [],
       systemPrompt: SUMMARY_SYSTEM,
     };
-    const options: Record<string, unknown> = { ...llmOptions };
+    const options: ProviderStreamOptions = resolveLlmOptions(llmOptions);
     if (signal) options.signal = signal;
     const result = await complete(model, context, options);
     const text = assistantText(result);

--- a/apps/coding-agent/src/config.ts
+++ b/apps/coding-agent/src/config.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
-import { getModels, getProviders } from "@mariozechner/pi-ai";
+import { getModels, getProviders } from "@earendil-works/pi-ai";
 import { dashScopeModelIds, isDashScopeProviderAlias } from "./providers/dashscope.js";
 
 type Env = Record<string, string | undefined>;
@@ -20,7 +20,7 @@ export const PROVIDER_ONBOARDING: ProviderOnboarding[] = [
   { provider: "anthropic", envVar: "ANTHROPIC_API_KEY", defaultModel: "claude-sonnet-4-0" },
   { provider: "openai", envVar: "OPENAI_API_KEY", defaultModel: "gpt-4.1" },
   { provider: "google", envVar: "GEMINI_API_KEY", defaultModel: "gemini-flash-latest" },
-  { provider: "xai", envVar: "XAI_API_KEY", defaultModel: "grok-3-latest" },
+  { provider: "xai", envVar: "XAI_API_KEY", defaultModel: "grok-3" },
   { provider: "groq", envVar: "GROQ_API_KEY", defaultModel: "llama-3.3-70b-versatile" },
   { provider: "deepseek", envVar: "DEEPSEEK_API_KEY", defaultModel: "deepseek-v4-flash" },
   { provider: "moonshotai", envVar: "MOONSHOT_API_KEY", defaultModel: "kimi-k2-0905-preview" },

--- a/apps/coding-agent/src/output.ts
+++ b/apps/coding-agent/src/output.ts
@@ -34,6 +34,12 @@ export function renderRunReport(report: RunReport): string {
   // 失败终态把原因打出来——否则只剩 "reason: error"，piped/captured 的报告完全丢失原因。
   if (report.summary.error) lines.push(`error: ${report.summary.error.message}`);
   if (report.summary.abortReason) lines.push(`abort reason: ${report.summary.abortReason}`);
+  // 持久化失败如实暴露（两种模式都填）——否则「done 但 transcript 不全」会被静默吞掉，resume 拿残缺状态。
+  if (report.summary.persistenceErrors?.length) {
+    lines.push(
+      `persistence errors (${report.summary.persistenceErrors.length}): ${report.summary.persistenceErrors.join("; ")}`,
+    );
+  }
   lines.push(`turns: ${report.summary.turns}`);
   lines.push(`continuations: ${report.summary.continuations}`);
   lines.push(`run wall time: ${formatMs(report.wallTimeMs)}`);

--- a/apps/coding-agent/src/providers/dashscope.ts
+++ b/apps/coding-agent/src/providers/dashscope.ts
@@ -1,4 +1,5 @@
-import type { Api, Model, Usage } from "@harness-pi/core";
+import { makeOpenAICompatibleModel } from "@harness-pi/core";
+import type { Api, LlmOptions, Model, Usage } from "@harness-pi/core";
 
 export interface DashScopeEnv {
   DASHSCOPE_API_KEY?: string | undefined;
@@ -7,7 +8,7 @@ export interface DashScopeEnv {
 
 export interface DashScopeResolvedModelRuntime {
   model: Model<Api>;
-  llmOptions: Record<string, unknown>;
+  llmOptions: LlmOptions;
 }
 
 export interface DashScopePricingTier {
@@ -244,17 +245,15 @@ export function resolveDashScopeModel(
 
   const metadata = getDashScopeModelMetadata(modelId);
   return {
-    model: {
+    // pi-ai Model.cost is USD per million tokens; DashScope docs publish CNY, so cost stays at the
+    // factory's zero default and CNY estimation is kept in this adapter (createDashScopeCostAccumulator).
+    model: makeOpenAICompatibleModel({
       id: modelId,
       name: `DashScope ${modelId}`,
-      api: "openai-completions",
       provider: "dashscope",
       baseUrl: DASHSCOPE_BASE_URL,
       reasoning: metadata.reasoning,
       input: metadata.input,
-      // pi-ai Model.cost is USD per million tokens. DashScope docs publish CNY;
-      // CNY estimation is kept in this adapter so the shared USD report stays honest.
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       contextWindow: metadata.contextWindow,
       maxTokens: metadata.maxTokens,
       compat: {
@@ -266,7 +265,7 @@ export function resolveDashScopeModel(
         thinkingFormat: "qwen",
         supportsStrictMode: false,
       },
-    } satisfies Model<"openai-completions">,
+    }),
     llmOptions: { apiKey },
   };
 }

--- a/apps/coding-agent/src/tui/__tests__/app.smoke.test.ts
+++ b/apps/coding-agent/src/tui/__tests__/app.smoke.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type { Terminal } from "@mariozechner/pi-tui";
+import type { Terminal } from "@earendil-works/pi-tui";
 import type { AssistantMessage, LiveEvent, RunSummary, SessionEvent, ToolCall } from "@harness-pi/core";
 import { createTuiApp, type TuiAgentLike, type TuiSession } from "../app.js";
 

--- a/apps/coding-agent/src/tui/__tests__/app.smoke.test.ts
+++ b/apps/coding-agent/src/tui/__tests__/app.smoke.test.ts
@@ -141,6 +141,36 @@ describe("TUI app smoke (headless, dual-track via fake terminal)", () => {
     expect(out.split("All good.").length - 1).toBe(1); // 只出现一次
   });
 
+  const failSummary: RunSummary = {
+    turns: 1,
+    continuations: 0,
+    reason: "error",
+    usage: { ...ZERO },
+    persistenceErrors: ["appendEntry(message): boom"],
+  };
+
+  it("finalize: summary.persistenceErrors → 渲染醒目告警 + persistenceErrorRuns()===1", async () => {
+    const app = makeApp(scriptedSession([{ coarse: { type: "session-end", summary: failSummary } }], failSummary));
+    await app.submit("go");
+    const out = strip(app.tui.render(80).join("\n"));
+    expect(out).toContain("持久化失败"); // 落盘失败当场可见(崩溃恢复路径)
+    expect(out).toContain("appendEntry(message): boom"); // 具体错误
+    expect(app.persistenceErrorRuns()).toBe(1);
+  });
+
+  it("persistenceErrorRuns 跨多轮累积:两轮都失败 → 2", async () => {
+    const app = makeApp(scriptedSession([{ coarse: { type: "session-end", summary: failSummary } }], failSummary));
+    await app.submit("a");
+    await app.submit("b");
+    expect(app.persistenceErrorRuns()).toBe(2);
+  });
+
+  it("干净 run 不自增 persistenceErrorRuns(无假阳性)", async () => {
+    const app = makeApp(scriptedSession([{ coarse: { type: "session-end", summary } }], summary));
+    await app.submit("go");
+    expect(app.persistenceErrorRuns()).toBe(0);
+  });
+
   it("ignores empty submits (no user bubble added)", async () => {
     const app = makeApp(scriptedSession([{ coarse: { type: "session-end", summary } }], summary));
     const before = app.tui.render(80).join("\n");

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -19,7 +19,7 @@ import {
   type Terminal,
   Text,
   TUI,
-} from "@mariozechner/pi-tui";
+} from "@earendil-works/pi-tui";
 import { createUserMessage, type LiveEvent, type Message, type RunSummary, type SessionEvent, type ToolCall } from "@harness-pi/core";
 import { coarseEventToActions, type TuiAction } from "./event-bridge.js";
 import { LiveStreamAccumulator, type StreamOp } from "./live-stream.js";

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -98,6 +98,8 @@ export interface TuiApp {
   /** start() 并返回一个直到用户退出（Ctrl-C）才 resolve 的 promise——CLI 用它驱动生命周期。 */
   run(): Promise<void>;
   isRunning(): boolean;
+  /** 本会话累计出现 persistenceErrors 的 run 次数（>0 ⇒ 落盘有失败，resume 可能不全）。CLI 退出消息据此告警。 */
+  persistenceErrorRuns(): number;
 }
 
 interface StatsView {
@@ -108,6 +110,7 @@ interface StatsView {
 
 export function createTuiApp(opts: TuiAppOptions): TuiApp {
   const tui = new TUI(opts.terminal);
+  let persistenceErrorRuns = 0; // 累计落盘失败的 run 次数（finalize 据 summary.persistenceErrors 自增）
   const messages = new Container();
   const status = new Loader(tui, color.cyan, color.dim, "");
   status.stop(); // Loader 构造即开始动画；空闲时停掉，避免启动后 ~12fps 空转 churn（run 时再 start）。
@@ -275,6 +278,19 @@ export function createTuiApp(opts: TuiAppOptions): TuiApp {
   function finalize(summary: RunSummary): void {
     stats.input = summary.usage.input;
     stats.output = summary.usage.output;
+    // 落盘失败显著告警（崩溃恢复路径上,「done 但 transcript 不全」必须让用户当场看到,而非静默）。
+    if (summary.persistenceErrors?.length) {
+      persistenceErrorRuns++;
+      append(
+        new Text(
+          color.red(
+            `⚠ 持久化失败（resume 可能不全）: ${summary.persistenceErrors.join("; ")}`,
+          ),
+          0,
+          0,
+        ),
+      );
+    }
     const est = opts.agent.getCostEstimate?.();
     if (est) {
       stats.costText =
@@ -570,5 +586,5 @@ export function createTuiApp(opts: TuiAppOptions): TuiApp {
     return done;
   }
 
-  return { tui, submit, start, stop, run, isRunning: () => running };
+  return { tui, submit, start, stop, run, isRunning: () => running, persistenceErrorRuns: () => persistenceErrorRuns };
 }

--- a/apps/coding-agent/src/tui/autocomplete.ts
+++ b/apps/coding-agent/src/tui/autocomplete.ts
@@ -15,7 +15,7 @@ import {
   fuzzyFilter,
   type AutocompleteItem,
   type AutocompleteProvider,
-} from "@mariozechner/pi-tui";
+} from "@earendil-works/pi-tui";
 
 const SKIP_DIRS = new Set([
   ".git",

--- a/apps/coding-agent/src/tui/theme.ts
+++ b/apps/coding-agent/src/tui/theme.ts
@@ -3,7 +3,7 @@
  * 故意精简：够 dogfood 用、可读即可，不做主题切换（pi-coding-agent 那套留作参考）。
  */
 
-import type { EditorTheme, MarkdownTheme, SelectListTheme } from "@mariozechner/pi-tui";
+import type { EditorTheme, MarkdownTheme, SelectListTheme } from "@earendil-works/pi-tui";
 
 /** ANSI CSI 前缀（ESC + '['）。用 fromCharCode(27) 而非源码里塞不可见 ESC 字节，避免编辑时被破坏。 */
 const CSI = `${String.fromCharCode(27)}[`;

--- a/apps/lark-bot/.env.example
+++ b/apps/lark-bot/.env.example
@@ -1,0 +1,45 @@
+# lark-bot 环境变量示例。复制为 .env 后填值，或经 systemd EnvironmentFile 注入。
+# 进程真实环境永远优先于 .env。
+
+# --- 必填 ---
+# DeepSeek API key（大脑）。本地可经 keychain→zshrc 注入；服务器放这里或 systemd EnvironmentFile。
+DEEPSEEK_API_KEY=sk-xxxx
+
+# --- 身份与安全（重要）---
+# 事件消费 + 回复身份（机器人是对话里的实体）：bot | user
+# LARK_BOT_IDENTITY=bot
+# lark_cli 工具默认身份：user = 代表主人访问其私有数据（消息/文档/日历/邮件/任务）；agent 可按调用覆盖
+# LARK_BOT_TOOL_IDENTITY=user
+# 只响应主人本人（ou_…）的消息。toolIdentity=user 时强烈建议设，否则别人 DM 也会被以主人身份执行。
+# 主人 open_id 可用 `lark-cli auth status` 查（identities.user.openId）
+# LARK_BOT_OWNER_OPEN_ID=ou_xxxx
+
+# --- 观测/评测数据 ---
+# 落盘目录：sessions/<id>.ndjson（全量 trace）+ metrics.ndjson
+# LARK_BOT_DATA_DIR=data
+# 是否挂观测插件（sessionLog/metrics/costTracker/toolStats）
+# LARK_BOT_TELEMETRY=true
+
+# --- 其它（都有默认值）---
+# pi-ai 模型 spec：provider:modelId
+# LARK_BOT_MODEL=deepseek:deepseek-v4-flash
+# 订阅事件
+# LARK_BOT_EVENT_KEY=im.message.receive_v1
+# lark-cli 路径（不在 PATH 时填绝对路径）
+# LARK_BOT_CLI=lark-cli
+# 是否响应群消息（默认 false：只回私聊）
+# LARK_BOT_GROUPS=false
+# 单轮最大 turn 数
+# LARK_BOT_MAX_TURNS=24
+# 缓存会话数上限（LRU）
+# LARK_BOT_MAX_SESSIONS=50
+# 去重窗口
+# LARK_BOT_DEDUP=2000
+# 单次 lark-cli 调用超时(ms)
+# LARK_BOT_TOOL_TIMEOUT_MS=60000
+# 工具输出回灌上限(字符)
+# LARK_BOT_TOOL_OUTPUT_CAP=12000
+# lark_cli 工具放行的命令家族（逗号分隔，覆盖默认白名单）
+# LARK_BOT_ALLOWED_FAMILIES=im,docx,calendar,task,base,wiki,drive,contact,search
+# 是否允许破坏性命令（默认 false）
+# LARK_BOT_ALLOW_DESTRUCTIVE=false

--- a/apps/lark-bot/.gitignore
+++ b/apps/lark-bot/.gitignore
@@ -1,0 +1,7 @@
+# 运行时产物 —— 绝不提交（含私有消息 trace / 记忆 / 遥测）
+data/
+dist/
+node_modules/
+.env
+.env.local
+*.tsbuildinfo

--- a/apps/lark-bot/README.md
+++ b/apps/lark-bot/README.md
@@ -1,0 +1,94 @@
+# @harness-pi/lark-bot
+
+跑在 harness-pi 内核上的飞书（Lark）个人助手 bot —— Chasey「Agent OS」的对话门面。
+
+- **大脑**：`deepseek-v4-flash`（经 `@earendil-works/pi-ai`）
+- **入口**：`lark-cli event consume im.message.receive_v1`（长连接，无需公网 endpoint）
+- **工具**：`lark_cli`（lark-cli 全家桶，家族白名单 + 破坏性拦截，**双身份**：默认 `user` 代表主人读自己的数据，`bot` 以助手名义行事）、`lark_send_message`、`remember`（自生长记忆）
+- **出口**：agent 最终文本 → `lark-cli im +messages-reply`
+
+## 设计理念
+
+- **瘦人设**：system prompt 只定义"我是谁、什么性格"，**不写死** "数据在哪 / 命令怎么拼 / 失败怎么办"。
+- **发现优先**：不熟的事 bot 自己用 lark-cli 探查（搜文档、列日程…），而非靠人喂地图。
+- **自沉淀**：探到的资源位置 / 有效命令 / 主人偏好，bot 用 `remember` 写进 `memory.md`，每轮注入回 prompt——**越用越懂主人**。短期对话历史易失（内存），长期知识持久（memory.md）。
+
+## 架构
+
+```
+飞书 IM 消息
+  │  lark-cli event consume im.message.receive_v1   (NDJSON 长连接, daemon)
+  ▼
+LarkBot (supervisor)
+  ├─ 去重(event_id) · 锁主人(ownerOpenId) · 按 chat 串行 · 每 chat 一条 AgentSession(内存多轮历史, LRU)
+  ▼
+AgentSession.run(text)              [harness-pi kernel]
+  ├─ deepseek-v4-flash              [pi-ai]
+  ├─ system prompt = 瘦人设 + memory.md(每轮 transformSystemPromptBeforeLlm 注入)
+  ├─ tools: lark_cli(user/bot) · lark_send_message · remember
+  └─ plugins: trimHistory · emptyRunGuard · repeatedCallGuard
+  │           + (telemetry) sessionLog · metrics · costTracker · toolStats
+  ▼
+最终文本 → lark-cli im +messages-reply   (幂等键 = event_id)
+```
+
+## 身份与安全
+
+- **双身份**：`lark_cli` 工具默认 `user`（代表主人读他自己的消息/文档/日历/邮件/任务/多维表），`bot` 仅用于"以助手名义发消息"。事件消费 + 回复用 `bot`（机器人是对话里的实体）。
+- **锁主人（重要）**：`user` 身份会以主人名义操作其私有数据，所以设 `LARK_BOT_OWNER_OPEN_ID` 后只响应主人本人，别人 DM 一律忽略。自用可留空。
+- **本地 vs 服务器**：本地 `--as user` 直接用本机已登录的用户 OAuth。**服务器常驻**需自行解决 user OAuth token 的刷新（refresh token 周期过期）——这是上服务器前要补的一环。
+
+## v1 范围与限制
+
+- **只回私聊（p2p）**。群消息默认不响应（`LARK_BOT_GROUPS=true` 可开，但 v1 无 @ 提及判定，慎用）。
+- **只处理文本/富文本（text/post）**；其它类型回一句「暂只支持文本」。
+- **对话历史不持久**：per-chat 多轮历史在内存里，daemon 重启即失（只有 `memory.md` 沉淀跨重启存活）。要不断片需挂 `JsonlSessionStore`（未做）。
+- **上下文管理仅 trim**：`trimHistory(keepRecent:16)` 滑窗，无摘要压缩——超长对话会丢早期上下文。要保前情可加 `compactSummarize`（未做）。
+
+## 运行
+
+前置：
+1. `pnpm install && pnpm --filter @harness-pi/lark-bot build`（或 `pnpm start` 用 tsx 直接跑）。
+2. 环境变量 `DEEPSEEK_API_KEY`（见 `.env.example`）。
+3. `lark-cli` 在 PATH：**bot 身份已就绪**（`lark-cli auth status` 里 `identities.bot.status == ready`）；要用 `user` 身份工具则 **user 身份也需就绪**。
+4. 设 `LARK_BOT_OWNER_OPEN_ID`（主人 open_id，`auth status` 里 `identities.user.openId`）——`user` 身份下务必锁主人。
+5. **飞书开发者后台**：事件订阅方式设为「长连接」，订阅 `im.message.receive_v1`，并开启机器人「接收消息」能力。
+
+```bash
+# 开发（tsx）
+DEEPSEEK_API_KEY=... pnpm --filter @harness-pi/lark-bot start
+# 生产（build 后）
+node apps/lark-bot/dist/index.js
+```
+
+配置全部走环境变量，见 [`.env.example`](./.env.example)。
+
+## 部署到 rune-sgp（systemd）
+
+```ini
+# /etc/systemd/system/lark-bot.service
+[Unit]
+Description=harness-pi lark-bot
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/lark-bot
+ExecStart=/usr/bin/node /opt/lark-bot/dist/index.js
+EnvironmentFile=/opt/lark-bot/.env
+Restart=always
+RestartSec=3
+# 1GB 小机器：限制内存，OOM 时由 Restart 拉起
+MemoryMax=400M
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload && sudo systemctl enable --now lark-bot
+journalctl -u lark-bot -f
+```
+
+> 1GB 无 swap 的机器先加 swap，再上常驻进程。

--- a/apps/lark-bot/package.json
+++ b/apps/lark-bot/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@harness-pi/lark-bot",
   "version": "0.1.0",
+  "private": true,
   "description": "Feishu/Lark personal Agent-OS bot built on the harness-pi kernel (deepseek-v4-flash brain, lark-cli toolbelt)",
   "license": "MIT",
   "repository": {

--- a/apps/lark-bot/package.json
+++ b/apps/lark-bot/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@harness-pi/lark-bot",
+  "version": "0.1.0",
+  "description": "Feishu/Lark personal Agent-OS bot built on the harness-pi kernel (deepseek-v4-flash brain, lark-cli toolbelt)",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chasey-myagi/harness-pi.git",
+    "directory": "apps/lark-bot"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "lark-bot": "./dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    ".env.example"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc -p .",
+    "typecheck": "tsc -p . --noEmit"
+  },
+  "dependencies": {
+    "@harness-pi/core": "workspace:*",
+    "@harness-pi/plugins": "workspace:*",
+    "@earendil-works/pi-ai": "^0.74.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/apps/lark-bot/src/agent.ts
+++ b/apps/lark-bot/src/agent.ts
@@ -1,0 +1,153 @@
+/**
+ * 把 harness-pi 内核装配成 bot 用的 AgentSession，并把 `provider:modelId` spec 解析成 pi-ai Model。
+ *
+ * 不复用 coding-agent 的 createCodingAgent —— 那套带文件系统工具和 coding system prompt。
+ * 这里直接 new AgentSession，挂最小够用的几个 plugin。
+ */
+
+import {
+  AgentSession,
+  type Api,
+  type HarnessTool,
+  type Hook,
+  type Model,
+  type Usage,
+} from "@harness-pi/core";
+import { calculateCost, getEnvApiKey, getModels, getProviders } from "@earendil-works/pi-ai";
+import {
+  costTracker,
+  emptyRunGuard,
+  metrics,
+  repeatedCallGuard,
+  sessionLog,
+  toolStats,
+  trimHistory,
+  type CostTrackerOptions,
+  type MetricsSink,
+} from "@harness-pi/plugins";
+import type { BotConfig } from "./config.js";
+import type { MemoryStore } from "./memory.js";
+
+/**
+ * 解析 `provider:modelId`。精确匹配优先；找不到精确 id 时退化到该 provider 目录里
+ * 名字含 "flash" 的、否则最后一个，并告警（容忍 pi-ai 目录里 model id 轮换）。
+ * provider 未知 / 目录为空 / 缺 API key 都 throw（fail fast）。
+ */
+export function resolveModel(spec: string): Model<Api> {
+  const sep = spec.indexOf(":");
+  if (sep <= 0 || sep === spec.length - 1) {
+    throw new Error(`Invalid model spec "${spec}". Expected provider:modelId.`);
+  }
+  const provider = spec.slice(0, sep);
+  const modelId = spec.slice(sep + 1);
+
+  const providers = getProviders() as string[];
+  if (!providers.includes(provider)) {
+    throw new Error(`Unknown provider "${provider}". Known: ${providers.join(", ")}`);
+  }
+
+  const models = getModels(provider as never);
+  if (models.length === 0) {
+    throw new Error(`No models in pi-ai catalog for provider "${provider}".`);
+  }
+
+  let model = models.find((m) => m.id === modelId);
+  if (!model) {
+    const fallback = models.find((m) => m.id.includes("flash")) ?? models[models.length - 1];
+    // models.length > 0 已校验，fallback 必有值
+    model = fallback as (typeof models)[number];
+    console.error(
+      `[lark-bot] model "${modelId}" not in pi-ai catalog for "${provider}"; falling back to "${model.id}". ` +
+        `Available: ${models.map((m) => m.id).join(", ")}`,
+    );
+  }
+
+  if (!getEnvApiKey(provider)) {
+    throw new Error(
+      `Missing API key for provider "${provider}". Set the provider's env var (e.g. DEEPSEEK_API_KEY) before starting.`,
+    );
+  }
+  return model as Model<Api>;
+}
+
+/** 用 pi-ai 的定价表把内核 usage 折算成 $ 成本（搬自 coding-agent）。无定价的 model 折算为 0。 */
+export function createPiAiCostModel(
+  model: Model<Api>,
+): NonNullable<CostTrackerOptions["costModel"]> {
+  return (_modelId, usage) => {
+    const piUsage: Usage = {
+      input: usage.input,
+      output: usage.output,
+      cacheRead: usage.cached,
+      cacheWrite: 0,
+      totalTokens: usage.input + usage.output + usage.cached,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    };
+    return calculateCost(model, piUsage).total;
+  };
+}
+
+/** 观测/评测插件的落点：共享的 metrics sink + 每会话 sessionLog 目录。 */
+export interface Observability {
+  /** 跨所有会话共享的一个 metrics 落盘 sink（NDJSON）。 */
+  metricsSink: MetricsSink;
+  /** sessionLog（全量 trace）目录，每会话一份 `<id>.ndjson`。 */
+  logDir: string;
+}
+
+/**
+ * 新建一条 bot 会话（每个飞书 chat 一条，复用以保留多轮记忆）。
+ * - `memory`：自生长记忆，每次 LLM 调用前把全文层叠到人设 prompt 之上（构造期 prompt 保持纯人设）。
+ * - `obs`：给了即挂观测插件 sessionLog(trace) + metrics(NDJSON) + costTracker($/token) + toolStats。
+ */
+export function createBotSession(
+  cfg: BotConfig,
+  model: Model<Api>,
+  tools: HarnessTool[],
+  memory: MemoryStore,
+  obs?: Observability,
+): AgentSession {
+  const hooks: Hook[] = [];
+
+  // 记忆注入：把当下记忆全文层叠到人设 prompt 之上（live 读取，turn N 写的下一轮就能用）。
+  hooks.push({
+    name: "memory-inject",
+    transformSystemPromptBeforeLlm(systemPrompt: string): string | void {
+      const mem = memory.load();
+      if (mem.length === 0) return;
+      return `${systemPrompt}\n\n# 你的记忆（过往沉淀，优先参考；若与现实不符就用工具核实并 remember 更新）\n\n${mem}`;
+    },
+  });
+
+  // 观测/评测插件（sessionLog 排最前：完整记录每个 event 作为 trace）。
+  if (obs) {
+    hooks.push(sessionLog({ dir: obs.logDir }));
+    hooks.push(metrics({ sink: obs.metricsSink }));
+    hooks.push(costTracker({ mode: "lifetime", costModel: createPiAiCostModel(model) }));
+    hooks.push(toolStats({}));
+  }
+
+  // 控制类插件
+  hooks.push(
+    // 控历史长度（小机器 + 长对话防 context 爆）
+    trimHistory({ keepRecent: 16 }),
+    // 连续空 turn 早停
+    emptyRunGuard({ maxEmptyTurns: 3 }),
+    // 同一工具反复调用兜底中止（防 deepseek 卡在某个 lark-cli 报错上死循环）
+    repeatedCallGuard({
+      threshold: 4,
+      windowSize: 20,
+      onRepeat(ctx, pattern) {
+        ctx.abort(`repeated-call-guard: ${pattern.tool} repeated ${pattern.count}x`);
+      },
+    }),
+  );
+
+  return new AgentSession({
+    model,
+    tools,
+    systemPrompt: cfg.systemPrompt,
+    maxTurns: cfg.maxTurns,
+    hooks,
+  });
+}

--- a/apps/lark-bot/src/bot.ts
+++ b/apps/lark-bot/src/bot.ts
@@ -1,0 +1,222 @@
+/**
+ * bot 主循环（supervisor）：
+ * - 带退避地常驻 `event consume`（子进程退出就重启 = lifecycle-restart）
+ * - 按 event_id 去重（飞书会重投）
+ * - 按 chat 串行处理（同 chat 不并发，跨 chat 可并行）
+ * - 每个 chat 缓存一条 AgentSession（多轮记忆），LRU 控内存
+ * - agent 最终文本 → im +messages-reply 回到原对话
+ */
+
+import { mkdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import type { AgentSession, Api, Model } from "@harness-pi/core";
+import { NdjsonFileSink } from "@harness-pi/plugins";
+import { createBotSession, resolveModel, type Observability } from "./agent.js";
+import { createLarkTools } from "./tools.js";
+import { consumeEvents, replyMessage, type LarkMessageEvent } from "./lark.js";
+import { MemoryStore } from "./memory.js";
+import type { BotConfig } from "./config.js";
+
+/** 从 assistant 消息里抽纯文本（用于当作飞书回复）。 */
+function extractText(message: unknown): string {
+  if (!message || typeof message !== "object") return "";
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === "string") return content.trim();
+  if (Array.isArray(content)) {
+    return content
+      .filter(
+        (b): b is { type: "text"; text: string } =>
+          !!b &&
+          typeof b === "object" &&
+          (b as { type?: unknown }).type === "text" &&
+          typeof (b as { text?: unknown }).text === "string",
+      )
+      .map((b) => b.text)
+      .join("\n")
+      .trim();
+  }
+  return "";
+}
+
+function delay(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (signal.aborted) return resolve();
+    const timer = setTimeout(resolve, ms);
+    signal.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true },
+    );
+  });
+}
+
+export class LarkBot {
+  private readonly cfg: BotConfig;
+  private readonly model: Model<Api>;
+  private readonly tools: ReturnType<typeof createLarkTools>;
+  /** 自生长记忆（全局共享，跨所有 chat / 会话）。 */
+  private readonly memory: MemoryStore;
+  /** 观测/评测落点（cfg.telemetry 关时为 undefined）。 */
+  private readonly obs: Observability | undefined;
+
+  private readonly sessions = new Map<string, AgentSession>();
+  private readonly chatLru: string[] = [];
+  /** 每个 chat 一条 promise 链，保证同 chat 串行。 */
+  private readonly chains = new Map<string, Promise<void>>();
+
+  private readonly seen = new Set<string>();
+  private readonly seenOrder: string[] = [];
+
+  constructor(cfg: BotConfig) {
+    this.cfg = cfg;
+    // 可能 throw（缺 key / 未知 model）——交给 index.ts 的顶层捕获，fail fast。
+    this.model = resolveModel(cfg.modelSpec);
+    this.memory = new MemoryStore(resolve(cfg.memoryFile));
+    this.tools = createLarkTools(cfg, this.memory);
+
+    if (cfg.telemetry) {
+      const dataDir = resolve(cfg.dataDir);
+      const logDir = join(dataDir, "sessions");
+      mkdirSync(logDir, { recursive: true });
+      this.obs = {
+        logDir,
+        metricsSink: new NdjsonFileSink({ path: join(dataDir, "metrics.ndjson"), batchSize: 1 }),
+      };
+    } else {
+      this.obs = undefined;
+    }
+  }
+
+  private log(msg: string): void {
+    console.error(`[lark-bot ${new Date().toISOString()}] ${msg}`);
+  }
+
+  async start(signal: AbortSignal): Promise<void> {
+    this.log(
+      `starting — model=${this.cfg.modelSpec} event=${this.cfg.eventKey} identity=${this.cfg.identity} toolIdentity=${this.cfg.toolIdentity} groups=${this.cfg.respondInGroups} owner=${this.cfg.ownerOpenId ?? "(any)"}`,
+    );
+    if (this.obs) this.log(`telemetry → ${this.obs.logDir} (sessions) + metrics.ndjson`);
+    const mem = this.memory.load();
+    this.log(`memory ← ${this.memory.path} (${mem.length} chars sedimented)`);
+    let backoff = 1000;
+    while (!signal.aborted) {
+      try {
+        await consumeEvents(
+          this.cfg,
+          {
+            onEvent: (ev) => this.enqueue(ev),
+            onLog: (m) => this.log(m),
+          },
+          signal,
+        );
+        if (signal.aborted) break;
+        this.log("event consume exited; restarting…");
+        backoff = 1000; // 干净退出，退避归零
+      } catch (err) {
+        this.log(`event consume failed: ${(err as Error).message}; retrying in ${backoff}ms`);
+      }
+      if (signal.aborted) break;
+      await delay(backoff, signal);
+      backoff = Math.min(backoff * 2, 30_000);
+    }
+    this.log("stopped");
+  }
+
+  private enqueue(ev: LarkMessageEvent): void {
+    const dedupId = ev.event_id ?? ev.message_id ?? ev.id;
+    if (dedupId) {
+      if (this.seen.has(dedupId)) return;
+      this.remember(dedupId);
+    }
+    const chatId = ev.chat_id ?? "(unknown)";
+    const prev = this.chains.get(chatId) ?? Promise.resolve();
+    const next = prev
+      .then(() => this.handle(ev))
+      .catch((err) => this.log(`handle error: ${(err as Error).message}`));
+    this.chains.set(chatId, next);
+  }
+
+  private async handle(ev: LarkMessageEvent): Promise<void> {
+    // 锁定主人：toolIdentity=user 时 bot 会以主人身份操作其私有数据，必须确认发件人就是主人，
+    // 否则任何人 DM 都能借 bot 之手读/动主人的东西。ownerOpenId 留空 = 不限制（仅自用可空）。
+    if (this.cfg.ownerOpenId && ev.sender_id && ev.sender_id !== this.cfg.ownerOpenId) {
+      this.log(`ignored message from non-owner ${ev.sender_id}`);
+      return;
+    }
+    if (!this.cfg.respondInGroups && ev.chat_type === "group") return;
+
+    const messageId = ev.message_id ?? ev.id;
+    const chatId = ev.chat_id;
+    const content = (ev.content ?? "").trim();
+    if (!messageId || !chatId || content.length === 0) return;
+
+    const mt = ev.message_type ?? "text";
+    if (mt !== "text" && mt !== "post") {
+      await replyMessage(this.cfg, messageId, `暂时只支持文本消息（收到 ${mt}）。`, {
+        ...(ev.event_id ? { idempotencyKey: ev.event_id } : {}),
+      });
+      return;
+    }
+
+    this.log(`← [${chatId}] ${mt} ${content.length}ch: ${content.slice(0, 80)}`);
+
+    const session = this.getSession(chatId);
+    let reply: string;
+    let turns = 0;
+    try {
+      const summary = await session.run(content);
+      turns = summary.turns;
+      reply = extractText(summary.lastMessage) || "（已处理）";
+    } catch (err) {
+      this.log(`agent run error for ${chatId}: ${(err as Error).message}`);
+      reply = `处理出错了：${(err as Error).message}`;
+    }
+
+    const res = await replyMessage(this.cfg, messageId, reply, {
+      ...(ev.event_id ? { idempotencyKey: ev.event_id } : {}),
+    });
+    this.log(
+      `→ [${chatId}] replied ${reply.length}ch turns=${turns} ${res.ok ? "ok" : `FAIL: ${res.stderr || res.stdout}`}`,
+    );
+  }
+
+  private getSession(chatId: string): AgentSession {
+    const existing = this.sessions.get(chatId);
+    if (existing) {
+      this.touchLru(chatId);
+      return existing;
+    }
+    const session = createBotSession(this.cfg, this.model, [...this.tools], this.memory, this.obs);
+    this.sessions.set(chatId, session);
+    this.chatLru.push(chatId);
+    this.evictSessions(chatId);
+    return session;
+  }
+
+  private touchLru(chatId: string): void {
+    const i = this.chatLru.indexOf(chatId);
+    if (i >= 0) this.chatLru.splice(i, 1);
+    this.chatLru.push(chatId);
+  }
+
+  private evictSessions(keep: string): void {
+    while (this.chatLru.length > this.cfg.maxSessions) {
+      const victim = this.chatLru.shift();
+      if (!victim || victim === keep) continue;
+      this.sessions.delete(victim);
+      this.chains.delete(victim);
+    }
+  }
+
+  private remember(id: string): void {
+    this.seen.add(id);
+    this.seenOrder.push(id);
+    while (this.seenOrder.length > this.cfg.dedupCapacity) {
+      const old = this.seenOrder.shift();
+      if (old) this.seen.delete(old);
+    }
+  }
+}

--- a/apps/lark-bot/src/config.ts
+++ b/apps/lark-bot/src/config.ts
@@ -1,0 +1,146 @@
+/**
+ * lark-bot 运行配置。全部从环境变量读，给足默认值——零配置也能起（只要有
+ * DEEPSEEK_API_KEY + 一个已就绪的飞书 bot 身份）。
+ */
+
+export type Identity = "bot" | "user";
+
+type Env = Record<string, string | undefined>;
+
+export interface BotConfig {
+  /** pi-ai 模型 spec：`provider:modelId`。默认 deepseek-v4-flash。 */
+  modelSpec: string;
+  /** 订阅的事件 key。默认接收 IM 消息。 */
+  eventKey: string;
+  /** 事件消费 + 默认回复的身份。bot（机器人是对话里的实体）。 */
+  identity: Identity;
+  /** lark_cli 工具默认身份。user = 代表主人本人访问其私有数据（消息/文档/日历/邮件/任务）。
+   *  agent 可按调用覆盖（如以 bot 名义发消息）。 */
+  toolIdentity: Identity;
+  /** 仅响应该 open_id（ou_…）发来的消息；设了即过滤其他发件人。user 身份代表主人操作，
+   *  必须锁定本人，否则别人 DM 也会被以主人身份执行。空 = 不限制（仅自用时可空）。 */
+  ownerOpenId: string | undefined;
+  /** 观测/评测数据落盘目录（sessionLog trace + metrics NDJSON）。 */
+  dataDir: string;
+  /** 是否挂观测插件（sessionLog/metrics/costTracker/toolStats）。默认 true。 */
+  telemetry: boolean;
+  /** lark-cli 可执行文件名/路径。 */
+  larkCliBin: string;
+  /** 系统提示词——只管人设/性格/身份。"怎么做" 不写死，靠交互 + 记忆沉淀涌现。 */
+  systemPrompt: string;
+  /** 自生长记忆文件（markdown）。bot 用 remember 工具往里沉淀，每轮注入回 prompt。可手动编辑。 */
+  memoryFile: string;
+  /** 单轮对话最大 turn 数（防失控）。 */
+  maxTurns: number;
+  /** 是否响应群消息。v1 默认 false（只回私聊，避免群里刷屏 + 回环）。 */
+  respondInGroups: boolean;
+  /** 去重窗口容量（按 event_id 去重，飞书会重投）。 */
+  dedupCapacity: number;
+  /** 缓存的会话数上限（按 chat 维度，LRU 淘汰，控内存）。 */
+  maxSessions: number;
+  /** 单次 lark-cli 调用超时（ms）。 */
+  toolTimeoutMs: number;
+  /** 工具输出回灌给 LLM 的字符上限（防 context 爆）。 */
+  toolOutputCap: number;
+  /** 允许 lark_cli 工具调用的命令家族白名单（首 token）。 */
+  allowedFamilies: string[];
+  /** 是否允许破坏性命令（默认 false：撞 destructivePatterns 直接拦）。 */
+  allowDestructive: boolean;
+  /** 破坏性命令子串黑名单（小写匹配整条 args）。 */
+  destructivePatterns: string[];
+}
+
+/** bot 身份可安全驱动的命令家族（读 + 编排 + 发送）。刻意不含 auth/event/config 等
+ *  会动到 bot 自身管线或凭证的家族。 */
+const DEFAULT_ALLOWED_FAMILIES = [
+  "im",
+  "docx",
+  "docs",
+  "sheets",
+  "base",
+  "calendar",
+  "mail",
+  "task",
+  "wiki",
+  "drive",
+  "contact",
+  "vc",
+  "minutes",
+  "approval",
+  "board",
+  "whiteboard",
+  "okr",
+  "attendance",
+  "slides",
+  "search",
+];
+
+const DEFAULT_DESTRUCTIVE = [
+  "delete",
+  "disband",
+  "recall",
+  "remove",
+  "logout",
+  "revoke",
+  "--purge",
+];
+
+/**
+ * 人设 prompt——**只**定义"我是谁、什么性格"，不写"该怎么做"的细则（资源在哪、命令怎么拼、
+ * 失败怎么兜底都不写）。这些靠日常交互 + 记忆沉淀涌现。能力只点到为止，让它自己探、自己记。
+ */
+const DEFAULT_SYSTEM_PROMPT = [
+  "你是 Chasey（叶炜鸿）的私人飞书助手——他「Agent OS」的对话门面。跑在 harness-pi 内核上，大脑是 deepseek-v4-flash。",
+  "",
+  "你的本事：一套 lark-cli 全家桶工具，可用 `user` 身份代表主人操作他的飞书（消息、文档、日历、邮件、任务、多维表、知识库…），或 `bot` 身份以助手名义行事；还能用 `remember` 把学到的东西记下来。",
+  "",
+  "你的性格与做事方式：",
+  "- 中文，简洁，先给结论。",
+  "- 诚实第一：不知道、没查到、没权限，就直说，绝不编。",
+  "- 不熟的事先自己探查飞书（搜文档、列日程、看 `--help`），别张口就猜。",
+  "- 被主人纠正、或摸清了某类事该怎么查/怎么做，就用 `remember` 沉淀下来——下次直接照做，越用越懂主人。",
+].join("\n");
+
+function readNumber(env: Env, key: string, fallback: number): number {
+  const raw = env[key];
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function readBool(env: Env, key: string, fallback: boolean): boolean {
+  const raw = env[key];
+  if (raw === undefined) return fallback;
+  return /^(1|true|yes|on)$/i.test(raw.trim());
+}
+
+export function loadConfig(env: Env = process.env): BotConfig {
+  const identityRaw = env.LARK_BOT_IDENTITY?.trim();
+  const toolIdentityRaw = env.LARK_BOT_TOOL_IDENTITY?.trim();
+  const dataDir = env.LARK_BOT_DATA_DIR?.trim() || "data";
+  const families = env.LARK_BOT_ALLOWED_FAMILIES?.split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  return {
+    modelSpec: env.LARK_BOT_MODEL?.trim() || "deepseek:deepseek-v4-flash",
+    eventKey: env.LARK_BOT_EVENT_KEY?.trim() || "im.message.receive_v1",
+    identity: identityRaw === "user" ? "user" : "bot",
+    toolIdentity: toolIdentityRaw === "bot" ? "bot" : "user",
+    ownerOpenId: env.LARK_BOT_OWNER_OPEN_ID?.trim() || undefined,
+    dataDir,
+    telemetry: readBool(env, "LARK_BOT_TELEMETRY", true),
+    larkCliBin: env.LARK_BOT_CLI?.trim() || "lark-cli",
+    systemPrompt: env.LARK_BOT_SYSTEM_PROMPT?.trim() || DEFAULT_SYSTEM_PROMPT,
+    memoryFile: env.LARK_BOT_MEMORY_FILE?.trim() || `${dataDir}/memory.md`,
+    maxTurns: readNumber(env, "LARK_BOT_MAX_TURNS", 24),
+    respondInGroups: readBool(env, "LARK_BOT_GROUPS", false),
+    dedupCapacity: readNumber(env, "LARK_BOT_DEDUP", 2000),
+    maxSessions: readNumber(env, "LARK_BOT_MAX_SESSIONS", 50),
+    toolTimeoutMs: readNumber(env, "LARK_BOT_TOOL_TIMEOUT_MS", 60_000),
+    toolOutputCap: readNumber(env, "LARK_BOT_TOOL_OUTPUT_CAP", 12_000),
+    allowedFamilies: families && families.length > 0 ? families : DEFAULT_ALLOWED_FAMILIES,
+    allowDestructive: readBool(env, "LARK_BOT_ALLOW_DESTRUCTIVE", false),
+    destructivePatterns: DEFAULT_DESTRUCTIVE,
+  };
+}

--- a/apps/lark-bot/src/index.ts
+++ b/apps/lark-bot/src/index.ts
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+/**
+ * lark-bot 入口：装配配置 → 起 bot → 常驻。SIGINT/SIGTERM 优雅退出。
+ */
+
+import { loadConfig } from "./config.js";
+import { LarkBot } from "./bot.js";
+
+async function main(): Promise<void> {
+  const cfg = loadConfig();
+  const bot = new LarkBot(cfg); // resolveModel 可能在此 throw（缺 key/未知 model）
+
+  const ac = new AbortController();
+  for (const sig of ["SIGINT", "SIGTERM"] as const) {
+    process.on(sig, () => {
+      console.error(`[lark-bot] ${sig} received, shutting down…`);
+      ac.abort();
+    });
+  }
+
+  await bot.start(ac.signal);
+}
+
+main().catch((err: unknown) => {
+  console.error(`[lark-bot] fatal: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+});

--- a/apps/lark-bot/src/lark.ts
+++ b/apps/lark-bot/src/lark.ts
@@ -1,0 +1,190 @@
+/**
+ * lark-cli 进出封装：
+ * - runLarkCli：一次性命令（execFile，参数数组，无 shell 注入面）
+ * - replyMessage / sendMessage：回复 / 主动发
+ * - consumeEvents：spawn `event consume`，把 stdout 的 NDJSON 逐行解析成事件
+ *
+ * 全部通过 lark-cli，不直接依赖飞书 SDK——契合「lark-cli 全家桶」路线，服务器上只需
+ * 一个 lark-cli + 已配好的 bot 凭证。
+ */
+
+import { execFile, spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+import { promisify } from "node:util";
+import type { BotConfig } from "./config.js";
+
+const execFileAsync = promisify(execFile);
+
+/** im.message.receive_v1 的事件载荷（字段对齐 `lark-cli event schema`）。全 optional——
+ *  消费端按存在性判定，容忍 lark-cli 输出形态的细微差异。 */
+export interface LarkMessageEvent {
+  type?: string;
+  event_id?: string;
+  message_id?: string;
+  /** message_id 的 legacy 别名。 */
+  id?: string;
+  chat_id?: string;
+  chat_type?: string; // "p2p" | "group"
+  /** 大多数类型已是渲染好的纯文本；interactive(卡片) 才是原始 JSON 串。 */
+  content?: string;
+  message_type?: string;
+  sender_id?: string;
+  create_time?: string;
+  timestamp?: string;
+}
+
+export interface LarkCliResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  code: number | null;
+}
+
+export interface RunOptions {
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+/** 跑一条 lark-cli 命令。永不 throw（除非 spawn 本身失败如 ENOENT）；非零退出以 ok:false 返回，
+ *  把 stdout/stderr 都带回，方便调用方（工具）让 LLM 自纠。 */
+export async function runLarkCli(
+  cfg: BotConfig,
+  args: string[],
+  opts: RunOptions = {},
+): Promise<LarkCliResult> {
+  try {
+    const { stdout, stderr } = await execFileAsync(cfg.larkCliBin, args, {
+      timeout: opts.timeoutMs ?? cfg.toolTimeoutMs,
+      maxBuffer: 16 * 1024 * 1024,
+      ...(opts.signal ? { signal: opts.signal } : {}),
+    });
+    return { ok: true, stdout: stdout.toString(), stderr: stderr.toString(), code: 0 };
+  } catch (err) {
+    const e = err as { stdout?: string | Buffer; stderr?: string | Buffer; code?: number | string; message?: string };
+    return {
+      ok: false,
+      stdout: e.stdout?.toString() ?? "",
+      stderr: e.stderr?.toString() ?? e.message ?? String(err),
+      code: typeof e.code === "number" ? e.code : null,
+    };
+  }
+}
+
+export interface SendOptions {
+  markdown?: boolean;
+  idempotencyKey?: string;
+}
+
+/** 回复某条消息（线程外，回到主对话）。 */
+export function replyMessage(
+  cfg: BotConfig,
+  messageId: string,
+  text: string,
+  opts: SendOptions = {},
+): Promise<LarkCliResult> {
+  const args = ["im", "+messages-reply", "--as", cfg.identity, "--message-id", messageId];
+  args.push(opts.markdown ? "--markdown" : "--text", text);
+  if (opts.idempotencyKey) args.push("--idempotency-key", opts.idempotencyKey);
+  return runLarkCli(cfg, args);
+}
+
+/** 主动发消息到 chat(oc_) 或 user(ou_)。 */
+export function sendMessage(
+  cfg: BotConfig,
+  target: { chatId?: string; userId?: string },
+  text: string,
+  opts: SendOptions = {},
+): Promise<LarkCliResult> {
+  const args = ["im", "+messages-send", "--as", cfg.identity];
+  if (target.userId) args.push("--user-id", target.userId);
+  else if (target.chatId) args.push("--chat-id", target.chatId);
+  args.push(opts.markdown ? "--markdown" : "--text", text);
+  if (opts.idempotencyKey) args.push("--idempotency-key", opts.idempotencyKey);
+  return runLarkCli(cfg, args);
+}
+
+/** NDJSON 行可能是事件对象本身，也可能裹在 event/data/payload 下——逐层探测，取第一个含消息字段的。 */
+function extractEvent(raw: unknown): LarkMessageEvent | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const obj = raw as Record<string, unknown>;
+  const nested = [obj.event, obj.data, obj.payload].filter(
+    (c): c is Record<string, unknown> => !!c && typeof c === "object",
+  );
+  for (const c of [obj, ...nested]) {
+    if (
+      typeof c.message_id === "string" ||
+      typeof c.chat_id === "string" ||
+      typeof c.content === "string"
+    ) {
+      return c as LarkMessageEvent;
+    }
+  }
+  return undefined;
+}
+
+export interface ConsumeHandlers {
+  onEvent: (ev: LarkMessageEvent) => void;
+  onLog?: (msg: string) => void;
+}
+
+/**
+ * spawn `lark-cli event consume <key>` 并把 stdout 的 NDJSON 逐行喂给 onEvent。
+ * Promise 在子进程退出时 resolve（正常退出/超时）——交给上层做带退避的重启（lifecycle）。
+ * 子进程 spawn 失败（如 ENOENT）reject。signal abort 时 SIGTERM 子进程。
+ */
+export function consumeEvents(
+  cfg: BotConfig,
+  handlers: ConsumeHandlers,
+  signal: AbortSignal,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    // stdin 必须是常开的 pipe：`event consume` 把 stdin EOF 当关闭信号（专为 AI 子进程设计）。
+    // 用 "ignore"(=/dev/null) 会立刻 EOF 导致一连上就退出；"pipe" 让父进程持住写端，
+    // 子进程的 stdin 一直开着，长连接得以常驻。关停走 SIGTERM（onAbort）。
+    const child = spawn(cfg.larkCliBin, ["event", "consume", cfg.eventKey, "--as", cfg.identity], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    // 子进程退出时父持的写端会 EPIPE；吞掉，避免 unhandled 'error'。
+    child.stdin?.on("error", () => {});
+    let settled = false;
+    const finish = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener("abort", onAbort);
+      fn();
+    };
+    const onAbort = () => {
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        /* already gone */
+      }
+    };
+    if (signal.aborted) onAbort();
+    else signal.addEventListener("abort", onAbort, { once: true });
+
+    if (child.stdout) {
+      const rl = createInterface({ input: child.stdout });
+      rl.on("line", (line) => {
+        const trimmed = line.trim();
+        if (trimmed.length === 0) return;
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(trimmed);
+        } catch {
+          handlers.onLog?.(`[consume:non-json] ${trimmed.slice(0, 200)}`);
+          return;
+        }
+        const ev = extractEvent(parsed);
+        if (ev) handlers.onEvent(ev);
+      });
+    }
+    if (child.stderr) {
+      const erl = createInterface({ input: child.stderr });
+      erl.on("line", (line) => handlers.onLog?.(`[consume:stderr] ${line}`));
+    }
+
+    child.on("error", (err) => finish(() => reject(err)));
+    child.on("close", () => finish(() => resolve()));
+  });
+}

--- a/apps/lark-bot/src/memory.ts
+++ b/apps/lark-bot/src/memory.ts
@@ -1,0 +1,50 @@
+/**
+ * 自生长记忆：极简的 append-only markdown。bot 用 `remember` 工具往里沉淀（探到的资源位置、
+ * 有效命令配方、主人偏好、被纠正后的正确做法…），每轮 LLM 调用前把全文注入 prompt。
+ *
+ * 刻意不做相关性检索 / 自动裁剪——先 load 全量，量真的大了再上 Engram 那套。文件是 markdown，
+ * 人也能直接读和编辑。这是 bot「越用越聪明」的载体，不是我写死的地图。
+ */
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+const HEADER = [
+  "# lark-bot 记忆",
+  "",
+  "bot 自己沉淀的：资源在哪、命令怎么拼、主人偏好。也可手动编辑。",
+  "",
+  "",
+].join("\n");
+
+export class MemoryStore {
+  private readonly file: string;
+
+  constructor(file: string) {
+    this.file = file;
+  }
+
+  get path(): string {
+    return this.file;
+  }
+
+  /** 当前记忆全文（无 / 读失败则空串）。 */
+  load(): string {
+    try {
+      return existsSync(this.file) ? readFileSync(this.file, "utf8").trim() : "";
+    } catch {
+      return "";
+    }
+  }
+
+  /** 追加一条沉淀（带 ISO 时间戳 + 可选 tag 的 markdown 项）。返回写入的那行（供工具回执）。 */
+  append(note: string, tags: string[] = []): string {
+    const clean = note.trim();
+    if (clean.length === 0) return "";
+    mkdirSync(dirname(this.file), { recursive: true });
+    const tagStr = tags.length > 0 ? ` ${tags.map((t) => `#${t.trim()}`).join(" ")}` : "";
+    const line = `- [${new Date().toISOString()}]${tagStr} ${clean}`;
+    appendFileSync(this.file, `${existsSync(this.file) ? "" : HEADER}${line}\n`, "utf8");
+    return line;
+  }
+}

--- a/apps/lark-bot/src/tools.ts
+++ b/apps/lark-bot/src/tools.ts
@@ -1,0 +1,147 @@
+/**
+ * 暴露给 agent 的工具：
+ * - lark_cli：通用闸口，按家族白名单放行任意 lark-cli 命令（默认 user 身份），破坏性命令拦截。
+ * - lark_send_message：主动发消息的强类型便捷封装。
+ * - remember：把学到的东西沉淀进记忆（资源位置 / 有效命令 / 主人偏好），下次自动带回 prompt。
+ *
+ * 注意：回复「当前对话」不靠工具——bot 主循环把 agent 最终文本当回复发回。工具只用于
+ * 额外动作（探查、发到别处、沉淀记忆……）。
+ */
+
+import { Type, type HarnessTool, type ToolExecResult } from "@harness-pi/core";
+import { runLarkCli } from "./lark.js";
+import type { BotConfig, Identity } from "./config.js";
+import type { MemoryStore } from "./memory.js";
+
+function asText(text: string): ToolExecResult {
+  return { content: [{ type: "text", text }] };
+}
+
+function cap(text: string, limit: number): string {
+  if (text.length <= limit) return text;
+  return `${text.slice(0, limit)}\n…[truncated ${text.length - limit} chars]`;
+}
+
+/** 把工具传入的 identity 收敛成合法身份；非法/缺省走 fallback。 */
+function pickIdentity(raw: unknown, fallback: Identity): Identity {
+  const v = String(raw ?? "").trim();
+  return v === "bot" || v === "user" ? v : fallback;
+}
+
+export function createLarkTools(cfg: BotConfig, memory: MemoryStore): HarnessTool[] {
+  const larkCli: HarnessTool = {
+    name: "lark_cli",
+    label: "lark-cli",
+    description: [
+      "Run a lark-cli (Feishu/Lark) command and return its output. Pass the full argument list AFTER `lark-cli` as a string array.",
+      `Allowed command families (first arg): ${cfg.allowedFamilies.join(", ")}.`,
+      "Two identities — pick via the `identity` field:",
+      "  user (default) = act as the OWNER; use to READ the owner's own data (messages, docs, calendar, mail, tasks, …).",
+      "  bot            = act as the assistant; use to send/operate as the bot itself.",
+      "Examples:",
+      '  owner\'s agenda:          args=["calendar","+agenda"] identity="user"',
+      '  search owner\'s messages: args=["im","+messages-search","--query","面试"] identity="user"',
+      '  send as the assistant:   args=["im","+messages-send","--chat-id","oc_x","--text","hi"] identity="bot"',
+      '  learn a command:         args=["calendar","--help"]',
+      "On failure lark-cli returns JSON with error.hint — read it and retry with corrected args.",
+    ].join("\n"),
+    parameters: Type.Object({
+      args: Type.Array(Type.String(), {
+        description: 'Argument list passed to lark-cli, e.g. ["im","+messages-search","--query","面试"]',
+      }),
+      identity: Type.Optional(
+        Type.String({ description: 'lark-cli identity: "user" (owner data, default) or "bot"' }),
+      ),
+    }),
+    async execute(input, _ctx, signal): Promise<ToolExecResult> {
+      const args = Array.isArray(input.args) ? (input.args as unknown[]).map((a) => String(a)) : [];
+      const family = args[0];
+      if (!family) return asText("Error: empty args — provide at least a command family.");
+      if (!cfg.allowedFamilies.includes(family)) {
+        return asText(
+          `Error: command family "${family}" is not allowed. Allowed: ${cfg.allowedFamilies.join(", ")}.`,
+        );
+      }
+      if (!cfg.allowDestructive) {
+        const joined = args.join(" ").toLowerCase();
+        const hit = cfg.destructivePatterns.find((p) => joined.includes(p));
+        if (hit) {
+          return asText(
+            `Error: blocked a potentially destructive command (matched "${hit}"). Ask the user to run it manually.`,
+          );
+        }
+      }
+      // 身份：调用方 identity 优先，否则 cfg.toolIdentity（默认 user）。已显式带 --as 则尊重原样。
+      const identity = pickIdentity(input.identity, cfg.toolIdentity);
+      const finalArgs = args.includes("--as") ? args : [...args, "--as", identity];
+      const res = await runLarkCli(cfg, finalArgs, { timeoutMs: cfg.toolTimeoutMs, signal });
+      const body = res.ok
+        ? res.stdout.trim() || "(no output)"
+        : `exit=${res.code ?? "n/a"}\nSTDOUT:\n${res.stdout}\nSTDERR:\n${res.stderr}`;
+      return asText(cap(body, cfg.toolOutputCap));
+    },
+  };
+
+  const sendMessage: HarnessTool = {
+    name: "lark_send_message",
+    label: "send message",
+    description:
+      "Proactively send a Feishu message to a chat (oc_…) or a user (ou_…). Use only to message somewhere OTHER than the current conversation — to reply here, just write your final answer. identity defaults to bot (send as the assistant); use user to send as the owner themselves.",
+    parameters: Type.Object({
+      target: Type.String({ description: "Destination: chat id oc_… or user open_id ou_…" }),
+      text: Type.String({ description: "Message body" }),
+      markdown: Type.Optional(
+        Type.Boolean({ description: "Render as markdown/post instead of plain text" }),
+      ),
+      identity: Type.Optional(
+        Type.String({ description: 'lark-cli identity: "bot" (default, as the assistant) or "user"' }),
+      ),
+    }),
+    async execute(input, _ctx, signal): Promise<ToolExecResult> {
+      const target = String(input.target ?? "").trim();
+      const body = String(input.text ?? "");
+      if (!target || body.length === 0) return asText("Error: both target and text are required.");
+      const isUser = target.startsWith("ou_");
+      const identity = pickIdentity(input.identity, cfg.identity);
+      const args = [
+        "im",
+        "+messages-send",
+        "--as",
+        identity,
+        isUser ? "--user-id" : "--chat-id",
+        target,
+        input.markdown ? "--markdown" : "--text",
+        body,
+      ];
+      const res = await runLarkCli(cfg, args, { timeoutMs: cfg.toolTimeoutMs, signal });
+      return asText(
+        res.ok ? `Sent to ${target}.` : `Failed (exit=${res.code ?? "n/a"}): ${res.stderr || res.stdout}`,
+      );
+    },
+  };
+
+  const remember: HarnessTool = {
+    name: "remember",
+    label: "remember",
+    description: [
+      "Persist a durable note to your long-term memory. Your memory is injected into every future conversation, so this is how you get smarter over time.",
+      "Record things worth reusing: WHERE the owner's data lives (e.g. an interview Base token + table id you discovered), command recipes that worked, the owner's preferences, and corrections the owner gave you.",
+      "Write one concise, self-contained fact per call (include concrete ids/tokens so future-you can act on it directly). Don't record one-off chatter.",
+    ].join("\n"),
+    parameters: Type.Object({
+      note: Type.String({ description: "The fact to remember — concise and self-contained, with concrete ids/commands." }),
+      tags: Type.Optional(
+        Type.Array(Type.String(), { description: 'Optional tags, e.g. ["resource","面试"] or ["preference"]' }),
+      ),
+    }),
+    async execute(input): Promise<ToolExecResult> {
+      const note = String(input.note ?? "").trim();
+      if (note.length === 0) return asText("Error: note is required.");
+      const tags = Array.isArray(input.tags) ? (input.tags as unknown[]).map((t) => String(t)) : [];
+      const line = memory.append(note, tags);
+      return asText(`Remembered: ${line}`);
+    },
+  };
+
+  return [larkCli, sendMessage, remember];
+}

--- a/apps/lark-bot/tsconfig.json
+++ b/apps/lark-bot/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -149,7 +149,7 @@ Hot path 上的 plugin **只允许同步操作或 push-to-queue**。需要持久
 
 详见 [roadmap](roadmap.md)。
 
-当前风险：尚无外部 production 用户；`message_update` / streaming thinking、完整 auto-compaction、PG metrics sink、`ctx.state` hardening 仍是后续工作。
+当前风险：核心机制已实现并有测试覆盖（`message_update` 渐进式 streaming、auto-compaction、PG metrics sink、`ctx.state` slot API 均已落地），但**尚无外部 production 用户**——真 LLM provider 的 streaming/error/overflow smoke、`bidding-agent` 真实迁移 spike 都还没做（成熟度三层详见 [README](../README.md)「当前状态」）。
 
 ## 8. 下一步
 

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -4,7 +4,7 @@
 
 ## 1. 一句话定位
 
-**harness-pi 是给后端 / 服务端 / headless agent 的运行时基础设施**，建立在 [`@mariozechner/pi-ai`](https://github.com/badlogic/pi-mono/tree/main/packages/ai) 之上，提供 hook 系统、生命周期管理、metrics、Context 注入、基础 coding tools、并行编排等"驾驭 agent 所必需的东西"——而把 agent 内核保持最小。
+**harness-pi 是给后端 / 服务端 / headless agent 的运行时基础设施**，建立在 [`@earendil-works/pi-ai`](https://github.com/badlogic/pi-mono/tree/main/packages/ai) 之上，提供 hook 系统、生命周期管理、metrics、Context 注入、基础 coding tools、并行编排等"驾驭 agent 所必需的东西"——而把 agent 内核保持最小。
 
 ## 2. 谁该用 harness-pi
 
@@ -30,14 +30,14 @@ pi-mono 是三层独立的 package。我们消费 L1，**不**消费 L2，跟 L3
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│   @mariozechner/pi-ai —— unified LLM API + tool spec    │  L1  ← 我们 100% 依赖
+│   @earendil-works/pi-ai —— unified LLM API + tool spec  │  L1  ← 我们 100% 依赖
 ├──────────────────────────┬──────────────────────────────┤
-│  @mariozechner/          │  @harness-pi/core            │  L2
+│  @earendil-works/        │  @harness-pi/core            │  L2
 │    pi-agent-core         │  (我们自己写 kernel，hook 一  │
 │  (Mario 的 agent 内核，   │   等公民)                     │
 │   observer pattern)      │                               │
 ├──────────────────────────┼──────────────────────────────┤
-│  @mariozechner/          │  @harness-pi/plugins         │  L3
+│  @earendil-works/        │  @harness-pi/plugins         │  L3
 │    pi-coding-agent       │  (watchdog / metrics / ...)  │
 │  (终端编码 agent)         │                               │
 └──────────────────────────┴──────────────────────────────┘
@@ -49,7 +49,7 @@ pi-mono 是三层独立的 package。我们消费 L1，**不**消费 L2，跟 L3
 **社交契约**：
 
 - 不动 pi-mono 一行代码
-- README 写明 "Built on `@mariozechner/pi-ai`. Inspired by pi-coding-agent's philosophy. Not affiliated."
+- README 写明 "Built on `@earendil-works/pi-ai`. Inspired by pi-coding-agent's philosophy. Not affiliated."
 - 类比：**LangGraph 之于 LangChain Core / Remix 之于 React Router**——下游应用框架，明确站在上游肩膀上，不挑战上游
 
 ## 5. 设计哲学（按重要性排序）

--- a/docs/01-architecture.md
+++ b/docs/01-architecture.md
@@ -24,7 +24,7 @@
 └──────────────────────────────────────────────────────────┘
                             ↓ 依赖
 ┌──────────────────────────────────────────────────────────┐
-│              @mariozechner/pi-ai (L1)                     │
+│              @earendil-works/pi-ai (L1)                     │
 │   stream · complete · Tool · Context · OAuth · ...       │
 └──────────────────────────────────────────────────────────┘
 ```
@@ -118,12 +118,12 @@ harness-pi/
                      ↓
 ┌───────────────────────────────────────────────┐
 │ @harness-pi/core                               │
-│  - dependencies: @mariozechner/pi-ai           │
+│  - dependencies: @earendil-works/pi-ai           │
 │  - 仅此一个 runtime dep                         │
 └────────────────────┬──────────────────────────┘
                      ↓
 ┌───────────────────────────────────────────────┐
-│ @mariozechner/pi-ai                            │
+│ @earendil-works/pi-ai                            │
 │  - 16 个 provider 适配 + OAuth + handoff       │
 └───────────────────────────────────────────────┘
 ```
@@ -277,7 +277,7 @@ grep -rE 'controllers/' packages/core/src/
     └── ...
 
 @harness-pi/core
-├── @mariozechner/pi-ai        (^0.53.0 or whatever current)
+├── @earendil-works/pi-ai        (^0.53.0 or whatever current)
 └── devDeps:
     ├── @types/node
     ├── typescript
@@ -291,7 +291,7 @@ grep -rE 'controllers/' packages/core/src/
 ```ts
 // ✅ Kernel 内部
 import { Hook } from "./hook.js";
-import { stream, getModel, type Context } from "@mariozechner/pi-ai";
+import { stream, getModel, type Context } from "@earendil-works/pi-ai";
 
 // ✅ Plugin 引用 kernel
 import type { Hook, HookContext, ToolDecision } from "@harness-pi/core";

--- a/docs/03-hook-system.md
+++ b/docs/03-hook-system.md
@@ -29,7 +29,7 @@ Hook 系统是 harness-pi 跟 [pi-agent-core](https://github.com/badlogic/pi-mon
 ## 2. Hook 接口定义
 
 ```ts
-import type { Message, AssistantMessage, ToolCall } from "@mariozechner/pi-ai";
+import type { Message, AssistantMessage, ToolCall } from "@earendil-works/pi-ai";
 import type { HookContext, HookResult, ToolExecResult, HarnessTool } from "@harness-pi/core";
 
 export interface Hook {

--- a/docs/05-plugins.md
+++ b/docs/05-plugins.md
@@ -265,7 +265,7 @@ Around (`wrapTurn`)——因为要在 LLM call 前改 messages view 但 turn 内
 
 ```ts
 import type { Hook, HookContext } from "@harness-pi/core";
-import type { Message } from "@mariozechner/pi-ai";
+import type { Message } from "@earendil-works/pi-ai";
 
 export interface TrimHistoryOptions {
   /** 最近 N 条 toolResult 保留原样。 */

--- a/docs/06-controllers.md
+++ b/docs/06-controllers.md
@@ -214,44 +214,34 @@ export interface WorkPoolOptions<I extends WorkItem> {
   maxConcurrency?: number;
   /** 单 group 完成时回调（用于 progress UI / metric）。 */
   onGroupComplete?: (groupId: string, summary: RunSummary) => void;
+  /** 单 group 失败（factory 抛或 run 抛）回调。 */
+  onGroupError?: (groupId: string, err: Error) => void;
+  /** abort 时未启动的 group 被跳过的回调（与 complete/error 对称，保证每个 group 都有终态信号）。 */
+  onGroupSkipped?: (groupId: string, reason: "aborted") => void;
 }
 
 export interface WorkPoolResult {
-  groups: Array<{ id: string; summary: RunSummary }>;
+  /** 每个 group 恰一条终态：summary（完成）/ error（失败）/ skipped（abort 时未启动）。 */
+  groups: Array<{ id: string; summary?: RunSummary; error?: Error; skipped?: "aborted" }>;
   totalItems: number;
+  completedGroups: number;
+  failedGroups: number;
+  /** abort 时未启动而被给终态的 group 数。completed+failed+skipped === groups 总数。 */
+  skippedGroups: number;
 }
 
 export class WorkPool<I extends WorkItem> {
   constructor(private opts: WorkPoolOptions<I>) {}
 
   async start(signal?: AbortSignal): Promise<WorkPoolResult> {
-    const groups = this.opts.partition(this.opts.items);
-    const concurrency = this.opts.maxConcurrency ?? groups.length;
-
-    const results: Array<{ id: string; summary: RunSummary }> = [];
-    const queue = [...groups];
-    const running = new Set<Promise<void>>();
-
-    while (queue.length > 0 || running.size > 0) {
-      if (signal?.aborted) break;
-      while (running.size < concurrency && queue.length > 0) {
-        const group = queue.shift()!;
-        const task = this.runGroup(group, signal).then(summary => {
-          results.push({ id: group.id, summary });
-          this.opts.onGroupComplete?.(group.id, summary);
-        });
-        running.add(task);
-        task.finally(() => running.delete(task));
-      }
-      await Promise.race(running);
-    }
-
-    return { groups: results, totalItems: this.opts.items.length };
-  }
-
-  private async runGroup(group: { id: string; items: I[] }, signal?: AbortSignal): Promise<RunSummary> {
-    const { session, prompt } = await this.opts.workerFactory(group);
-    return session.run(prompt, { signal });
+    // 实现要点（已发布）：
+    // 1. partition → groups；queue = [...groups]；running = Set<Promise>。
+    // 2. while (queue 或 running 非空)：abort 则 break；否则把 queue 填到 maxConcurrency 并发跑。
+    //    每个 group：factory → session.run → push {summary} + onGroupComplete；抛错 → push {error} + onGroupError。
+    // 3. **abort 必给终态**：break 后先 allSettled drain 在跑的 worker（否则 caller 拿到不一致快照），
+    //    再 sweep queue 里未启动的 group → push {skipped:"aborted"} + skippedGroups++ + onGroupSkipped。
+    //    每个 group 恰一条终态；守恒：completedGroups + failedGroups + skippedGroups === groups 总数。
+    // ……见 packages/plugins/src/controllers/work-pool.ts。
   }
 }
 ```
@@ -366,30 +356,35 @@ export interface LeaseQueueOptions<I extends QueueItem> {
 }
 
 export interface LeaseQueueResult {
+  totalItems: number;
   completed: number;
   failed: number;
-  totalItems: number;
+  conflicted: number;
+  /** abort 后从未派发（或 abort 时回退）而被给终态的 item 数。 */
+  skipped: number;
 }
 
 export class LeaseQueue<I extends QueueItem> {
   constructor(private opts: LeaseQueueOptions<I>) {}
 
   async start(signal?: AbortSignal): Promise<LeaseQueueResult> {
-    // 实现要点：
-    // 1. pending queue + leases map
-    // 2. K 个 worker promise 并发
-    // 3. 每个 worker: while (queue 非空 && !signal.aborted)
-    //      lease = leaseNext()
+    // 实现要点（已发布）：
+    // 1. pending queue（单线程 event loop 下 shift/splice 在 await 之间原子，K worker 不竞态）
+    // 2. K 个 worker promise 并发：while (pending 非空 && !signal.aborted)
+    //      lease = 取队首 + attempts 计数
     //      session = factory(item, lease, { releaseLease })
-    //      summary = await session.run(prompt)
-    //      根据 summary + plugin 调用 releaseLease 的情况决定计数
-    // 4. 全部 worker exit → 返回汇总
-    throw new Error("TODO");
+    //      summary = await session.run(prompt, { signal })
+    //      status = releaseLease 优先；否则 summary.reason==="done" → done / 其余 → error
+    //      非 done 且 attempt < maxAttempts → 回退队尾重试；否则 finalize（单点裁决）
+    // 3. **abort 必给终态**：全部 worker exit 后，sweep pending 里残留的 item（从未派发 + abort
+    //    时回退的）统一 finalize 成 "skipped" —— 每个 item 恰 finalize 一次（worker 与 sweep 互斥）。
+    //    守恒：completed + failed + conflicted + skipped === totalItems，work item 不静默消失。
+    // ……见 packages/plugins/src/controllers/lease-queue.ts。
   }
 }
 ```
 
-完整实现参考 bidding-agent `question-pool.ts`（326 行）。
+完整实现见 `packages/plugins/src/controllers/lease-queue.ts`（abort 必给终态 + 守恒，已被 `controllers.test.ts` 的混合终态/守恒用例覆盖）。
 
 ### 5.5 跟 plugin 配合用法
 

--- a/docs/09-bidding-core-parity-design.md
+++ b/docs/09-bidding-core-parity-design.md
@@ -266,7 +266,7 @@ roadmap 已列 `sideQuestion` controller + `subAgent` tool factory。给 Hybrid 
 - ✅ #6 overflow 事件（`onContextOverflow`）+ #10 `compactRestartFresh`
 - ✅ #5 steering（`AgentSession.steer()` + `onSteer`，turn-start drain）
 - ✅ #7 fail-closed 分类 + #9 `permissionGate`（规则引擎骨架，domain 谓词由调用方给）
-- 🟡 #4 `PostgresSessionStore` ✅ ；**lifecycleRestart 从 store resume ⬜**（`AgentSession.resume()` 原语在，但没有 controller 把它接进「重启即续跑」流程——是 harness-pi 这边唯一未接的机制 glue）
+- ✅ #4 `PostgresSessionStore` ＋ **lifecycleRestart 从 store resume**（`LifecycleRestart` 的 `resume` 模式：每次（重）启走 `AgentSession.resume(store, sessionId, deps)` 从落盘历史续跑——「重启即续跑」已接通，与内存 `sessionFactory` 模式二选一）
 - ✅ #9 杂项：ctx.state slot API（TypedStateMap）、around-hook 超时（结论：不加内核机制，协作式 abort）、去 `questionId` domain 默认（lease-decision argField 必填）
 
 **Phase 3 — Hybrid 闭环**

--- a/examples/01-bare-kernel/package.json
+++ b/examples/01-bare-kernel/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@harness-pi/core": "workspace:*",
-    "@mariozechner/pi-ai": "^0.73.1"
+    "@earendil-works/pi-ai": "^0.74.2"
   },
   "devDependencies": {
     "tsx": "^4.0.0",

--- a/examples/02-with-plugins/package.json
+++ b/examples/02-with-plugins/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@harness-pi/core": "workspace:*",
     "@harness-pi/plugins": "workspace:*",
-    "@mariozechner/pi-ai": "^0.73.1"
+    "@earendil-works/pi-ai": "^0.74.2"
   },
   "devDependencies": {
     "tsx": "^4.0.0",

--- a/examples/04-batch-pipeline/package.json
+++ b/examples/04-batch-pipeline/package.json
@@ -14,7 +14,7 @@
     "@harness-pi/adapters": "workspace:*",
     "@harness-pi/core": "workspace:*",
     "@harness-pi/plugins": "workspace:*",
-    "@mariozechner/pi-ai": "^0.73.1"
+    "@earendil-works/pi-ai": "^0.74.2"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/examples/04-batch-pipeline/src/batch-pipeline.ts
+++ b/examples/04-batch-pipeline/src/batch-pipeline.ts
@@ -22,7 +22,7 @@ import {
   type SessionStore,
   type RunSummary,
 } from "@harness-pi/core";
-import type { Api, Model } from "@mariozechner/pi-ai";
+import type { Api, Model } from "@earendil-works/pi-ai";
 import { pipeline, type PipelineOutcome } from "@harness-pi/plugins/controllers";
 import { EventPump, type TransportSink } from "@harness-pi/adapters";
 

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@harness-pi/core": "workspace:*",
-    "@mariozechner/pi-ai": "^0.73.1"
+    "@earendil-works/pi-ai": "^0.74.2"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/adapters/src/__tests__/postgres-session-store.test.ts
+++ b/packages/adapters/src/__tests__/postgres-session-store.test.ts
@@ -51,6 +51,34 @@ describe("PostgresSessionStore specifics", () => {
     expect(b.seq).toBe(2);
   });
 
+  it("原子性：appendEntry/fork 各只发 1 条含写入的语句(单条 CTE → 同语句原子,无跨语句半成功窗口)", async () => {
+    // 用计数包装器证明结构性原子:每个操作的所有写入(entry/leaf/lineage)收进**一条**语句。
+    // 单条语句在 PG 是一个隐式事务,任一步失败整条回滚——这正是 #29 要消除的「INSERT 成、leaf 败」窗口。
+    const pg = newDb().adapters.createPg();
+    const pool = new pg.Pool();
+    let writeStmts = 0;
+    const counting: PgClient = {
+      query: (text: string, params?: unknown[]) => {
+        if (/INSERT|UPDATE|DELETE/i.test(text)) writeStmts++;
+        return pool.query(text, params);
+      },
+    };
+    const store = new PostgresSessionStore(counting);
+    await store.migrate();
+    const msg = (role: string): SessionEntry =>
+      ({ kind: "message", message: { role, content: "x" } } as never);
+
+    writeStmts = 0;
+    await store.appendEntry("s", msg("user"));
+    await store.appendEntry("s", msg("assistant"));
+    expect(writeStmts).toBe(2); // 每次 appendEntry 恰 1 条写语句(原先 entry-insert + leaf-upsert 两条)
+
+    const fromId = (await store.getPathToLeaf("s"))[0]!.id;
+    writeStmts = 0;
+    await store.fork("s", fromId);
+    expect(writeStmts).toBe(1); // fork 恰 1 条写语句(原先 entries + leaf + lineage 三条);getPathToLeaf 的 SELECT 不计
+  });
+
   it("persists jsonb entry content faithfully (terminal RunSummary deep round-trip)", async () => {
     const store = await freshStore();
     const terminal: SessionEntry = {

--- a/packages/adapters/src/postgres-session-store.ts
+++ b/packages/adapters/src/postgres-session-store.ts
@@ -7,12 +7,12 @@
  *
  * DDL 见导出的 `POSTGRES_SESSION_STORE_DDL`；`migrate()` 会执行它（IF NOT EXISTS，幂等）。
  *
- * **并发契约**：协议要求同一 sessionId 的 appendEntry / fork 串行。appendEntry 的 leaf+seq 现在
- * 并入 INSERT 自身的同一条语句（单条 INSERT...SELECT...RETURNING）读取，在该语句自己的快照里算出
- * parent_id 与 seq，**消除了原先 getLeafId + SELECT MAX 多次往返的 read-modify-write 窗口**。
- * `session_entries(session_id, seq)` 的 UNIQUE 约束仍是**跨进程真并发**写同一 session 的兜底
- * （协议本就禁止——同 session 的 append 由调用方串行）：并发写中撞号的一方插入失败，是兜底而非协调。
- * 不同 sessionId 之间可并发。
+ * **原子性 & 并发契约**：`appendEntry` 与 `fork` 各自是**单条 data-modifying CTE**——entry/entries 插入
+ * + leaf 指针 upsert（+ fork 的 lineage 写入）在同一条语句/同一隐式事务里完成,**任一步失败整条回滚**,
+ * 不留半成功数据（不依赖 HWM 重试自愈或 UNIQUE 兜底来收拾跨语句的中途失败）。parent_id/seq 在该语句
+ * 自身快照里算出。`session_entries(session_id, seq)` 的 UNIQUE 约束仍是**跨进程真并发**写同一 session 的
+ * 兜底（协议本就要求同 session 的 append/fork 由调用方串行）：并发撞号一方整条失败,是兜底而非协调。
+ * 不同 sessionId 之间可并发。真 PG 的原子性 + 真并发由 CI 的 postgres:16 集成测试覆盖（env-gated）。
  */
 
 import { randomUUID } from "node:crypto";
@@ -94,28 +94,32 @@ export class PostgresSessionStore implements SessionStore {
     entry: SessionEntry,
   ): Promise<StoredEntry> {
     const id = randomUUID();
-    // 单条 INSERT...SELECT...RETURNING：parent_id（当前 leaf）与 seq（MAX+1）在 INSERT 自身的
-    // 快照里算出并写入，消除原先 getLeafId + SELECT MAX 多次往返的 read-modify-write 窗口。
-    // leaf / max(seq) 用 FROM 子句的 LEFT JOIN（而非 SELECT-list 标量子查询）取值——两者在真 PG 等价
-    // （单行源 LEFT JOIN 恰产一行），但 pg-mem 会把 SELECT-list 里的标量子查询错当成 record 行包裹，
-    // 故走 FROM 子查询绕开模拟器这一限制，语义不变。
-    const insRes = await this.client.query(
-      `INSERT INTO session_entries (id, session_id, parent_id, seq, entry)
-       SELECT $1, $2, l.leaf_id, COALESCE(m.mx, 0) + 1, $3::jsonb
-       FROM (SELECT 1) AS one
-       LEFT JOIN (SELECT leaf_id FROM session_leaf WHERE session_id = $2) AS l ON true
-       LEFT JOIN (SELECT MAX(seq) AS mx FROM session_entries WHERE session_id = $2) AS m ON true
-       RETURNING parent_id, seq`,
+    // **单条 data-modifying CTE**：entry 插入(ins)+ leaf 指针 upsert(upd)在**同一条语句/同一隐式事务**
+    // 里完成,任一步失败整条回滚——彻底消除原先「INSERT 成、leaf upsert 败」留孤儿行/半成功的跨语句窗口
+    // （不再靠 HWM 重试自愈或 UNIQUE 兜底）。data-modifying CTE「无论是否被主查询引用都恰执行一次到完成」
+    // （PG 契约;pg-mem 实测同此行为,upd 虽不被最终 SELECT 引用仍会更新 leaf）。
+    // parent_id（当前 leaf）与 seq（MAX+1）仍在 ins 自身快照里算（FROM 子句 LEFT JOIN,绕开 pg-mem 对
+    // SELECT-list 标量子查询的限制,真 PG 等价）。
+    const res = await this.client.query(
+      `WITH ins AS (
+         INSERT INTO session_entries (id, session_id, parent_id, seq, entry)
+         SELECT $1, $2, l.leaf_id, COALESCE(m.mx, 0) + 1, $3::jsonb
+         FROM (SELECT 1) AS one
+         LEFT JOIN (SELECT leaf_id FROM session_leaf WHERE session_id = $2) AS l ON true
+         LEFT JOIN (SELECT MAX(seq) AS mx FROM session_entries WHERE session_id = $2) AS m ON true
+         RETURNING id, parent_id, seq
+       ), upd AS (
+         INSERT INTO session_leaf (session_id, leaf_id)
+         SELECT $2, id FROM ins
+         ON CONFLICT (session_id) DO UPDATE SET leaf_id = EXCLUDED.leaf_id
+         RETURNING leaf_id
+       )
+       SELECT parent_id, seq FROM ins`,
       [id, sessionId, JSON.stringify(entry)],
     );
-    const row = insRes.rows[0]!;
+    const row = res.rows[0]!;
     const parentId = row.parent_id === null ? null : String(row.parent_id);
     const seq = Number(row.seq);
-    await this.client.query(
-      `INSERT INTO session_leaf (session_id, leaf_id) VALUES ($1, $2)
-       ON CONFLICT (session_id) DO UPDATE SET leaf_id = EXCLUDED.leaf_id`,
-      [sessionId, id],
-    );
     return { id, parentId, seq, entry };
   }
 
@@ -171,7 +175,9 @@ export class PostgresSessionStore implements SessionStore {
     }
     const forkId = randomUUID();
 
-    // 批量复制前缀（新 id，重建 parent 链）—— 一条多行 INSERT，符合协议「fork 是批量插入」。
+    // **单条 data-modifying CTE**：批量插 entries(ins)+ leaf upsert(leaf)+ lineage 写入在同一条语句/
+    // 同一隐式事务里完成,任一步失败整条回滚——消除原先三条独立语句的半成功窗口（entries 落了但 leaf/
+    // lineage 没更新,且 fork 无 HWM 自愈）。三个 data-modifying CTE 各「无论是否被引用都恰执行一次到完成」。
     const tuples: string[] = [];
     const params: unknown[] = [];
     let p = 0;
@@ -181,21 +187,34 @@ export class PostgresSessionStore implements SessionStore {
       const id = randomUUID();
       tuples.push(`($${++p}, $${++p}, $${++p}, $${++p}, $${++p}::jsonb)`);
       params.push(id, forkId, prevId, ++seq, JSON.stringify(node.entry));
-      prevId = id;
+      prevId = id; // 循环结束后 = 最后一条 entry 的 id = fork 链的 leaf
     }
+    const pLeafSid = ++p;
+    const pLeafId = ++p;
+    params.push(forkId, prevId);
+    const pLinSid = ++p;
+    const pLinParent = ++p;
+    const pLinFrom = ++p;
+    params.push(forkId, sessionId, fromEntryId);
+    // 三个 INSERT 全做成 data-modifying CTE,**主查询用 SELECT**(而非 INSERT):data-modifying CTE
+    // 无论是否被主查询引用都恰执行一次到完成,故三条插入都会落地、且同语句原子。主查询必须是 SELECT——
+    // pg-mem 不支持「WITH ... 主查询为 INSERT」(× "WITH nested statement with query type 'insert'"),
+    // 真 PG 两种都支持;统一用 SELECT 主查询以同时兼容,语义不变。
     await this.client.query(
-      `INSERT INTO session_entries (id, session_id, parent_id, seq, entry) VALUES ${tuples.join(", ")}`,
+      `WITH ins AS (
+         INSERT INTO session_entries (id, session_id, parent_id, seq, entry) VALUES ${tuples.join(", ")}
+         RETURNING id
+       ), leaf AS (
+         INSERT INTO session_leaf (session_id, leaf_id) VALUES ($${pLeafSid}, $${pLeafId})
+         ON CONFLICT (session_id) DO UPDATE SET leaf_id = EXCLUDED.leaf_id
+         RETURNING leaf_id
+       ), lin AS (
+         INSERT INTO session_lineage (session_id, parent_session_id, from_entry_id)
+         VALUES ($${pLinSid}, $${pLinParent}, $${pLinFrom})
+         RETURNING session_id
+       )
+       SELECT id FROM ins`,
       params,
-    );
-    await this.client.query(
-      `INSERT INTO session_leaf (session_id, leaf_id) VALUES ($1, $2)
-       ON CONFLICT (session_id) DO UPDATE SET leaf_id = EXCLUDED.leaf_id`,
-      [forkId, prevId],
-    );
-    await this.client.query(
-      `INSERT INTO session_lineage (session_id, parent_session_id, from_entry_id)
-       VALUES ($1, $2, $3)`,
-      [forkId, sessionId, fromEntryId],
     );
     return forkId;
   }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -10,7 +10,7 @@
 pnpm add @harness-pi/core
 ```
 
-Peer: `@mariozechner/pi-ai` (model runtime, a dependency).
+Peer: `@earendil-works/pi-ai` (model runtime, a dependency).
 
 ## Quick start
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@mariozechner/pi-ai": "^0.73.1"
+    "@earendil-works/pi-ai": "^0.74.2"
   },
   "devDependencies": {
     "typescript": "^5.6.0",

--- a/packages/core/src/__tests__/around-hook-timeout.test.ts
+++ b/packages/core/src/__tests__/around-hook-timeout.test.ts
@@ -12,7 +12,7 @@
 import { describe, it, expect } from "vitest";
 import { AgentSession } from "../session.js";
 import { createFakeModel } from "../testing.js";
-import { Type } from "@mariozechner/pi-ai";
+import { Type } from "@earendil-works/pi-ai";
 import type { Hook } from "../hook.js";
 import type { HarnessTool } from "../types.js";
 

--- a/packages/core/src/__tests__/context-overflow.test.ts
+++ b/packages/core/src/__tests__/context-overflow.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Type } from "@mariozechner/pi-ai";
+import { Type } from "@earendil-works/pi-ai";
 import { AgentSession } from "../session.js";
 import { createFakeModel } from "../testing.js";
 import { defaultIsContextOverflow } from "../context-overflow.js";

--- a/packages/core/src/__tests__/edge-cases.test.ts
+++ b/packages/core/src/__tests__/edge-cases.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import { Type } from "@mariozechner/pi-ai";
+import { Type } from "@earendil-works/pi-ai";
 import { AgentSession } from "../session.js";
 import {
   HookDispatcher,

--- a/packages/core/src/__tests__/event-bus.test.ts
+++ b/packages/core/src/__tests__/event-bus.test.ts
@@ -3,7 +3,7 @@ import { AgentSession } from "../session.js";
 import type { LiveEvent } from "../session.js";
 import { createFakeModel } from "../testing.js";
 import type { HarnessTool } from "../types.js";
-import type { AssistantMessage } from "@mariozechner/pi-ai";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
 
 const noopTool: HarnessTool = {
   name: "noop",

--- a/packages/core/src/__tests__/integration.test.ts
+++ b/packages/core/src/__tests__/integration.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import { Type } from "@mariozechner/pi-ai";
+import { Type } from "@earendil-works/pi-ai";
 import { AgentSession } from "../session.js";
 import type { HarnessTool, Hook, HookContext } from "../index.js";
 import { createFakeModel } from "../testing.js";

--- a/packages/core/src/__tests__/llm-model.test.ts
+++ b/packages/core/src/__tests__/llm-model.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  makeOpenAICompatibleModel,
+  resolveLlmOptions,
+  type Model,
+  type Api,
+} from "../index.js";
+
+describe("makeOpenAICompatibleModel (#38)", () => {
+  it("builds a valid openai-completions Model with sane defaults — no cast, no cost placeholder", () => {
+    const model = makeOpenAICompatibleModel({
+      id: "qwen-plus",
+      baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      provider: "dashscope",
+      contextWindow: 131072,
+      maxTokens: 8192,
+    });
+
+    expect(model.api).toBe("openai-completions");
+    expect(model.id).toBe("qwen-plus");
+    expect(model.provider).toBe("dashscope");
+    expect(model.name).toBe("dashscope qwen-plus");
+    expect(model.reasoning).toBe(false);
+    expect(model.input).toEqual(["text"]);
+    expect(model.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+    // compat 未传 → 省略，交给 pi-ai 按 baseUrl 自动探测。
+    expect(model.compat).toBeUndefined();
+
+    // 关键:返回值隐式 widen 到 Model<Api> 无需 cast(编译能过即证明 #38 的 cast 已消除)。
+    const widened: Model<Api> = model;
+    expect(widened.api).toBe("openai-completions");
+  });
+
+  it("defaults provider to the baseUrl hostname when omitted", () => {
+    const model = makeOpenAICompatibleModel({
+      id: "local-model",
+      baseUrl: "http://localhost:8000/v1",
+      contextWindow: 8192,
+      maxTokens: 2048,
+    });
+    expect(model.provider).toBe("localhost");
+    expect(model.name).toBe("localhost local-model");
+  });
+
+  it("passes explicit cost and compat through when given", () => {
+    const model = makeOpenAICompatibleModel({
+      id: "qwen-plus",
+      baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      provider: "dashscope",
+      reasoning: true,
+      contextWindow: 131072,
+      maxTokens: 8192,
+      cost: { input: 1, output: 2, cacheRead: 0.2, cacheWrite: 0 },
+      compat: { thinkingFormat: "qwen", maxTokensField: "max_tokens" },
+    });
+    expect(model.reasoning).toBe(true);
+    expect(model.cost.input).toBe(1);
+    expect(model.compat?.thinkingFormat).toBe("qwen");
+    expect(model.compat?.maxTokensField).toBe("max_tokens");
+  });
+
+  it("throws fail-loud on a malformed baseUrl when provider is derived", () => {
+    expect(() =>
+      makeOpenAICompatibleModel({
+        id: "x",
+        baseUrl: "not-a-url",
+        contextWindow: 1,
+        maxTokens: 1,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("resolveLlmOptions (#39)", () => {
+  it("returns empty object for undefined", () => {
+    expect(resolveLlmOptions(undefined)).toEqual({});
+  });
+
+  it("flattens providerExtras back to the top level for pi-ai", () => {
+    const resolved = resolveLlmOptions({
+      apiKey: "sk-test",
+      temperature: 0.2,
+      providerExtras: { reasoningEffort: "high" },
+    });
+    expect(resolved.apiKey).toBe("sk-test");
+    expect(resolved.temperature).toBe(0.2);
+    expect((resolved as Record<string, unknown>).reasoningEffort).toBe("high");
+    // providerExtras 本身不应作为一个键泄漏到 pi-ai 选项里。
+    expect((resolved as Record<string, unknown>).providerExtras).toBeUndefined();
+  });
+});

--- a/packages/core/src/__tests__/llm-options.test.ts
+++ b/packages/core/src/__tests__/llm-options.test.ts
@@ -74,8 +74,9 @@ describe("AgentSession llmOptions", () => {
         tools: [],
         llmOptions: {
           temperature: 0.2,
-          customOption: "kept",
-          signal: callerSignal,
+          // provider 专属 / 非 StreamOptions 键走 providerExtras 逃生口；摊平后回到顶层透传。
+          // signal 经 providerExtras「偷传」也应被 kernel 覆盖（文档承诺的不变量）。
+          providerExtras: { customOption: "kept", signal: callerSignal },
         },
       });
 

--- a/packages/core/src/__tests__/llm-options.test.ts
+++ b/packages/core/src/__tests__/llm-options.test.ts
@@ -7,7 +7,7 @@ import {
   type Context,
   type Model,
   type StreamOptions,
-} from "@mariozechner/pi-ai";
+} from "@earendil-works/pi-ai";
 import { AgentSession } from "../session.js";
 
 describe("AgentSession llmOptions", () => {

--- a/packages/core/src/__tests__/round3-fixes.test.ts
+++ b/packages/core/src/__tests__/round3-fixes.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import { Type } from "@mariozechner/pi-ai";
+import { Type } from "@earendil-works/pi-ai";
 import { AgentSession } from "../session.js";
 import { HookDispatcher } from "../dispatcher.js";
 import type { HarnessTool, Hook, HookContext } from "../index.js";

--- a/packages/core/src/__tests__/smoke.test.ts
+++ b/packages/core/src/__tests__/smoke.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { Type } from "@mariozechner/pi-ai";
+import { Type } from "@earendil-works/pi-ai";
 import { AgentSession } from "../session.js";
 import type { HarnessTool, Hook } from "../index.js";
 import { createFakeModel } from "../testing.js";

--- a/packages/core/src/__tests__/steering.test.ts
+++ b/packages/core/src/__tests__/steering.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Type, type Context, type Message } from "@mariozechner/pi-ai";
+import { Type, type Context, type Message } from "@earendil-works/pi-ai";
 import { AgentSession } from "../session.js";
 import { MemorySessionStore } from "../session-store.js";
 import { createFakeModel } from "../testing.js";

--- a/packages/core/src/context-overflow.ts
+++ b/packages/core/src/context-overflow.ts
@@ -23,7 +23,7 @@
 import {
   isContextOverflow as piAiIsContextOverflow,
   type AssistantMessage,
-} from "@mariozechner/pi-ai";
+} from "@earendil-works/pi-ai";
 
 /**
  * 内核特有补充：pi-ai 的列表**不含** DashScope/Qwen 的 overflow 文案。

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -13,7 +13,7 @@
  *   - config 是 SessionConfigView 只读视图，由 session 构造时一次性 deep-freeze；turn 内不变。
  */
 
-import type { Message } from "@mariozechner/pi-ai";
+import type { Message } from "@earendil-works/pi-ai";
 import type {
   HookContext,
   HookLogger,

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -18,7 +18,7 @@
  *   - 如果 dashboard 按 sink call 计数，两路径会差一截；按字节数 / 行数计就一致。
  */
 
-import type { ToolCall } from "@mariozechner/pi-ai";
+import type { ToolCall } from "@earendil-works/pi-ai";
 import type {
   ContextOverflowInput,
   ContinuationCheckInput,
@@ -38,7 +38,7 @@ import type {
   TurnStartInput,
   UserPromptSubmitInput,
 } from "./hook.js";
-import type { Message } from "@mariozechner/pi-ai";
+import type { Message } from "@earendil-works/pi-ai";
 
 /* ────────────── 默认 timeout ────────────── */
 

--- a/packages/core/src/hook.ts
+++ b/packages/core/src/hook.ts
@@ -14,7 +14,7 @@ import type {
   AssistantMessage,
   Message,
   ToolCall,
-} from "@mariozechner/pi-ai";
+} from "@earendil-works/pi-ai";
 import type { HarnessTool } from "./types.js";
 
 /* ──────────────────── Tool 执行结果 ──────────────────── */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,6 +67,10 @@ export type {
   LiveEvent,
 } from "./session.js";
 
+// ─────────── LLM seam（自定义 Model 构造 + typed llmOptions，收口 pi-ai 公共面） ───────────
+export { makeOpenAICompatibleModel, resolveLlmOptions } from "./llm-model.js";
+export type { OpenAICompatibleModelSpec, LlmOptions } from "./llm-model.js";
+
 // ─────────── HookContextImpl 实例类型（plugin / controller 偶尔需要） ───────────
 export type { HookContextImpl, HookContextDeps } from "./context.js";
 // 注意：getKernelInternals / KERNEL_INTERNALS_BAG 故意不导出——它们是 kernel-internal API。
@@ -85,6 +89,7 @@ export type {
   Usage,
   StopReason,
   Context,
+  OpenAICompletionsCompat,
 } from "@earendil-works/pi-ai";
 export { Type } from "@earendil-works/pi-ai";
 export type { Static, TSchema } from "@earendil-works/pi-ai";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -85,6 +85,6 @@ export type {
   Usage,
   StopReason,
   Context,
-} from "@mariozechner/pi-ai";
-export { Type } from "@mariozechner/pi-ai";
-export type { Static, TSchema } from "@mariozechner/pi-ai";
+} from "@earendil-works/pi-ai";
+export { Type } from "@earendil-works/pi-ai";
+export type { Static, TSchema } from "@earendil-works/pi-ai";

--- a/packages/core/src/llm-model.ts
+++ b/packages/core/src/llm-model.ts
@@ -1,0 +1,143 @@
+/**
+ * LLM seam：在 pi-ai 公共面**之上**收口两个人体工学缺口，让消费者(engram / bidding-agent /
+ * coding-agent)无需直接 import `@earendil-works/pi-ai`、也无需手写 Model 字面量或裸 `Record` options。
+ *
+ * 这层**不改 pi-ai 一行**(架构不变量 L1 仍成立)——只是在内核侧把「自定义 Model 构造」与「provider
+ * options 类型」集中到一个咽喉点。pi-ai 将来 churn `Model` 类型时只动本文件 + index re-export。
+ *
+ * 解决两个 issue：
+ *   #38 `makeOpenAICompatibleModel()`：自定义 OpenAI-compatible model 不再需要手写字面量 + `as Model` cast +
+ *       无意义的 `cost:{0,0,0,0}` 占位。
+ *   #39 `LlmOptions`：把 `AgentSessionOptions.llmOptions` 从 `Record<string,unknown>` 收紧成 typed shape，
+ *       `{apikey}` 这类 typo 在编译期失败；真·provider 私有键走具名 `providerExtras` 逃生口。
+ */
+
+import type {
+  Model,
+  StreamOptions,
+  ProviderStreamOptions,
+  OpenAICompletionsCompat,
+} from "@earendil-works/pi-ai";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #39 — typed llmOptions
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 透传给 pi-ai `stream()`/`complete()` 的跨-provider 选项，typed 版。
+ *
+ * 锚定 pi-ai 已导出的 `StreamOptions`(apiKey / temperature / maxTokens / headers / timeoutMs /
+ * maxRetries / metadata / …)，这是**所有 provider 共有**的基底。两处偏离：
+ *
+ * - **去掉 `signal`**：它是 kernel 保留字段(session 用自己的 AbortSignal)，传了也会被覆盖。
+ *   Omit 让「传 signal」直接变编译错误，把保留语义写进类型而不是注释。
+ * - **加具名 `providerExtras`**：pi-ai 的 provider 专属选项(如 openai-completions 的 `reasoningEffort`、
+ *   anthropic 的 thinking 配置)不在公共 `StreamOptions` 里。它们走这个**显式逃生口**，而不是把整个对象
+ *   放松成 `Record<string,unknown>`——后者会顺带丢掉 `{apikey}` 的 typo 检查(#39 的核心诉求)。
+ *
+ * 注意 `baseUrl` **不在这里**——它是 Model 的字段(见 {@link makeOpenAICompatibleModel})，不是 per-call option。
+ */
+export type LlmOptions = Omit<StreamOptions, "signal"> & {
+  /**
+   * Provider 专属、不在公共 `StreamOptions` 里的选项(如 openai-completions 的 `reasoningEffort`)。
+   * 原样 spread 到顶层透传。
+   *
+   * **优先级**:`resolveLlmOptions` 把 providerExtras 在 typed 字段**之后** spread(`{...rest, ...providerExtras}`),
+   * 故同名键以 providerExtras 为准——这是有意的逃生口语义(能覆盖任何 typed 字段)。`signal` 例外:始终被
+   * kernel 的 AbortSignal 覆盖。别把已 typed 的键(如 `apiKey`)塞进 providerExtras——那会绕过 #39 的 typo 检查。
+   */
+  providerExtras?: Record<string, unknown>;
+};
+
+/**
+ * 把 {@link LlmOptions} 摊平成 pi-ai `stream()`/`complete()` 实际吃的 `ProviderStreamOptions`：
+ * 把 `providerExtras` spread 回顶层。**不**注入 signal —— 调用方(kernel / compaction)各自负责。
+ *
+ * kernel(session.ts)与 coding-agent 的 compaction 都直连 pi-ai，复用同一份摊平逻辑避免漂移。
+ */
+export function resolveLlmOptions(
+  opts: LlmOptions | undefined,
+): ProviderStreamOptions {
+  if (!opts) return {};
+  const { providerExtras, ...rest } = opts;
+  return { ...rest, ...providerExtras };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #38 — custom OpenAI-compatible Model 工厂
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 构造一个 OpenAI-compatible(`api: "openai-completions"`)自定义 Model 的输入。
+ * 覆盖 DashScope/Qwen、Moonshot、本地 vLLM、任意 OpenAI 兼容端点。
+ */
+export interface OpenAICompatibleModelSpec {
+  /** Provider 侧的 model id，如 `"qwen-plus"`。 */
+  id: string;
+  /** OpenAI 兼容端点 baseUrl，如 `"https://dashscope.aliyuncs.com/compatible-mode/v1"`。 */
+  baseUrl: string;
+  /** Provider 名(影响 cost 归类 / 展示)。默认取 `baseUrl` 的 hostname。 */
+  provider?: string;
+  /** 展示名。默认 `${provider} ${id}`。 */
+  name?: string;
+  /** 模型是否支持 reasoning/thinking。默认 `false`。 */
+  reasoning?: boolean;
+  /** 输入模态。默认 `["text"]`。 */
+  input?: ("text" | "image")[];
+  /** 上下文窗口 token 数。 */
+  contextWindow: number;
+  /** 单次输出 token 上限。 */
+  maxTokens: number;
+  /**
+   * 价格(USD per million tokens)。默认 `{0,0,0,0}`——自定义 model 通常拿不到官方 USD 价，
+   * 零默认让调用点不必再写无意义占位。若 cost-budget 要精确,显式传。
+   */
+  cost?: { input: number; output: number; cacheRead: number; cacheWrite: number };
+  /**
+   * OpenAI-compatible 兼容性覆盖。**不传则整个省略**，交给 pi-ai 按 baseUrl 自动探测——
+   * 别硬塞默认值，否则对非目标端点(如把 qwen 的 `thinkingFormat` 套到别的 provider)反而是错的。
+   */
+  compat?: OpenAICompletionsCompat;
+}
+
+/** 默认 provider 名：取 baseUrl 的 hostname。baseUrl 非法 URL 会 throw(fail-loud，早于跑模型)。 */
+function providerFromBaseUrl(baseUrl: string): string {
+  return new URL(baseUrl).hostname;
+}
+
+/**
+ * 造一个 OpenAI-compatible 自定义 Model —— **零 `as Model` cast、无 `cost:{0,0,0,0}` 占位**。
+ *
+ * cast 能消除的关键：返回类型标注成**具体 api 字面量** `Model<"openai-completions">`，pi-ai 的条件字段
+ * `compat?: TApi extends "openai-completions" ? OpenAICompletionsCompat : …`(types.d.ts)对窄字面量正确解析为
+ * `OpenAICompletionsCompat`(而非宽联合 `Model<Api>` 下塌成的 `never`)。返回值可隐式 widen 到 `Model<Api>` 供下游用。
+ *
+ * @example
+ * const model = makeOpenAICompatibleModel({
+ *   id: "qwen-plus",
+ *   baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+ *   provider: "dashscope",
+ *   contextWindow: 131072,
+ *   maxTokens: 8192,
+ * });
+ * new AgentSession({ model, tools, llmOptions: { apiKey } });
+ */
+export function makeOpenAICompatibleModel(
+  spec: OpenAICompatibleModelSpec,
+): Model<"openai-completions"> {
+  const provider = spec.provider ?? providerFromBaseUrl(spec.baseUrl);
+  return {
+    id: spec.id,
+    name: spec.name ?? `${provider} ${spec.id}`,
+    api: "openai-completions",
+    provider,
+    baseUrl: spec.baseUrl,
+    reasoning: spec.reasoning ?? false,
+    input: spec.input ?? ["text"],
+    cost: spec.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: spec.contextWindow,
+    maxTokens: spec.maxTokens,
+    // compat 未给则省略 → pi-ai 按 baseUrl 自动探测(exactOptionalPropertyTypes 下不能写 compat:undefined)。
+    ...(spec.compat ? { compat: spec.compat } : {}),
+  };
+}

--- a/packages/core/src/session-store.ts
+++ b/packages/core/src/session-store.ts
@@ -13,7 +13,7 @@
  *   - **leaf pointer**：每个 sessionId 记一个当前 leaf；append 自动挂到 leaf 之后并推进 leaf。
  */
 
-import type { Message } from "@mariozechner/pi-ai";
+import type { Message } from "@earendil-works/pi-ai";
 import { randomUUID } from "node:crypto";
 // type-only import（无运行时循环）：terminal entry 携带内核的 RunSummary 终态。
 import type { RunSummary } from "./session.js";

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -118,6 +118,8 @@ import { createAttachmentMessage } from "./types.js";
 import type { HarnessTool } from "./types.js";
 import type { SessionStore } from "./session-store.js";
 import { defaultIsContextOverflow } from "./context-overflow.js";
+import { resolveLlmOptions } from "./llm-model.js";
+import type { LlmOptions } from "./llm-model.js";
 import { randomUUID } from "node:crypto";
 
 export interface AgentSessionOptions {
@@ -153,10 +155,12 @@ export interface AgentSessionOptions {
    */
   resumedMessageCount?: number;
   /**
-   * 透传给 pi-ai complete() 的 provider options。
-   * `signal` 是 kernel 保留字段：即使传入也会被当前 session 的 AbortSignal 覆盖。
+   * 透传给 pi-ai stream()/complete() 的 provider options（typed，见 {@link LlmOptions}）。
+   * 公共字段（apiKey / temperature / headers / …）类型化，`{apikey}` 这类 typo 编译期失败；
+   * provider 专属键走 `providerExtras` 逃生口。`signal` 是 kernel 保留字段，已从类型 Omit 掉
+   * （即使经 `providerExtras` 偷传也会被当前 session 的 AbortSignal 覆盖）。
    */
-  llmOptions?: Record<string, unknown>;
+  llmOptions?: LlmOptions;
   /** Hook 失败上报通道（metrics plugin 通常 hook 进来）。 */
   hookFailureSink?: HookFailureSink;
   /**
@@ -248,7 +252,7 @@ export class AgentSession {
   readonly systemPrompt: string;
   readonly maxTurns: number;
   readonly maxContinuations: number;
-  private readonly _llmOptions: Record<string, unknown>;
+  private readonly _llmOptions: LlmOptions;
 
   private _messages: Message[];
   private _hooks: Hook[];
@@ -1219,7 +1223,7 @@ export class AgentSession {
       // stream() 而非 complete()：complete() 内部就是 stream().result()，两者结果完全等价，
       // 但 stream 让我们在回合进行中把 delta 作为 live 事件发出（Event Bus）。
       const s = stream(this.model, context, {
-        ...this._llmOptions,
+        ...resolveLlmOptions(this._llmOptions),
         signal: this._abortCtrl.signal,
       });
       for await (const ev of s) {

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -23,7 +23,7 @@ import {
   type ToolResultMessage,
   type Usage,
   type StopReason,
-} from "@mariozechner/pi-ai";
+} from "@earendil-works/pi-ai";
 
 /**
  * Phase 3：streaming consumer 看到的事件类型。每个事件对应一个 EVENT-category hook。

--- a/packages/core/src/testing.ts
+++ b/packages/core/src/testing.ts
@@ -27,7 +27,7 @@ import {
   type Context,
   type Model,
   type ToolCall,
-} from "@mariozechner/pi-ai";
+} from "@earendil-works/pi-ai";
 import { HookContextImpl, getKernelInternals } from "./context.js";
 import type {
   HookContext,
@@ -302,7 +302,7 @@ export interface TestContextOptions {
   signal?: AbortSignal;
   config?: Partial<SessionConfigView>;
   logSink?: (level: LogLevel, msg: string, fields: Record<string, unknown>) => void;
-  onAppendMessage?: (msg: import("@mariozechner/pi-ai").Message) => void;
+  onAppendMessage?: (msg: import("@earendil-works/pi-ai").Message) => void;
   onAbort?: (reason: string) => void;
   /** captureLog=true 时 logSink 默认变成把 log 推到一个数组里，便于 assert。 */
   captureLog?: boolean;
@@ -327,14 +327,14 @@ export interface TestContextHandle {
   /** captureLog=true 时收集到的 log。 */
   logs: Array<{ level: LogLevel; msg: string; fields: Record<string, unknown> }>;
   /** 最近 appendMessage 的内容（默认收集；可被 onAppendMessage 覆盖）。 */
-  appended: import("@mariozechner/pi-ai").Message[];
+  appended: import("@earendil-works/pi-ai").Message[];
   /** 最近 onAbort 的 reason。 */
   abortReasons: string[];
 }
 
 export function createTestContext(opts: TestContextOptions = {}): TestContextHandle {
   const logs: TestContextHandle["logs"] = [];
-  const appended: import("@mariozechner/pi-ai").Message[] = [];
+  const appended: import("@earendil-works/pi-ai").Message[] = [];
   const abortReasons: string[] = [];
 
   const defaultConfig: SessionConfigView = Object.freeze({

--- a/packages/core/src/tool-executor.ts
+++ b/packages/core/src/tool-executor.ts
@@ -21,7 +21,7 @@
 import {
   validateToolCall,
   type ToolCall,
-} from "@mariozechner/pi-ai";
+} from "@earendil-works/pi-ai";
 import type { HookContextImpl } from "./context.js";
 import type { HookDispatcher } from "./dispatcher.js";
 import type { ToolExecResult } from "./hook.js";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -5,7 +5,7 @@
  * 我们只补 pi-ai 没有的几个：HarnessTool（在 pi-ai Tool 基础上加 execute）。
  */
 
-import type { Tool, Message } from "@mariozechner/pi-ai";
+import type { Tool, Message } from "@earendil-works/pi-ai";
 import type { HookContext, ToolExecResult } from "./hook.js";
 
 /**

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@harness-pi/core": "workspace:*",
-    "@mariozechner/pi-ai": "^0.73.1"
+    "@earendil-works/pi-ai": "^0.74.2"
   },
   "devDependencies": {
     "typescript": "^5.6.0",

--- a/packages/plugins/src/__tests__/auto-compaction.test.ts
+++ b/packages/plugins/src/__tests__/auto-compaction.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { AgentSession, createUserMessage } from "@harness-pi/core";
 import { createTestContext, createFakeModel } from "@harness-pi/core/testing";
-import type { Message } from "@mariozechner/pi-ai";
+import type { Message } from "@earendil-works/pi-ai";
 import { autoCompaction, estimateTokensByChars } from "../auto-compaction.js";
 
 function textOf(m: Message): string {

--- a/packages/plugins/src/__tests__/compact-summarize.test.ts
+++ b/packages/plugins/src/__tests__/compact-summarize.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { AgentSession, createUserMessage } from "@harness-pi/core";
 import { createTestContext, createFakeModel } from "@harness-pi/core/testing";
-import type { Message } from "@mariozechner/pi-ai";
+import type { Message } from "@earendil-works/pi-ai";
 import { compactSummarize } from "../compact-summarize.js";
 
 function textOf(m: Message): string {

--- a/packages/plugins/src/__tests__/controllers.test.ts
+++ b/packages/plugins/src/__tests__/controllers.test.ts
@@ -15,6 +15,7 @@ import {
   LifecycleRestart,
   WorkPool,
   LeaseQueue,
+  type LeaseStatus,
 } from "../controllers/index.js";
 
 /* ──────────────── LifecycleRestart ──────────────── */
@@ -279,6 +280,7 @@ describe("WorkPool", () => {
       text: "x",
     }));
     const ac = new AbortController();
+    const onSkip = vi.fn();
     const pool = new WorkPool<Item>({
       items,
       partition: (its) => its.map((it) => ({ id: it.id, items: [it] })),
@@ -293,13 +295,146 @@ describe("WorkPool", () => {
         ]);
         return { session: new AgentSession({ model, tools: [] }), prompt: "x" };
       },
+      onGroupSkipped: onSkip,
     });
     setTimeout(() => ac.abort(), 20);
     const res = await pool.start(ac.signal);
     // 关键：start() 返回时，inflight 一定是 0（已 drain）
     expect(inflight.count).toBe(0);
-    // result 反映已完成的 group 数（应该是当时 in-flight 的 3 个）
-    expect(res.completedGroups + res.failedGroups).toBe(inflight.peak);
+    // #31:未启动的 group 不再静默消失——进 results 标 skipped、计入 skippedGroups、触发 onGroupSkipped。
+    // 守恒:每个 group 都有终态,三类计数之和 === group 总数;results 也覆盖全部 group。
+    expect(res.completedGroups + res.failedGroups + res.skippedGroups).toBe(5);
+    expect(res.groups).toHaveLength(5);
+    expect(res.skippedGroups).toBe(2); // 并发 3 先启动,abort 在任一完成前触发 → 剩 2 个从未启动
+    expect(onSkip).toHaveBeenCalledTimes(2);
+    expect(res.groups.filter((g) => g.skipped === "aborted")).toHaveLength(2);
+  });
+
+  it("pre-aborted signal:全部 group 直接 skipped、不启动 worker、onGroupSkipped 全触发", async () => {
+    const onSkip = vi.fn();
+    const ac = new AbortController();
+    ac.abort(); // 启动前就已 abort
+    const items: Item[] = [
+      { id: "a", text: "x" },
+      { id: "b", text: "y" },
+    ];
+    const pool = new WorkPool<Item>({
+      items,
+      partition: (its) => its.map((it) => ({ id: it.id, items: [it] })),
+      workerFactory: async () => {
+        throw new Error("workerFactory must not run under pre-aborted signal");
+      },
+      onGroupSkipped: onSkip,
+    });
+    const res = await pool.start(ac.signal);
+    expect(res.completedGroups).toBe(0);
+    expect(res.failedGroups).toBe(0);
+    expect(res.skippedGroups).toBe(2);
+    expect(res.groups).toHaveLength(2);
+    expect(onSkip).toHaveBeenCalledTimes(2);
+  });
+
+  it("abort 时全部 in-flight(items <= 并发):无未启动 group → skippedGroups 0、不误触发 onGroupSkipped", async () => {
+    const onSkip = vi.fn();
+    const ac = new AbortController();
+    const items: Item[] = Array.from({ length: 3 }, (_, i) => ({ id: `i${i}`, text: "x" }));
+    const pool = new WorkPool<Item>({
+      items,
+      partition: (its) => its.map((it) => ({ id: it.id, items: [it] })),
+      maxConcurrency: 3, // 全部一次性启动,queue 为空
+      workerFactory: async () => {
+        await new Promise<void>((r) => setTimeout(r, 50));
+        const model = createFakeModel([{ content: [{ type: "text", text: "ok" }] }]);
+        return { session: new AgentSession({ model, tools: [] }), prompt: "x" };
+      },
+      onGroupSkipped: onSkip,
+    });
+    setTimeout(() => ac.abort(), 20);
+    const res = await pool.start(ac.signal);
+    expect(res.skippedGroups).toBe(0); // queue 空,无未启动 group
+    expect(onSkip).not.toHaveBeenCalled();
+    expect(res.completedGroups + res.failedGroups).toBe(3); // 守恒:全是已启动的
+  });
+
+  it("混合终态(串行 maxConcurrency=1):已跑完的 group 仍 completed,未启动的 skipped,二者共存且守恒", async () => {
+    // 钉死非退化(并非全 skipped)的守恒:abort 不会把已 completed 的 group 误判/回收成 skipped。
+    // 串行下 g0 正常跑完 → onGroupComplete 内触发 abort → loop 顶部见 aborted 退出 → g1/g2 从未启动 → sweep skipped。
+    const ac = new AbortController();
+    const items: Item[] = Array.from({ length: 3 }, (_, i) => ({ id: `i${i}`, text: "x" }));
+    const completedIds: string[] = [];
+    const pool = new WorkPool<Item>({
+      items,
+      partition: (its) => its.map((it) => ({ id: it.id, items: [it] })),
+      maxConcurrency: 1, // 串行,一次只跑一个
+      workerFactory: async () => {
+        const model = createFakeModel([{ content: [{ type: "text", text: "ok" }] }]);
+        return { session: new AgentSession({ model, tools: [] }), prompt: "x" };
+      },
+      onGroupComplete: (id) => {
+        completedIds.push(id);
+        if (id === "i0") ac.abort(); // g0 收尾后立刻 abort,后续 group 应一个都不启动
+      },
+    });
+    const res = await pool.start(ac.signal);
+    expect(res.completedGroups).toBe(1); // g0 真完成,未被 abort 回收
+    expect(res.skippedGroups).toBe(2); // g1/g2 从未启动
+    expect(res.failedGroups).toBe(0);
+    expect(res.completedGroups + res.failedGroups + res.skippedGroups).toBe(3); // 守恒,非退化(completed≥1 且 skipped≥1)
+    expect(completedIds).toEqual(["i0"]); // 串行:abort 后没有第二个 group 被启动
+    expect(res.groups.filter((g) => g.skipped === "aborted")).toHaveLength(2);
+  });
+
+  it("混合终态(串行):in-flight group factory 抛错(failed)与未启动 group(skipped)共存", async () => {
+    // failedGroups≥1 && skippedGroups≥1 同时出现:证明 abort sweep 不吞掉真实失败、失败也不污染 skipped 计数。
+    const ac = new AbortController();
+    const items: Item[] = Array.from({ length: 3 }, (_, i) => ({ id: `i${i}`, text: "x" }));
+    const onErr = vi.fn();
+    const onSkip = vi.fn();
+    const pool = new WorkPool<Item>({
+      items,
+      partition: (its) => its.map((it) => ({ id: it.id, items: [it] })),
+      maxConcurrency: 1, // 串行:只有 g0 启动
+      workerFactory: async (g) => {
+        if (g.id === "i0") {
+          ac.abort(); // g0 跑时 abort:其失败收尾后 loop 退出,g1/g2 不启动
+          throw new Error("boom");
+        }
+        const model = createFakeModel([{ content: [{ type: "text", text: "ok" }] }]);
+        return { session: new AgentSession({ model, tools: [] }), prompt: "x" };
+      },
+      onGroupError: onErr,
+      onGroupSkipped: onSkip,
+    });
+    const res = await pool.start(ac.signal);
+    expect(res.failedGroups).toBe(1); // g0 factory 抛错 → failed,不被 sweep 误判成 skipped
+    expect(res.skippedGroups).toBe(2); // g1/g2 从未启动
+    expect(res.completedGroups).toBe(0);
+    expect(res.failedGroups + res.skippedGroups).toBe(3); // 守恒,失败与跳过两类共存
+    expect(onErr).toHaveBeenCalledOnce();
+    expect(onSkip).toHaveBeenCalledTimes(2);
+  });
+
+  it("空 items + 已 abort:直接全零返回,不启动 worker、不误触发 onGroupSkipped", async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const onSkip = vi.fn();
+    const pool = new WorkPool<Item>({
+      items: [],
+      partition: () => [],
+      workerFactory: async () => {
+        throw new Error("should not be called");
+      },
+      onGroupSkipped: onSkip,
+    });
+    const res = await pool.start(ac.signal);
+    expect(res).toMatchObject({
+      totalItems: 0,
+      completedGroups: 0,
+      failedGroups: 0,
+      skippedGroups: 0,
+    });
+    expect(res.groups).toEqual([]);
+    expect(onSkip).not.toHaveBeenCalled();
   });
 
   it("maxConcurrency truly caps concurrent groups", async () => {
@@ -434,6 +569,160 @@ describe("LeaseQueue", () => {
     });
     const res = await queue.start();
     expect(res.conflicted).toBe(1);
+  });
+
+  it("aborted mid-flight: 未派发的 item 必给 skipped 终态(不静默消失)", async () => {
+    // 5 items / 并发 2:abort 时 2 个 in-flight、3 个从未派发。#31 要求残留的 3 个也得终态。
+    const statuses: string[] = [];
+    const items: Item[] = Array.from({ length: 5 }, (_, i) => ({ id: `i${i}` }));
+    const ac = new AbortController();
+    const queue = new LeaseQueue<Item>({
+      items,
+      concurrency: 2,
+      workerFactory: async (item) => {
+        await new Promise<void>((r) => setTimeout(r, 50)); // 让 abort 能在派发后、跑完前触发
+        const model = createFakeModel([{ content: [{ type: "text", text: `d-${item.id}` }] }]);
+        return { session: new AgentSession({ model, tools: [] }), prompt: "go" };
+      },
+      onItemComplete: (_item, status) => statuses.push(status),
+    });
+    setTimeout(() => ac.abort(), 20);
+    const res = await queue.start(ac.signal);
+
+    // 守恒:每个 item 恰一条终态。
+    expect(res.totalItems).toBe(5);
+    expect(res.completed + res.failed + res.conflicted + res.skipped).toBe(5);
+    expect(res.skipped).toBe(3); // 并发 2 先派发 2,剩 3 个从未派发 → skipped
+    expect(statuses).toHaveLength(5); // onItemComplete 为每个 item 触发(含 skipped),无静默消失
+    expect(statuses.filter((s) => s === "skipped")).toHaveLength(3);
+  });
+
+  it("abort × retry 交错(maxAttempts>1):回退重试的 item 与未派发的都给 skipped、各恰一次", async () => {
+    // 钉死「abort 时回退重试的 item 也给终态」这条注释承诺、却最易漏测的路径。
+    // 并发 1 / maxAttempts 3:i0 跑时 abort → 其 run 以 aborted 收尾(reason!=done)→ attempt1<3 → 回退进 pending;
+    // 下一轮 loop 见 aborted 退出 → i0(回退)+ i1/i2(从未派发)都由末尾 sweep finalize 成 skipped。
+    const statuses: string[] = [];
+    const ac = new AbortController();
+    let firstCall = true;
+    const queue = new LeaseQueue<Item>({
+      items: [{ id: "i0" }, { id: "i1" }, { id: "i2" }],
+      concurrency: 1,
+      maxAttempts: 3,
+      workerFactory: async (item) => {
+        if (firstCall) {
+          firstCall = false;
+          ac.abort(); // i0 跑时触发:其 session.run 以 aborted 收尾 → status error → 回退重试
+        }
+        const model = createFakeModel([{ content: [{ type: "text", text: `d-${item.id}` }] }]);
+        return { session: new AgentSession({ model, tools: [] }), prompt: "go" };
+      },
+      onItemComplete: (_item, status) => statuses.push(status),
+    });
+    const res = await queue.start(ac.signal);
+    expect(res.completed + res.failed + res.conflicted + res.skipped).toBe(3); // 守恒
+    expect(res.skipped).toBe(3); // i0(回退)+ i1/i2(未派发)
+    expect(statuses).toHaveLength(3); // 每个 item 恰 finalize 一次,无双计/漏计
+    expect(statuses.every((s) => s === "skipped")).toBe(true);
+  });
+
+  it("pre-aborted signal:全部 item 直接 skipped、不调 workerFactory、onItemComplete 全触发", async () => {
+    const statuses: string[] = [];
+    const ac = new AbortController();
+    ac.abort();
+    const queue = new LeaseQueue<Item>({
+      items: [{ id: "a" }, { id: "b" }],
+      concurrency: 2,
+      workerFactory: async () => {
+        throw new Error("workerFactory must not run under pre-aborted signal");
+      },
+      onItemComplete: (_item, status) => statuses.push(status),
+    });
+    const res = await queue.start(ac.signal);
+    expect(res.completed).toBe(0);
+    expect(res.skipped).toBe(2);
+    expect(statuses).toEqual(["skipped", "skipped"]);
+  });
+
+  it("混合终态:abort 时部分 item 真完成、部分失败、剩余 skipped,三类共存且守恒", async () => {
+    // 钉死非退化守恒(并非全 skipped):并发 1 串行下,i0 正常 done、i1 在跑时 abort 收尾成 error(failed),
+    // i2/i3 从未派发 → sweep skipped。completed≥1 && skipped≥1 同时成立,且四类之和仍 === totalItems。
+    const statuses: LeaseStatus[] = [];
+    const ac = new AbortController();
+    let call = 0;
+    const queue = new LeaseQueue<Item>({
+      items: [{ id: "i0" }, { id: "i1" }, { id: "i2" }, { id: "i3" }],
+      concurrency: 1, // 串行:i0 先跑完,再派 i1
+      maxAttempts: 1, // i1 abort 收尾后不重试 → 直接 error(failed)
+      workerFactory: async (item) => {
+        call++;
+        if (call === 2) ac.abort(); // 第 2 次派发(i1)时 abort:i0 已 done,i1 以 aborted 收尾
+        const model = createFakeModel([{ content: [{ type: "text", text: `d-${item.id}` }] }]);
+        return { session: new AgentSession({ model, tools: [] }), prompt: "go" };
+      },
+      onItemComplete: (_item, status) => statuses.push(status),
+    });
+    const res = await queue.start(ac.signal);
+    expect(res.totalItems).toBe(4);
+    expect(res.completed).toBe(1); // i0
+    expect(res.failed).toBe(1); // i1(abort 收尾,maxAttempts 1 不重试)
+    expect(res.skipped).toBe(2); // i2/i3 从未派发
+    expect(res.completed + res.failed + res.conflicted + res.skipped).toBe(4); // 守恒
+    expect(res.completed).toBeGreaterThanOrEqual(1);
+    expect(res.skipped).toBeGreaterThanOrEqual(1);
+    expect(statuses).toHaveLength(4); // 每个 item 恰 finalize 一次
+    expect(statuses.filter((s) => s === "done")).toHaveLength(1);
+    expect(statuses.filter((s) => s === "skipped")).toHaveLength(2);
+  });
+
+  it("conflict × abort 交错:worker 已 releaseLease('conflict') 的 item 终态是 conflict,不被 sweep 误判 skipped", async () => {
+    // i0 在 worker 内主动 releaseLease('conflict') 并 abort → 其终态应由 worker 裁成 conflict(优先于 sweep);
+    // 未派发的 i1/i2 才进 sweep 成 skipped。验证 conflict 与 skipped 互不串味、守恒成立。
+    const statuses: LeaseStatus[] = [];
+    const ac = new AbortController();
+    const queue = new LeaseQueue<Item>({
+      items: [{ id: "i0" }, { id: "i1" }, { id: "i2" }],
+      concurrency: 1,
+      maxAttempts: 1,
+      workerFactory: async (item, _lease, ctx) => {
+        if (item.id === "i0") {
+          ctx.releaseLease("conflict"); // worker 主动裁定 conflict
+          ac.abort(); // 同时 abort:i1/i2 将从未派发
+        }
+        const model = createFakeModel([{ content: [{ type: "text", text: `d-${item.id}` }] }]);
+        return { session: new AgentSession({ model, tools: [] }), prompt: "go" };
+      },
+      onItemComplete: (_item, status) => statuses.push(status),
+    });
+    const res = await queue.start(ac.signal);
+    expect(res.conflicted).toBe(1); // i0:worker 裁定 conflict 优先,不被末尾 sweep 改写
+    expect(res.skipped).toBe(2); // i1/i2 从未派发
+    expect(res.completed + res.failed + res.conflicted + res.skipped).toBe(3); // 守恒
+    expect(statuses[0]).toBe("conflict"); // i0 由 worker 先 finalize 成 conflict
+    expect(statuses.filter((s) => s === "skipped")).toHaveLength(2);
+  });
+
+  it("空 items + 已 abort:直接全零返回,不调 workerFactory", async () => {
+    // LeaseQueue 此前完全没有空 items 用例。空 + 已 abort 是 sweep 与 workerCount=0 的退化边界。
+    const ac = new AbortController();
+    ac.abort();
+    const onComplete = vi.fn();
+    const queue = new LeaseQueue<Item>({
+      items: [],
+      concurrency: 2,
+      workerFactory: async () => {
+        throw new Error("workerFactory must not run with empty items");
+      },
+      onItemComplete: onComplete,
+    });
+    const res = await queue.start(ac.signal);
+    expect(res).toEqual({
+      totalItems: 0,
+      completed: 0,
+      failed: 0,
+      conflicted: 0,
+      skipped: 0,
+    });
+    expect(onComplete).not.toHaveBeenCalled();
   });
 
   it("throws on bad concurrency", () => {

--- a/packages/plugins/src/auto-compaction.ts
+++ b/packages/plugins/src/auto-compaction.ts
@@ -24,7 +24,7 @@
 
 import type { Hook, HookContext } from "@harness-pi/core";
 import { createUserMessage } from "@harness-pi/core";
-import type { Message } from "@mariozechner/pi-ai";
+import type { Message } from "@earendil-works/pi-ai";
 
 export interface AutoCompactionOptions {
   /** context token 预算（通常 = 模型上下文窗口，或你愿意用满的上限）。须 > 0。 */

--- a/packages/plugins/src/compact-summarize.ts
+++ b/packages/plugins/src/compact-summarize.ts
@@ -18,7 +18,7 @@
 
 import type { Hook, HookContext } from "@harness-pi/core";
 import { createUserMessage } from "@harness-pi/core";
-import type { Message } from "@mariozechner/pi-ai";
+import type { Message } from "@earendil-works/pi-ai";
 
 export interface CompactSummarizeOptions {
   /** 触发阈值：messages 条数 > maxMessages 才压缩。须 > keepRecent。 */

--- a/packages/plugins/src/controllers/lease-queue.ts
+++ b/packages/plugins/src/controllers/lease-queue.ts
@@ -4,6 +4,10 @@
  * 跟 WorkPool 的区别：动态领单，适合 item 完成时间分布极不均的场景。
  * 失败的 item 可重试（attempt 计数 + maxAttempts 兜底）。
  *
+ * **abort 必给终态**：abort 时正在跑的 item 由内核 abort 收尾，残留(从未派发 / abort 时回退)的 item
+ * 在 `start()` 末尾统一 finalize 成 `skipped` 并触发 `onItemComplete`——保证每个 item 都有终态,
+ * `completed + failed + conflicted + skipped === totalItems`,不让 work item 静默消失。
+ *
  * **并发安全前提**：依赖 Node.js 单线程 event loop——`pending.shift()` / `pending.splice()`
  * 在 await 之间是原子的，K 个 worker 不会竞态。任何修改请保持此契约（shift/splice 跟 length
  * 检查之间禁止插入 await）。
@@ -23,7 +27,7 @@ export interface QueueLease {
   attempt: number;
 }
 
-export type LeaseStatus = "done" | "error" | "conflict";
+export type LeaseStatus = "done" | "error" | "conflict" | "skipped";
 
 export interface LeaseQueueOptions<I extends QueueItem> {
   items: I[];
@@ -52,6 +56,8 @@ export interface LeaseQueueResult {
   completed: number;
   failed: number;
   conflicted: number;
+  /** abort 后从未派发(或 abort 时回退)而被给终态的 item 数。completed+failed+conflicted+skipped === totalItems。 */
+  skipped: number;
 }
 
 const DEFAULT_MAX_ATTEMPTS = 1;
@@ -71,6 +77,21 @@ export class LeaseQueue<I extends QueueItem> {
     let completed = 0;
     let failed = 0;
     let conflicted = 0;
+    let skipped = 0;
+
+    // 单点终态裁决:worker 与下面的 abort 兜底 sweep 共用,保证每个 item 恰被 finalize 一次。
+    const finalize = (
+      item: I,
+      status: LeaseStatus,
+      summary?: RunSummary,
+      error?: Error,
+    ): void => {
+      if (status === "done") completed++;
+      else if (status === "conflict") conflicted++;
+      else if (status === "skipped") skipped++;
+      else failed++;
+      this.opts.onItemComplete?.(item, status, summary, error);
+    };
 
     const workerCount = Math.min(
       this.opts.concurrency,
@@ -79,31 +100,28 @@ export class LeaseQueue<I extends QueueItem> {
     const workers: Promise<void>[] = [];
 
     for (let i = 0; i < workerCount; i++) {
-      const workerId = `worker-${i}`;
       workers.push(
-        this._workerLoop(
-          workerId,
-          pending,
-          attempts,
-          maxAttempts,
-          signal,
-          (item, status, summary, error) => {
-            if (status === "done") completed++;
-            else if (status === "conflict") conflicted++;
-            else failed++;
-            this.opts.onItemComplete?.(item, status, summary, error);
-          },
-        ),
+        this._workerLoop(`worker-${i}`, pending, attempts, maxAttempts, signal, finalize),
       );
     }
 
     await Promise.all(workers);
+
+    // abort 后 pending 里残留的 item(从未派发 + abort 时回退重试的)必须给终态——否则「work item
+    // 无终态、静默消失」,正是新原语要消灭却从旧 controller 旁路回来的问题(#31)。每个 item 至此恰
+    // finalize 一次:派发并跑完的在 worker 里 finalize、未跑完的回退进 pending 在此 sweep,二者互斥。
+    while (pending.length > 0) {
+      const item = pending.shift()!;
+      attempts.delete(item.id);
+      finalize(item, "skipped");
+    }
 
     return {
       totalItems: this.opts.items.length,
       completed,
       failed,
       conflicted,
+      skipped,
     };
   }
 

--- a/packages/plugins/src/controllers/sub-agent-tool.ts
+++ b/packages/plugins/src/controllers/sub-agent-tool.ts
@@ -10,7 +10,7 @@
  */
 
 import type { AgentSession, HarnessTool, HookContext, Message } from "@harness-pi/core";
-import { Type } from "@mariozechner/pi-ai";
+import { Type } from "@earendil-works/pi-ai";
 
 export interface SubAgentToolOptions {
   /** tool name（默认 "subAgent"）。 */

--- a/packages/plugins/src/controllers/work-pool.ts
+++ b/packages/plugins/src/controllers/work-pool.ts
@@ -4,6 +4,10 @@
  * 跟 LeaseQueue 的区别：WorkPool 把 items 静态分组（如按 heading），每 group
  * 一个 worker 跑完；LeaseQueue 是动态领单制，worker 持 lease 完了领下一题。
  *
+ * **abort 必给终态**：abort 时 in-flight group drain 收尾，未启动的 group 进 `results` 标
+ * `skipped:"aborted"` 并触发 `onGroupSkipped`——每个 group 都有终态,
+ * `completedGroups + failedGroups + skippedGroups === groups 总数`,不静默丢 group。
+ *
  * 详见 docs/06-controllers.md §4。
  */
 
@@ -32,13 +36,18 @@ export interface WorkPoolOptions<I extends WorkItem> {
   onGroupComplete?: (groupId: string, summary: RunSummary) => void;
   /** 单 group 失败回调（factory 抛或 run 抛）。 */
   onGroupError?: (groupId: string, err: Error) => void;
+  /** abort 时未启动的 group 被跳过的回调（与 complete/error 对称,保证每个 group 都有终态信号,不静默消失）。 */
+  onGroupSkipped?: (groupId: string, reason: "aborted") => void;
 }
 
 export interface WorkPoolResult {
-  groups: Array<{ id: string; summary?: RunSummary; error?: Error }>;
+  /** 每个 group 恰一条终态：summary（完成）/ error（失败）/ skipped（abort 时未启动）。 */
+  groups: Array<{ id: string; summary?: RunSummary; error?: Error; skipped?: "aborted" }>;
   totalItems: number;
   completedGroups: number;
   failedGroups: number;
+  /** abort 时未启动而被给终态的 group 数。completed+failed+skipped === groups 总数。 */
+  skippedGroups: number;
 }
 
 export class WorkPool<I extends WorkItem> {
@@ -52,6 +61,7 @@ export class WorkPool<I extends WorkItem> {
         totalItems: this.opts.items.length,
         completedGroups: 0,
         failedGroups: 0,
+        skippedGroups: 0,
       };
     }
 
@@ -65,10 +75,12 @@ export class WorkPool<I extends WorkItem> {
       id: string;
       summary?: RunSummary;
       error?: Error;
+      skipped?: "aborted";
     }> = [];
     const running = new Set<Promise<void>>();
     let completed = 0;
     let failed = 0;
+    let skippedGroups = 0;
 
     const runGroup = (g: WorkGroup<I>): Promise<void> =>
       (async () => {
@@ -106,11 +118,21 @@ export class WorkPool<I extends WorkItem> {
       await Promise.allSettled([...running]);
     }
 
+    // abort 后 queue 里未启动的 group 必须给终态(进 results + 计数 + 回调)——否则它们静默消失,
+    // 调用方按 group 归账时漏项(#31)。每个 group 至此恰一条终态:跑过的在 runGroup 里 push、未启动的在此。
+    while (queue.length > 0) {
+      const g = queue.shift()!;
+      results.push({ id: g.id, skipped: "aborted" });
+      skippedGroups++;
+      this.opts.onGroupSkipped?.(g.id, "aborted");
+    }
+
     return {
       groups: results,
       totalItems: this.opts.items.length,
       completedGroups: completed,
       failedGroups: failed,
+      skippedGroups,
     };
   }
 }

--- a/packages/plugins/src/lease-decision.ts
+++ b/packages/plugins/src/lease-decision.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Hook, HookContext } from "@harness-pi/core";
-import type { ToolCall } from "@mariozechner/pi-ai";
+import type { ToolCall } from "@earendil-works/pi-ai";
 
 export interface LeaseDecisionOptions {
   /** 返回当前 lease 持有的 id；null/undefined = 没 lease，跳过检查。 */

--- a/packages/plugins/src/permission-gate.ts
+++ b/packages/plugins/src/permission-gate.ts
@@ -14,7 +14,7 @@
  */
 
 import type { Hook, HookContext } from "@harness-pi/core";
-import type { ToolCall } from "@mariozechner/pi-ai";
+import type { ToolCall } from "@earendil-works/pi-ai";
 
 export type PermissionDecision = "allow" | "ask" | "deny";
 

--- a/packages/plugins/src/trim-history.ts
+++ b/packages/plugins/src/trim-history.ts
@@ -8,7 +8,7 @@
  */
 
 import type { Hook } from "@harness-pi/core";
-import type { Message } from "@mariozechner/pi-ai";
+import type { Message } from "@earendil-works/pi-ai";
 
 export interface TrimHistoryOptions {
   /** 最近 N 条 toolResult 保留原样。N=0 全部 trim；负数视为 0；非整数向下取整。 */

--- a/packages/tools/src/__tests__/pi-compat.test.ts
+++ b/packages/tools/src/__tests__/pi-compat.test.ts
@@ -153,6 +153,8 @@ describe("pi-coding-agent 0.53 compatibility", () => {
     const pkg = JSON.parse(
       readFileSync(join(process.cwd(), "package.json"), "utf8"),
     ) as { dependencies?: Record<string, string> };
+    // 第一方实现,不把 coding-agent 拉进 tools runtime —— 两个命名空间都不许(迁移到 @earendil-works/* 后)。
     expect(pkg.dependencies).not.toHaveProperty("@mariozechner/pi-coding-agent");
+    expect(pkg.dependencies).not.toHaveProperty("@earendil-works/pi-coding-agent");
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,12 @@ importers:
 
   apps/coding-agent:
     dependencies:
+      '@earendil-works/pi-ai':
+        specifier: ^0.74.2
+        version: 0.74.2(ws@8.21.0)(zod@3.25.76)
+      '@earendil-works/pi-tui':
+        specifier: 0.74.2
+        version: 0.74.2
       '@harness-pi/adapters':
         specifier: workspace:*
         version: link:../../packages/adapters
@@ -22,16 +28,7 @@ importers:
       '@harness-pi/tools':
         specifier: workspace:*
         version: link:../../packages/tools
-      '@mariozechner/pi-ai':
-        specifier: ^0.73.1
-        version: 0.73.1(ws@8.21.0)(zod@3.25.76)
-      '@mariozechner/pi-tui':
-        specifier: 0.73.1
-        version: 0.73.1
     devDependencies:
-      '@mariozechner/pi-coding-agent':
-        specifier: 0.73.1
-        version: 0.73.1(ws@8.21.0)(zod@3.25.76)
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.19
@@ -47,12 +44,12 @@ importers:
 
   examples/01-bare-kernel:
     dependencies:
+      '@earendil-works/pi-ai':
+        specifier: ^0.74.2
+        version: 0.74.2(ws@8.21.0)(zod@3.25.76)
       '@harness-pi/core':
         specifier: workspace:*
         version: link:../../packages/core
-      '@mariozechner/pi-ai':
-        specifier: ^0.73.1
-        version: 0.73.1(ws@8.21.0)(zod@3.25.76)
     devDependencies:
       tsx:
         specifier: ^4.0.0
@@ -63,15 +60,15 @@ importers:
 
   examples/02-with-plugins:
     dependencies:
+      '@earendil-works/pi-ai':
+        specifier: ^0.74.2
+        version: 0.74.2(ws@8.21.0)(zod@3.25.76)
       '@harness-pi/core':
         specifier: workspace:*
         version: link:../../packages/core
       '@harness-pi/plugins':
         specifier: workspace:*
         version: link:../../packages/plugins
-      '@mariozechner/pi-ai':
-        specifier: ^0.73.1
-        version: 0.73.1(ws@8.21.0)(zod@3.25.76)
     devDependencies:
       tsx:
         specifier: ^4.0.0
@@ -98,6 +95,9 @@ importers:
 
   examples/04-batch-pipeline:
     dependencies:
+      '@earendil-works/pi-ai':
+        specifier: ^0.74.2
+        version: 0.74.2(ws@8.21.0)(zod@3.25.76)
       '@harness-pi/adapters':
         specifier: workspace:*
         version: link:../../packages/adapters
@@ -107,9 +107,6 @@ importers:
       '@harness-pi/plugins':
         specifier: workspace:*
         version: link:../../packages/plugins
-      '@mariozechner/pi-ai':
-        specifier: ^0.73.1
-        version: 0.73.1(ws@8.21.0)(zod@3.25.76)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -126,12 +123,12 @@ importers:
 
   packages/adapters:
     dependencies:
+      '@earendil-works/pi-ai':
+        specifier: ^0.74.2
+        version: 0.74.2(ws@8.21.0)(zod@3.25.76)
       '@harness-pi/core':
         specifier: workspace:*
         version: link:../core
-      '@mariozechner/pi-ai':
-        specifier: ^0.73.1
-        version: 0.73.1(ws@8.21.0)(zod@3.25.76)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -154,9 +151,9 @@ importers:
 
   packages/core:
     dependencies:
-      '@mariozechner/pi-ai':
-        specifier: ^0.73.1
-        version: 0.73.1(ws@8.21.0)(zod@3.25.76)
+      '@earendil-works/pi-ai':
+        specifier: ^0.74.2
+        version: 0.74.2(ws@8.21.0)(zod@3.25.76)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -170,12 +167,12 @@ importers:
 
   packages/plugins:
     dependencies:
+      '@earendil-works/pi-ai':
+        specifier: ^0.74.2
+        version: 0.74.2(ws@8.21.0)(zod@3.25.76)
       '@harness-pi/core':
         specifier: workspace:*
         version: link:../core
-      '@mariozechner/pi-ai':
-        specifier: ^0.73.1
-        version: 0.73.1(ws@8.21.0)(zod@3.25.76)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -322,8 +319,14 @@ packages:
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
-  '@borewit/text-codec@0.2.2':
-    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
+  '@earendil-works/pi-ai@0.74.2':
+    resolution: {integrity: sha512-ukQBHGDm20k9ZUS2cGjNN9vDJp/48r35xmvgSx3paCaC06r2N/PLuRZoJmwQ1ZM7f8T3072odv9YPWn+77w0LA==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+
+  '@earendil-works/pi-tui@0.74.2':
+    resolution: {integrity: sha512-valQPz74qbdydRqII6t9rJ46YANMOOJeDhKm25a1ZrWvWwdjAaAEu6s3ur/LWz84Wkkwcbub2ZkVjzCZi8gFGA==}
+    engines: {node: '>=20.0.0'}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -631,91 +634,6 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  '@mariozechner/clipboard-darwin-arm64@0.3.9':
-    resolution: {integrity: sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@mariozechner/clipboard-darwin-universal@0.3.9':
-    resolution: {integrity: sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==}
-    engines: {node: '>= 10'}
-    os: [darwin]
-
-  '@mariozechner/clipboard-darwin-x64@0.3.9':
-    resolution: {integrity: sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
-    resolution: {integrity: sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
-    resolution: {integrity: sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
-    resolution: {integrity: sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==}
-    engines: {node: '>= 10'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
-    resolution: {integrity: sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@mariozechner/clipboard-linux-x64-musl@0.3.9':
-    resolution: {integrity: sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
-    resolution: {integrity: sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
-    resolution: {integrity: sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@mariozechner/clipboard@0.3.9':
-    resolution: {integrity: sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==}
-    engines: {node: '>= 10'}
-
-  '@mariozechner/pi-agent-core@0.73.1':
-    resolution: {integrity: sha512-Y/KVOhuKSgRQgYBlwmRtO2gPkUcoavOSqGF9bpQIINvNZvc19k6Z1H3bFDTce3Vp5ApMmTsfLH3+tNvOg75fAQ==}
-    engines: {node: '>=20.0.0'}
-    deprecated: please use @earendil-works/pi-agent-core instead going forward
-
-  '@mariozechner/pi-ai@0.73.1':
-    resolution: {integrity: sha512-Jh4lXawZYuC83HzSIYuVum9NBqJD49i4JOt3H96cGW/924cwJMOyUs1Mv/e4QPzTXnzrqMoGviNQnvGgSu1LSg==}
-    engines: {node: '>=20.0.0'}
-    deprecated: please use @earendil-works/pi-ai instead going forward
-    hasBin: true
-
-  '@mariozechner/pi-coding-agent@0.73.1':
-    resolution: {integrity: sha512-gXQh3SaZmWTfVMc4Ao5+LGbVeKvzyO7tolok0nLsZgq9nGjZx/EEU3NM8C+qUnB4Nvs2rswG5qOVgLzQkq0fHQ==}
-    engines: {node: '>=20.6.0'}
-    deprecated: please use @earendil-works/pi-coding-agent instead going forward
-    hasBin: true
-
-  '@mariozechner/pi-tui@0.73.1':
-    resolution: {integrity: sha512-ybVsRnUbzQRtbocltJ2OXb2QogrO67N2BlUyKjZz9BHcZYiDJtNkcKQockxDjsVvDc0uBCLDX6iZJoBElBd8fw==}
-    engines: {node: '>=20.0.0'}
-    deprecated: please use @earendil-works/pi-tui instead going forward
-
   '@mistralai/mistralai@2.2.5':
     resolution: {integrity: sha512-ATbWzKkNzNAZ+gtw9MI/c/ULTMG80tKUiRNIbQFfg4OP0uEZZpTfXZeBCNfs5Dq0uqMQ/tQWc4o6RRJQtMrpDA==}
 
@@ -877,9 +795,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@silvia-odwyer/photon-node@0.3.4':
-    resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
-
   '@smithy/core@3.24.4':
     resolution: {integrity: sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==}
     engines: {node: '>=18.0.0'}
@@ -916,24 +831,11 @@ packages:
     resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
 
-  '@tokenizer/inflate@0.4.1':
-    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
-    engines: {node: '>=18'}
-
-  '@tokenizer/token@0.3.0':
-    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
-
-  '@tootallnate/quickjs-emscripten@0.23.0':
-    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
-
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
-
-  '@types/mime-types@2.1.4':
-    resolution: {integrity: sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==}
 
   '@types/node@22.19.19':
     resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
@@ -943,9 +845,6 @@ packages:
 
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
-
-  '@types/yauzl@2.10.3':
-    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
@@ -980,52 +879,18 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  ansi-regex@5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
-    engines: {node: '>=8'}
-
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
-    engines: {node: '>=12'}
-
-  ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
-
-  any-promise@1.3.0:
-    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
-
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  ast-types@0.13.4:
-    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
-    engines: {node: '>=4'}
-
-  balanced-match@4.0.4:
-    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
-    engines: {node: 18 || 20 || >=22}
-
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
-  basic-ftp@5.3.1:
-    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
-    engines: {node: '>=10.0.0'}
 
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
-
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
-
-  buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -1050,32 +915,9 @@ packages:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
 
-  chalk@4.1.2:
-    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
-    engines: {node: '>=10'}
-
-  chalk@5.6.2:
-    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
-
-  cli-highlight@2.1.11:
-    resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
-    engines: {node: '>=8.0.0', npm: '>=5.0.0'}
-    hasBin: true
-
-  cliui@7.0.4:
-    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
-
-  color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
-
-  color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -1083,10 +925,6 @@ packages:
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
-
-  data-uri-to-buffer@6.0.2:
-    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
-    engines: {node: '>= 14'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1105,14 +943,6 @@ packages:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
 
-  degenerator@5.0.1:
-    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
-    engines: {node: '>= 14'}
-
-  diff@8.0.4:
-    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
-    engines: {node: '>=0.3.1'}
-
   discontinuous-range@1.0.0:
     resolution: {integrity: sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==}
 
@@ -1122,12 +952,6 @@ packages:
 
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
-
-  emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  end-of-stream@1.4.5:
-    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -1154,30 +978,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  escalade@3.2.0:
-    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
-    engines: {node: '>=6'}
-
-  escodegen@2.1.0:
-    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
-    engines: {node: '>=6.0'}
-    hasBin: true
-
-  esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
-
-  estraverse@5.3.0:
-    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
-    engines: {node: '>=4.0'}
-
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
-
-  esutils@2.0.3:
-    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
-    engines: {node: '>=0.10.0'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -1186,11 +988,6 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
-  extract-zip@2.0.1:
-    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
-    engines: {node: '>= 10.17.0'}
-    hasBin: true
-
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
 
@@ -1198,16 +995,9 @@ packages:
     resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
     hasBin: true
 
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
-
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
-
-  file-type@21.3.4:
-    resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
-    engines: {node: '>=20'}
 
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
@@ -1232,10 +1022,6 @@ packages:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
     engines: {node: '>=18'}
 
-  get-caller-file@2.0.5:
-    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
-    engines: {node: 6.* || 8.* || >= 10.*}
-
   get-east-asian-width@1.6.0:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
@@ -1247,18 +1033,6 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
-
-  get-stream@5.2.0:
-    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
-    engines: {node: '>=8'}
-
-  get-uri@6.0.5:
-    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
-    engines: {node: '>= 14'}
-
-  glob@13.0.6:
-    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
-    engines: {node: 18 || 20 || >=22}
 
   google-auth-library@10.6.2:
     resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
@@ -1272,13 +1046,6 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
-  graceful-fs@4.2.11:
-    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  has-flag@4.0.0:
-    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
-    engines: {node: '>=8'}
-
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
@@ -1290,13 +1057,6 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  highlight.js@10.7.3:
-    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
-
-  hosted-git-info@9.0.3:
-    resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -1305,30 +1065,11 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
-  ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-
-  ignore@7.0.5:
-    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
-    engines: {node: '>= 4'}
-
   immutable@4.3.8:
     resolution: {integrity: sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
-    engines: {node: '>= 12'}
-
-  is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
-
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
-
-  jiti@2.7.0:
-    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
-    hasBin: true
 
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
@@ -1359,17 +1100,9 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
-  lru-cache@11.5.1:
-    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
-    engines: {node: 20 || >=22}
-
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
-
-  lru-cache@7.18.3:
-    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
-    engines: {node: '>=12'}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1383,22 +1116,6 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  mime-db@1.54.0:
-    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
-    engines: {node: '>= 0.6'}
-
-  mime-types@3.0.2:
-    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
-    engines: {node: '>=18'}
-
-  minimatch@10.2.5:
-    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
-    engines: {node: 18 || 20 || >=22}
-
-  minipass@7.1.3:
-    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   moment@2.30.1:
     resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
 
@@ -1407,9 +1124,6 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
-  mz@2.7.0:
-    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
@@ -1420,10 +1134,6 @@ packages:
     resolution: {integrity: sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==}
     hasBin: true
 
-  netmask@2.1.1:
-    resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
-    engines: {node: '>= 0.4.0'}
-
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
@@ -1433,10 +1143,6 @@ packages:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
-
   object-hash@2.2.0:
     resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
     engines: {node: '>= 6'}
@@ -1444,9 +1150,6 @@ packages:
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
-
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   openai@6.26.0:
     resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
@@ -1464,23 +1167,6 @@ packages:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
     engines: {node: '>=8'}
 
-  pac-proxy-agent@7.2.0:
-    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
-    engines: {node: '>= 14'}
-
-  pac-resolver@7.0.1:
-    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
-    engines: {node: '>= 14'}
-
-  parse5-htmlparser2-tree-adapter@6.0.1:
-    resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
-
-  parse5@5.1.1:
-    resolution: {integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==}
-
-  parse5@6.0.1:
-    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
-
   partial-json@0.1.7:
     resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
@@ -1488,19 +1174,12 @@ packages:
     resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
     engines: {node: '>=14.0.0'}
 
-  path-scurry@2.0.2:
-    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
-    engines: {node: 18 || 20 || >=22}
-
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
-
-  pend@1.2.0:
-    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   pg-cloudflare@1.4.0:
     resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
@@ -1597,22 +1276,9 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
-  proper-lockfile@4.1.2:
-    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
-
   protobufjs@7.6.1:
     resolution: {integrity: sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==}
     engines: {node: '>=12.0.0'}
-
-  proxy-agent@6.5.0:
-    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
-    engines: {node: '>= 14'}
-
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-
-  pump@3.0.4:
-    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   railroad-diagrams@1.0.0:
     resolution: {integrity: sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==}
@@ -1621,17 +1287,9 @@ packages:
     resolution: {integrity: sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==}
     engines: {node: '>=0.12'}
 
-  require-directory@2.1.1:
-    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
-    engines: {node: '>=0.10.0'}
-
   ret@0.1.15:
     resolution: {integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==}
     engines: {node: '>=0.12'}
-
-  retry@0.12.0:
-    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
-    engines: {node: '>= 4'}
 
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
@@ -1652,27 +1310,8 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
-  signal-exit@3.0.7:
-    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
-
-  smart-buffer@4.2.0:
-    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
-    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
-
-  socks-proxy-agent@8.0.5:
-    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
-    engines: {node: '>= 14'}
-
-  socks@2.8.9:
-    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
-    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
-    engines: {node: '>=0.10.0'}
-
-  source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
   split2@4.2.0:
@@ -1685,35 +1324,8 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
-  string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
-
-  strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
-
-  strip-ansi@7.2.0:
-    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
-    engines: {node: '>=12'}
-
   strnum@2.3.0:
     resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
-
-  strtok3@10.3.5:
-    resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
-    engines: {node: '>=18'}
-
-  supports-color@7.2.0:
-    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
-    engines: {node: '>=8'}
-
-  thenify-all@1.6.0:
-    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
-    engines: {node: '>=0.8'}
-
-  thenify@3.3.1:
-    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1732,10 +1344,6 @@ packages:
   tinyspy@3.0.2:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
-
-  token-types@6.1.2:
-    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
-    engines: {node: '>=14.16'}
 
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
@@ -1756,20 +1364,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  uint8array-extras@1.5.0:
-    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
-    engines: {node: '>=18'}
-
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
-    engines: {node: '>=20.18.1'}
-
-  uuid@14.0.0:
-    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
-    hasBin: true
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -1841,13 +1437,6 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
-
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
@@ -1868,28 +1457,8 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
-  y18n@5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
-    engines: {node: '>=10'}
-
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-
-  yaml@2.9.0:
-    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
-
-  yargs-parser@20.2.9:
-    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
-    engines: {node: '>=10'}
-
-  yargs@16.2.0:
-    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
-    engines: {node: '>=10'}
-
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
@@ -2134,7 +1703,31 @@ snapshots:
 
   '@babel/runtime@7.29.2': {}
 
-  '@borewit/text-codec@0.2.2': {}
+  '@earendil-works/pi-ai@0.74.2(ws@8.21.0)(zod@3.25.76)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@3.25.76)
+      '@aws-sdk/client-bedrock-runtime': 3.1053.0
+      '@google/genai': 1.52.0
+      '@mistralai/mistralai': 2.2.5
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      openai: 6.26.0(ws@8.21.0)(zod@3.25.76)
+      partial-json: 0.1.7
+      typebox: 1.1.39
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-tui@0.74.2':
+    dependencies:
+      get-east-asian-width: 1.6.0
+      marked: 15.0.12
+    optionalDependencies:
+      koffi: 2.16.2
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -2296,126 +1889,6 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@mariozechner/clipboard-darwin-arm64@0.3.9':
-    optional: true
-
-  '@mariozechner/clipboard-darwin-universal@0.3.9':
-    optional: true
-
-  '@mariozechner/clipboard-darwin-x64@0.3.9':
-    optional: true
-
-  '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
-    optional: true
-
-  '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
-    optional: true
-
-  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
-    optional: true
-
-  '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
-    optional: true
-
-  '@mariozechner/clipboard-linux-x64-musl@0.3.9':
-    optional: true
-
-  '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
-    optional: true
-
-  '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
-    optional: true
-
-  '@mariozechner/clipboard@0.3.9':
-    optionalDependencies:
-      '@mariozechner/clipboard-darwin-arm64': 0.3.9
-      '@mariozechner/clipboard-darwin-universal': 0.3.9
-      '@mariozechner/clipboard-darwin-x64': 0.3.9
-      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.9
-      '@mariozechner/clipboard-linux-arm64-musl': 0.3.9
-      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.9
-      '@mariozechner/clipboard-linux-x64-gnu': 0.3.9
-      '@mariozechner/clipboard-linux-x64-musl': 0.3.9
-      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.9
-      '@mariozechner/clipboard-win32-x64-msvc': 0.3.9
-    optional: true
-
-  '@mariozechner/pi-agent-core@0.73.1(ws@8.21.0)(zod@3.25.76)':
-    dependencies:
-      '@mariozechner/pi-ai': 0.73.1(ws@8.21.0)(zod@3.25.76)
-      typebox: 1.1.39
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-ai@0.73.1(ws@8.21.0)(zod@3.25.76)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.91.1(zod@3.25.76)
-      '@aws-sdk/client-bedrock-runtime': 3.1053.0
-      '@google/genai': 1.52.0
-      '@mistralai/mistralai': 2.2.5
-      chalk: 5.6.2
-      openai: 6.26.0(ws@8.21.0)(zod@3.25.76)
-      partial-json: 0.1.7
-      proxy-agent: 6.5.0
-      typebox: 1.1.39
-      undici: 7.25.0
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-coding-agent@0.73.1(ws@8.21.0)(zod@3.25.76)':
-    dependencies:
-      '@mariozechner/pi-agent-core': 0.73.1(ws@8.21.0)(zod@3.25.76)
-      '@mariozechner/pi-ai': 0.73.1(ws@8.21.0)(zod@3.25.76)
-      '@mariozechner/pi-tui': 0.73.1
-      '@silvia-odwyer/photon-node': 0.3.4
-      chalk: 5.6.2
-      cli-highlight: 2.1.11
-      diff: 8.0.4
-      extract-zip: 2.0.1
-      file-type: 21.3.4
-      glob: 13.0.6
-      hosted-git-info: 9.0.3
-      ignore: 7.0.5
-      jiti: 2.7.0
-      marked: 15.0.12
-      minimatch: 10.2.5
-      proper-lockfile: 4.1.2
-      strip-ansi: 7.2.0
-      typebox: 1.1.39
-      undici: 7.25.0
-      uuid: 14.0.0
-      yaml: 2.9.0
-    optionalDependencies:
-      '@mariozechner/clipboard': 0.3.9
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-tui@0.73.1':
-    dependencies:
-      '@types/mime-types': 2.1.4
-      chalk: 5.6.2
-      get-east-asian-width: 1.6.0
-      marked: 15.0.12
-      mime-types: 3.0.2
-    optionalDependencies:
-      koffi: 2.16.2
-
   '@mistralai/mistralai@2.2.5':
     dependencies:
       ws: 8.21.0
@@ -2524,8 +1997,6 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.4':
     optional: true
 
-  '@silvia-odwyer/photon-node@0.3.4': {}
-
   '@smithy/core@3.24.4':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
@@ -2574,22 +2045,9 @@ snapshots:
       '@smithy/util-buffer-from': 2.2.0
       tslib: 2.8.1
 
-  '@tokenizer/inflate@0.4.1':
-    dependencies:
-      debug: 4.4.3
-      token-types: 6.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@tokenizer/token@0.3.0': {}
-
-  '@tootallnate/quickjs-emscripten@0.23.0': {}
-
   '@types/estree@1.0.8': {}
 
   '@types/estree@1.0.9': {}
-
-  '@types/mime-types@2.1.4': {}
 
   '@types/node@22.19.19':
     dependencies:
@@ -2602,11 +2060,6 @@ snapshots:
       pg-types: 2.2.0
 
   '@types/retry@0.12.0': {}
-
-  '@types/yauzl@2.10.3':
-    dependencies:
-      '@types/node': 22.19.19
-    optional: true
 
   '@vitest/expect@2.1.9':
     dependencies:
@@ -2650,37 +2103,13 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ansi-regex@5.0.1: {}
-
-  ansi-regex@6.2.2: {}
-
-  ansi-styles@4.3.0:
-    dependencies:
-      color-convert: 2.0.1
-
-  any-promise@1.3.0: {}
-
   assertion-error@2.0.1: {}
 
-  ast-types@0.13.4:
-    dependencies:
-      tslib: 2.8.1
-
-  balanced-match@4.0.4: {}
-
   base64-js@1.5.1: {}
-
-  basic-ftp@5.3.1: {}
 
   bignumber.js@9.3.1: {}
 
   bowser@2.14.1: {}
-
-  brace-expansion@5.0.6:
-    dependencies:
-      balanced-match: 4.0.4
-
-  buffer-crc32@0.2.13: {}
 
   buffer-equal-constant-time@1.0.1: {}
 
@@ -2711,41 +2140,11 @@ snapshots:
       loupe: 3.2.1
       pathval: 2.0.1
 
-  chalk@4.1.2:
-    dependencies:
-      ansi-styles: 4.3.0
-      supports-color: 7.2.0
-
-  chalk@5.6.2: {}
-
   check-error@2.1.3: {}
-
-  cli-highlight@2.1.11:
-    dependencies:
-      chalk: 4.1.2
-      highlight.js: 10.7.3
-      mz: 2.7.0
-      parse5: 5.1.1
-      parse5-htmlparser2-tree-adapter: 6.0.1
-      yargs: 16.2.0
-
-  cliui@7.0.4:
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-
-  color-convert@2.0.1:
-    dependencies:
-      color-name: 1.1.4
-
-  color-name@1.1.4: {}
 
   commander@2.20.3: {}
 
   data-uri-to-buffer@4.0.1: {}
-
-  data-uri-to-buffer@6.0.2: {}
 
   debug@4.4.3:
     dependencies:
@@ -2759,14 +2158,6 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  degenerator@5.0.1:
-    dependencies:
-      ast-types: 0.13.4
-      escodegen: 2.1.0
-      esprima: 4.0.1
-
-  diff@8.0.4: {}
-
   discontinuous-range@1.0.0: {}
 
   dunder-proto@1.0.1:
@@ -2778,12 +2169,6 @@ snapshots:
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
-
-  emoji-regex@8.0.0: {}
-
-  end-of-stream@1.4.5:
-    dependencies:
-      once: 1.4.0
 
   es-define-property@1.0.1: {}
 
@@ -2850,39 +2235,13 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.0
       '@esbuild/win32-x64': 0.28.0
 
-  escalade@3.2.0: {}
-
-  escodegen@2.1.0:
-    dependencies:
-      esprima: 4.0.1
-      estraverse: 5.3.0
-      esutils: 2.0.3
-    optionalDependencies:
-      source-map: 0.6.1
-
-  esprima@4.0.1: {}
-
-  estraverse@5.3.0: {}
-
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
 
-  esutils@2.0.3: {}
-
   expect-type@1.3.0: {}
 
   extend@3.0.2: {}
-
-  extract-zip@2.0.1:
-    dependencies:
-      debug: 4.4.3
-      get-stream: 5.2.0
-      yauzl: 2.10.0
-    optionalDependencies:
-      '@types/yauzl': 2.10.3
-    transitivePeerDependencies:
-      - supports-color
 
   fast-xml-builder@1.2.0:
     dependencies:
@@ -2896,23 +2255,10 @@ snapshots:
       path-expression-matcher: 1.5.0
       strnum: 2.3.0
 
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
-
   fetch-blob@3.2.0:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
-
-  file-type@21.3.4:
-    dependencies:
-      '@tokenizer/inflate': 0.4.1
-      strtok3: 10.3.5
-      token-types: 6.1.2
-      uint8array-extras: 1.5.0
-    transitivePeerDependencies:
-      - supports-color
 
   formdata-polyfill@4.0.10:
     dependencies:
@@ -2941,8 +2287,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  get-caller-file@2.0.5: {}
-
   get-east-asian-width@1.6.0: {}
 
   get-intrinsic@1.3.0:
@@ -2963,24 +2307,6 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.2
 
-  get-stream@5.2.0:
-    dependencies:
-      pump: 3.0.4
-
-  get-uri@6.0.5:
-    dependencies:
-      basic-ftp: 5.3.1
-      data-uri-to-buffer: 6.0.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  glob@13.0.6:
-    dependencies:
-      minimatch: 10.2.5
-      minipass: 7.1.3
-      path-scurry: 2.0.2
-
   google-auth-library@10.6.2:
     dependencies:
       base64-js: 1.5.1
@@ -2996,10 +2322,6 @@ snapshots:
 
   gopd@1.2.0: {}
 
-  graceful-fs@4.2.11: {}
-
-  has-flag@4.0.0: {}
-
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
@@ -3009,12 +2331,6 @@ snapshots:
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
-
-  highlight.js@10.7.3: {}
-
-  hosted-git-info@9.0.3:
-    dependencies:
-      lru-cache: 11.5.1
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -3030,19 +2346,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ieee754@1.2.1: {}
-
-  ignore@7.0.5: {}
-
   immutable@4.3.8: {}
 
-  ip-address@10.2.0: {}
-
-  is-fullwidth-code-point@3.0.0: {}
-
   isarray@2.0.5: {}
-
-  jiti@2.7.0: {}
 
   json-bigint@1.0.0:
     dependencies:
@@ -3081,13 +2387,9 @@ snapshots:
 
   loupe@3.2.1: {}
 
-  lru-cache@11.5.1: {}
-
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
-
-  lru-cache@7.18.3: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -3097,29 +2399,11 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mime-db@1.54.0: {}
-
-  mime-types@3.0.2:
-    dependencies:
-      mime-db: 1.54.0
-
-  minimatch@10.2.5:
-    dependencies:
-      brace-expansion: 5.0.6
-
-  minipass@7.1.3: {}
-
   moment@2.30.1: {}
 
   moo@0.5.3: {}
 
   ms@2.1.3: {}
-
-  mz@2.7.0:
-    dependencies:
-      any-promise: 1.3.0
-      object-assign: 4.1.1
-      thenify-all: 1.6.0
 
   nanoid@3.3.12: {}
 
@@ -3130,8 +2414,6 @@ snapshots:
       railroad-diagrams: 1.0.0
       randexp: 0.4.6
 
-  netmask@2.1.1: {}
-
   node-domexception@1.0.0: {}
 
   node-fetch@3.3.2:
@@ -3140,15 +2422,9 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
-  object-assign@4.1.1: {}
-
   object-hash@2.2.0: {}
 
   object-keys@1.1.1: {}
-
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
 
   openai@6.26.0(ws@8.21.0)(zod@3.25.76):
     optionalDependencies:
@@ -3160,46 +2436,13 @@ snapshots:
       '@types/retry': 0.12.0
       retry: 0.13.1
 
-  pac-proxy-agent@7.2.0:
-    dependencies:
-      '@tootallnate/quickjs-emscripten': 0.23.0
-      agent-base: 7.1.4
-      debug: 4.4.3
-      get-uri: 6.0.5
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      pac-resolver: 7.0.1
-      socks-proxy-agent: 8.0.5
-    transitivePeerDependencies:
-      - supports-color
-
-  pac-resolver@7.0.1:
-    dependencies:
-      degenerator: 5.0.1
-      netmask: 2.1.1
-
-  parse5-htmlparser2-tree-adapter@6.0.1:
-    dependencies:
-      parse5: 6.0.1
-
-  parse5@5.1.1: {}
-
-  parse5@6.0.1: {}
-
   partial-json@0.1.7: {}
 
   path-expression-matcher@1.5.0: {}
 
-  path-scurry@2.0.2:
-    dependencies:
-      lru-cache: 11.5.1
-      minipass: 7.1.3
-
   pathe@1.1.2: {}
 
   pathval@2.0.1: {}
-
-  pend@1.2.0: {}
 
   pg-cloudflare@1.4.0:
     optional: true
@@ -3269,12 +2512,6 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
-  proper-lockfile@4.1.2:
-    dependencies:
-      graceful-fs: 4.2.11
-      retry: 0.12.0
-      signal-exit: 3.0.7
-
   protobufjs@7.6.1:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -3290,26 +2527,6 @@ snapshots:
       '@types/node': 22.19.19
       long: 5.3.2
 
-  proxy-agent@6.5.0:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      lru-cache: 7.18.3
-      pac-proxy-agent: 7.2.0
-      proxy-from-env: 1.1.0
-      socks-proxy-agent: 8.0.5
-    transitivePeerDependencies:
-      - supports-color
-
-  proxy-from-env@1.1.0: {}
-
-  pump@3.0.4:
-    dependencies:
-      end-of-stream: 1.4.5
-      once: 1.4.0
-
   railroad-diagrams@1.0.0: {}
 
   randexp@0.4.6:
@@ -3317,11 +2534,7 @@ snapshots:
       discontinuous-range: 1.0.0
       ret: 0.1.15
 
-  require-directory@2.1.1: {}
-
   ret@0.1.15: {}
-
-  retry@0.12.0: {}
 
   retry@0.13.1: {}
 
@@ -3369,27 +2582,7 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  signal-exit@3.0.7: {}
-
-  smart-buffer@4.2.0: {}
-
-  socks-proxy-agent@8.0.5:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-      socks: 2.8.9
-    transitivePeerDependencies:
-      - supports-color
-
-  socks@2.8.9:
-    dependencies:
-      ip-address: 10.2.0
-      smart-buffer: 4.2.0
-
   source-map-js@1.2.1: {}
-
-  source-map@0.6.1:
-    optional: true
 
   split2@4.2.0: {}
 
@@ -3397,37 +2590,7 @@ snapshots:
 
   std-env@3.10.0: {}
 
-  string-width@4.2.3:
-    dependencies:
-      emoji-regex: 8.0.0
-      is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.1
-
-  strip-ansi@6.0.1:
-    dependencies:
-      ansi-regex: 5.0.1
-
-  strip-ansi@7.2.0:
-    dependencies:
-      ansi-regex: 6.2.2
-
   strnum@2.3.0: {}
-
-  strtok3@10.3.5:
-    dependencies:
-      '@tokenizer/token': 0.3.0
-
-  supports-color@7.2.0:
-    dependencies:
-      has-flag: 4.0.0
-
-  thenify-all@1.6.0:
-    dependencies:
-      thenify: 3.3.1
-
-  thenify@3.3.1:
-    dependencies:
-      any-promise: 1.3.0
 
   tinybench@2.9.0: {}
 
@@ -3438,12 +2601,6 @@ snapshots:
   tinyrainbow@1.2.0: {}
 
   tinyspy@3.0.2: {}
-
-  token-types@6.1.2:
-    dependencies:
-      '@borewit/text-codec': 0.2.2
-      '@tokenizer/token': 0.3.0
-      ieee754: 1.2.1
 
   ts-algebra@2.0.0: {}
 
@@ -3459,13 +2616,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  uint8array-extras@1.5.0: {}
-
   undici-types@6.21.0: {}
-
-  undici@7.25.0: {}
-
-  uuid@14.0.0: {}
 
   vite-node@2.1.9(@types/node@22.19.19):
     dependencies:
@@ -3536,42 +2687,13 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  wrap-ansi@7.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
-  wrappy@1.0.2: {}
-
   ws@8.21.0: {}
 
   xml-naming@0.1.0: {}
 
   xtend@4.0.2: {}
 
-  y18n@5.0.8: {}
-
   yallist@4.0.0: {}
-
-  yaml@2.9.0: {}
-
-  yargs-parser@20.2.9: {}
-
-  yargs@16.2.0:
-    dependencies:
-      cliui: 7.0.4
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 20.2.9
-
-  yauzl@2.10.0:
-    dependencies:
-      buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
 
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,28 @@ importers:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@22.19.19)
 
+  apps/lark-bot:
+    dependencies:
+      '@earendil-works/pi-ai':
+        specifier: ^0.74.2
+        version: 0.74.2(ws@8.21.0)(zod@3.25.76)
+      '@harness-pi/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@harness-pi/plugins':
+        specifier: workspace:*
+        version: link:../../packages/plugins
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.19
+      tsx:
+        specifier: ^4.0.0
+        version: 4.22.3
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+
   examples/01-bare-kernel:
     dependencies:
       '@earendil-works/pi-ai':


### PR DESCRIPTION
把当前 `dev` 状态发布到 `main`(仓库标准发布流:dev 累积 → dev→main)。本次累积 8 个 commit,均已分别过 CI 合入 dev。

## 内容
- **feat(core): LLM seam — `makeOpenAICompatibleModel` + typed `LlmOptions`(#38, #39)** — 消除自定义 Model 的 `as Model` cast 与 cost 占位;`llmOptions` typed 化,typo 编译期失败。三门禁 review 判干净。
- **chore(lark-bot): 标 `private:true`** — 防止个人飞书 bot 被 `pnpm -r publish` 误发到公共 npm(三门禁 review 抓到)。
- feat(lark-bot): Feishu Agent-OS bot(c0a1d86)
- chore: `@mariozechner/pi-*` → `@earendil-works/*` 迁移(#27, #37)
- docs: 设计文档同步(#32, #36)
- fix(plugins): LeaseQueue/WorkPool abort must-settle(#31, #35)
- fix(adapters): atomic appendEntry/fork via single CTE(#29, #34)
- fix(coding-agent): strictPersistence 接线 + persistenceErrors(#30, #33)

## 验证
全仓 build → typecheck → test 全绿(core / plugins / adapters / tools / coding-agent / examples)。CI 挂 postgres:16 service,18 个真 PG 集成测试在 CI 实跑。

## 发布后(本 PR 合并后由 owner 手动执行)
版本 bump + `pnpm -r publish`(发布集 5 包,lark-bot 已 `private` 排除)+ 打 tag。

🤖 Generated with [Claude Code](https://claude.com/claude-code)