### PR TITLE
fix(plugins): forkSession 过滤悬挂 tool_use (#43 S1)

### DIFF
--- a/packages/core/src/__tests__/filter-incomplete-toolcalls.test.ts
+++ b/packages/core/src/__tests__/filter-incomplete-toolcalls.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { filterIncompleteToolCalls, type Message } from "../index.js";
+
+// filterIncompleteToolCalls 只读 role / content / toolCallId / block.type / block.id，
+// 故用最小构造（其余 provider/usage/stopReason 等字段无关，cast 掉）。
+const user = (t: string): Message =>
+  ({ role: "user", content: t, timestamp: 0 }) as unknown as Message;
+const toolCall = (id: string) => ({ type: "toolCall", id, name: "read", arguments: {} });
+const text = (t: string) => ({ type: "text", text: t });
+const asst = (blocks: unknown[]): Message =>
+  ({ role: "assistant", content: blocks, timestamp: 0 }) as unknown as Message;
+const toolResult = (toolCallId: string): Message =>
+  ({
+    role: "toolResult",
+    toolCallId,
+    toolName: "read",
+    content: [],
+    isError: false,
+    timestamp: 0,
+  }) as unknown as Message;
+
+describe("filterIncompleteToolCalls", () => {
+  it("丢掉含未被 result 的 toolCall 的 assistant（悬挂 tool_use）", () => {
+    const msgs = [user("hi"), asst([text("calling"), toolCall("tc1")])];
+    expect(filterIncompleteToolCalls(msgs)).toEqual([msgs[0]]);
+  });
+
+  it("保留所有 toolCall 都有 result 的 assistant", () => {
+    const msgs = [user("hi"), asst([toolCall("tc1")]), toolResult("tc1")];
+    expect(filterIncompleteToolCalls(msgs)).toHaveLength(3);
+  });
+
+  it("partial batch：整条 assistant 被丢 + 随之产生的 orphan result 也被丢", () => {
+    // tc1 有 result、tc2 悬挂 → 整条 assistant 丢 → tc1 的 result 变 orphan → 丢
+    const msgs = [
+      user("hi"),
+      asst([toolCall("tc1"), toolCall("tc2")]),
+      toolResult("tc1"),
+    ];
+    expect(filterIncompleteToolCalls(msgs)).toEqual([msgs[0]]);
+  });
+
+  it("丢掉本就存在的 orphan toolResult（result 无对应 toolCall）", () => {
+    const msgs = [user("hi"), toolResult("ghost")];
+    expect(filterIncompleteToolCalls(msgs)).toEqual([msgs[0]]);
+  });
+
+  it("无悬挂时返回内容等价的新数组（始终 copy）", () => {
+    const msgs = [user("hi"), asst([text("done")])];
+    const out = filterIncompleteToolCalls(msgs);
+    expect(out).toEqual(msgs);
+    expect(out).not.toBe(msgs);
+  });
+
+  it("non-assistant 与纯文本 assistant 原样保留", () => {
+    const msgs = [user("a"), asst([text("t")]), user("b")];
+    expect(filterIncompleteToolCalls(msgs)).toEqual(msgs);
+  });
+
+  it("多 toolCall 全部 resolved 的 assistant 保留，其 result 不被误删", () => {
+    const msgs = [
+      user("hi"),
+      asst([toolCall("tc1"), toolCall("tc2")]),
+      toolResult("tc1"),
+      toolResult("tc2"),
+    ];
+    expect(filterIncompleteToolCalls(msgs)).toHaveLength(4);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,7 +47,11 @@ export { defaultIsContextOverflow } from "./context-overflow.js";
 
 // ─────────── Tool 形态 + message helpers ───────────
 export type { HarnessTool } from "./types.js";
-export { createUserMessage, createAttachmentMessage } from "./types.js";
+export {
+  createUserMessage,
+  createAttachmentMessage,
+  filterIncompleteToolCalls,
+} from "./types.js";
 
 // ─────────── Session persistence (协议在内核，落盘实现在 adapter) ───────────
 export { MemorySessionStore } from "./session-store.js";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -116,3 +116,52 @@ export function createAttachmentMessage(opts: {
     },
   } as Message & { _meta?: Record<string, unknown> };
 }
+
+/**
+ * 剔除「悬挂的 tool 调用」，让一段 messages snapshot 重新喂给 pi-ai 时合法。
+ *
+ * 背景：snapshot 可能停在 tool batch 中途——assistant 已发出 `toolCall`，但对应的
+ * `toolResult` 还没 append。把这种带「无 result 的 toolCall」的消息直接喂 provider 会
+ * 报错（orphan tool_use 400）。fork / sub-agent 这类「拿父 snapshot 当 initialMessages」
+ * 的路径必须先过一遍本函数。借鉴 Claude Code `filterIncompleteToolCalls`
+ * （[08-claude-code-lessons](docs/08-claude-code-lessons.md)），并补齐对称的 orphan-result 清理。
+ *
+ * 三遍、纯函数（不改入参）：
+ *   1. 收集所有 `toolResult` 的 `toolCallId`。
+ *   2. 丢掉「含任一未被 result 的 `toolCall`」的整条 assistant（连同其 text/thinking——
+ *      与 pi-ai 消息原子性一致：assistant 的 content 块不可拆开发）。
+ *   3. 丢掉 orphan `toolResult`（其 `toolCallId` 对应的 assistant 已在第 2 步被丢）。
+ *
+ * snapshot 无悬挂时返回**内容等价**的新数组（始终是 copy，不返回原引用）。
+ */
+export function filterIncompleteToolCalls(messages: Message[]): Message[] {
+  // Pass 1：已有 result 的 toolCallId。
+  const resolved = new Set<string>();
+  for (const m of messages) {
+    if (m.role === "toolResult") resolved.add(m.toolCallId);
+  }
+
+  // Pass 2：保留 non-assistant + 所有 toolCall 都有 result 的 assistant；
+  // 记录存活的 toolCall id 供 Pass 3 清理 orphan result。
+  const survivingToolCallIds = new Set<string>();
+  const afterAssistantFilter = messages.filter((m) => {
+    if (m.role !== "assistant") return true;
+    let hasIncomplete = false;
+    for (const block of m.content) {
+      if (block.type === "toolCall" && !resolved.has(block.id)) {
+        hasIncomplete = true;
+        break;
+      }
+    }
+    if (hasIncomplete) return false;
+    for (const block of m.content) {
+      if (block.type === "toolCall") survivingToolCallIds.add(block.id);
+    }
+    return true;
+  });
+
+  // Pass 3：丢掉 toolCall 已被丢弃的 orphan toolResult。
+  return afterAssistantFilter.filter(
+    (m) => m.role !== "toolResult" || survivingToolCallIds.has(m.toolCallId),
+  );
+}

--- a/packages/plugins/src/__tests__/phase3.test.ts
+++ b/packages/plugins/src/__tests__/phase3.test.ts
@@ -4,7 +4,13 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { AgentSession, Type, type HarnessTool } from "@harness-pi/core";
+import {
+  AgentSession,
+  Type,
+  createUserMessage,
+  type HarnessTool,
+  type Message,
+} from "@harness-pi/core";
 import { createFakeModel } from "@harness-pi/core/testing";
 import { costTracker, getCostStats } from "../cost-tracker.js";
 import { forkSession, forkSessionAll } from "../controllers/fork-session.js";
@@ -145,6 +151,56 @@ describe("Phase 3: forkSession controller", () => {
     expect(parent.messages.length).toBe(parentBeforeFork);
     // 子拿到父历史 + 自己新增
     expect(result.messages.length).toBeGreaterThan(parentBeforeFork);
+    expect(result.summary.reason).toBe("done");
+    parentFake.teardown();
+    childFake.teardown();
+  });
+
+  it("fork 过滤父 snapshot 里悬挂的 tool_use（S1 真 bug）", async () => {
+    // 父 snapshot 停在 tool batch 中途：assistant 发了 toolCall 但还没 toolResult。
+    // 裸拷这段当子 initialMessages 喂 pi-ai 会 400；forkSession 必须先过滤掉。
+    const hangingAssistant = {
+      role: "assistant",
+      content: [{ type: "toolCall", id: "tc1", name: "read", arguments: {} }],
+      timestamp: 0,
+    } as unknown as Message;
+    const parentFake = createFakeModel([
+      { content: [{ type: "text", text: "unused" }] },
+    ]);
+    const parent = new AgentSession({
+      model: parentFake,
+      tools: [],
+      initialMessages: [createUserMessage("hi"), hangingAssistant],
+    });
+
+    let received: Message[] | undefined;
+    const childFake = createFakeModel([
+      { content: [{ type: "text", text: "child done" }] },
+    ]);
+    const result = await forkSession(
+      parent,
+      (init) => {
+        received = init;
+        return new AgentSession({
+          model: childFake,
+          tools: [],
+          initialMessages: init,
+        });
+      },
+      { prompt: "child prompt" },
+    );
+
+    // factory 收到的 init 不含任何悬挂 toolCall（fake model 不校验消息，故断言过滤本身）
+    const hasHangingToolCall = (received ?? []).some(
+      (m) =>
+        m.role === "assistant" &&
+        m.content.some(
+          (b: { type: string }) => b.type === "toolCall",
+        ),
+    );
+    expect(hasHangingToolCall).toBe(false);
+    // 但 user 历史保留
+    expect((received ?? []).some((m) => m.role === "user")).toBe(true);
     expect(result.summary.reason).toBe("done");
     parentFake.teardown();
     childFake.teardown();

--- a/packages/plugins/src/controllers/fork-session.ts
+++ b/packages/plugins/src/controllers/fork-session.ts
@@ -15,6 +15,7 @@
  * 借鉴 Claude Code `forkedAgent` + `CacheSafeParams`（[08-claude-code-lessons](docs/08-claude-code-lessons.md) §4.1）。
  */
 
+import { filterIncompleteToolCalls } from "@harness-pi/core";
 import type { AgentSession, Message, RunSummary } from "@harness-pi/core";
 
 export interface ForkOptions {
@@ -53,9 +54,11 @@ export async function forkSession(
   factory: (initialMessages: Message[]) => AgentSession,
   opts: ForkOptions = {},
 ): Promise<ForkResult> {
-  // 拷贝 snapshot —— 父 session 不会被 child 影响（initialMessages 是 [...父messages] copy）
+  // 拷贝 snapshot —— 父 session 不会被 child 影响（initialMessages 是 [...父messages] copy）。
+  // 过滤悬挂的 tool 调用：父若在 tool batch 中途被 fork，snapshot 会含「无 result 的 toolCall」，
+  // 直接当子 initialMessages 喂 pi-ai 会 400。filterIncompleteToolCalls 也始终返回 copy。
   const snapshot = parent.snapshot();
-  const child = factory(snapshot.messages);
+  const child = factory(filterIncompleteToolCalls(snapshot.messages));
 
   // M4：防 self-fork。factory 必须返回新的 AgentSession 实例，否则 child.run() 会
   // 直接 mutate 父，破坏 fork 语义。


### PR DESCRIPTION
**0.3.0 Wave A · S1**(epic #43)。修一个真 bug:父在 tool batch 中途被 `forkSession` 时,snapshot 含「有 `toolCall` 但无对应 `toolResult`」的悬挂 assistant,裸拷当子 initialMessages 喂 pi-ai 会 400(orphan tool_use)。

## 改动
- core 新增并导出纯函数 `filterIncompleteToolCalls`(`types.ts`):三遍过滤——丢悬挂 tool_use 的整条 assistant + 对称清理随之产生的 orphan `toolResult`(两者都会 400)。snapshot 一致性是内核不变量延伸,放 core 供 fork/sub-agent 复用。
- `fork-session.ts` 拷 snapshot 后先过 `filterIncompleteToolCalls`。

## 测试
- core 单测 7 例(悬挂 / partial batch / orphan result / copy 语义 / 多 toolCall)。
- plugins 集成 1 例:断言 `forkSession` 确实把过滤后的 init 交给 factory(fake model 不校验消息,故断言过滤本身而非"子不报错")。
- 全仓 build → typecheck → test 全绿(core 269 / plugins 234 / 其余不变)。

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)