### PR TITLE
chore(release): v0.2.1

### DIFF
--- a/apps/coding-agent/package.json
+++ b/apps/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-pi/coding-agent",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Dogfood coding agent built on harness-pi — usable pi-tui CLI showcasing the harness-pi kernel",
   "license": "MIT",
   "repository": {

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-pi/adapters",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "SessionStore adapters for harness-pi (JSONL file + Postgres). Concrete I/O behind the kernel SessionStore protocol.",
   "license": "MIT",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-pi/core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Agent kernel — pi-ai loop + first-class hook system",
   "license": "MIT",
   "repository": {

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-pi/plugins",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Standard library of harness-pi plugins + controllers + sinks",
   "license": "MIT",
   "repository": {

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-pi/tools",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "First-party coding tools for harness-pi agents",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
统一 bump 5 个发布包 0.2.0 → 0.2.1(core / plugins / tools / adapters / coding-agent)。

发布内容已在 main(上一个发布 PR #41):LLM seam(#38/#39)、lark-bot 私有化、#29/#30/#31 修复、pi-ai 迁移。本 PR 仅打版本号,合并后由 owner 执行 `pnpm -r publish` + 打 tag。

lark-bot 保持 `private:true`,发布集 = 5 包。

🤖 Generated with [Claude Code](https://claude.com/claude-code)