### PR TITLE
feat(plugins): microcompact — tool-result 级廉价分档清理 (#43 C2)

### DIFF
--- a/packages/plugins/src/__tests__/microcompact.test.ts
+++ b/packages/plugins/src/__tests__/microcompact.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect } from "vitest";
+import { AgentSession, createUserMessage } from "@harness-pi/core";
+import { createTestContext, createFakeModel } from "@harness-pi/core/testing";
+import type { Message } from "@earendil-works/pi-ai";
+import { microcompact } from "../microcompact.js";
+
+function textOf(m: Message): string {
+  return typeof m.content === "string"
+    ? m.content
+    : m.content.map((b) => ("text" in b ? b.text : "")).join("");
+}
+
+/** 造一条 toolResult message。 */
+function tr(toolName: string, text: string, ts = 0): Message {
+  return {
+    role: "toolResult",
+    toolCallId: `c-${Math.random()}`,
+    toolName,
+    content: [{ type: "text", text }],
+    isError: false,
+    timestamp: ts,
+  };
+}
+
+describe("microcompact", () => {
+  it("keeps the most recent N tool results verbatim, clears older whitelisted ones with a named placeholder", () => {
+    // 20 条 'read' 的 toolResult，keepRecent=5；triggerTokens 极小确保触发、targetTokens 极小确保清到最多。
+    const msgs: Message[] = Array.from({ length: 20 }, (_, i) =>
+      tr("read", `RESULT_${i}_` + "x".repeat(40)),
+    );
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 1,
+      targetTokens: 1,
+      keepRecent: 5,
+    });
+    const { ctx } = createTestContext();
+    const view = compact.transformMessagesBeforeLlm!(msgs, ctx) as Message[];
+
+    expect(view).toBeDefined();
+    // 最近 5 条原文保留
+    for (let i = 15; i < 20; i++) {
+      expect(textOf(view[i]!)).toBe(textOf(msgs[i]!));
+    }
+    // 其余 15 条被占位符替换，且占位符含工具名
+    for (let i = 0; i < 15; i++) {
+      const t = textOf(view[i]!);
+      expect(t).toContain("microcompact");
+      expect(t).toContain("read"); // 工具名
+      expect(t).not.toContain("RESULT_"); // 原文已清
+    }
+  });
+
+  it("triggers on token volume even with few-but-huge results", () => {
+    // 只有 3 条，但单条巨大：按条数测不出，按体积能触发。keepRecent=1 → 留最后 1 条。
+    const msgs: Message[] = [
+      tr("read", "A".repeat(4000)),
+      tr("read", "B".repeat(4000)),
+      tr("read", "C".repeat(40)), // 最近，保留
+    ];
+    const compact = microcompact({
+      compactableTools: new Set(["read"]),
+      triggerTokens: 500, // 估算 (4000+4000)/4 ≈ 2000 > 500 → 触发
+      targetTokens: 100,
+      keepRecent: 1,
+    });
+    const { ctx } = createTestContext();
+    const view = compact.transformMessagesBeforeLlm!(msgs, ctx) as Message[];
+
+    expect(view).toBeDefined();
+    expect(textOf(view[0]!)).toContain("microcompact"); // 巨大旧条被清
+    expect(textOf(view[1]!)).toContain("microcompact");
+    expect(textOf(view[2]!)).toBe("C".repeat(40)); // 最近 1 条原文保留
+  });
+
+  it("stops clearing once target volume is reached (does not clear everything)", () => {
+    // 5 条各 ~1000 tokens（estimateTokensByChars ≈ chars/4），keepRecent=0。总 ≈ 5000。
+    // trigger=3000（5000 > 3000 → 触发）；target=3000 → 逐条清并重估，降到 ≤3000 即停。
+    // 实测：清 2 条剩 ≈3024（仍 >3000）→ 再清 1 条剩 ≈2036（≤3000）即停 = 清 3 条；关键是**不会**全清 5 条。
+    const msgs: Message[] = Array.from({ length: 5 }, () => tr("read", "z".repeat(4000)));
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 3000, // 低于总体积 → 触发
+      targetTokens: 3000, // 清到 ≤3000 即停
+      keepRecent: 0,
+    });
+    const { ctx } = createTestContext();
+    const view = compact.transformMessagesBeforeLlm!(msgs, ctx) as Message[];
+
+    expect(view).toBeDefined();
+    const clearedCount = view.filter((m) => textOf(m).includes("microcompact")).length;
+    expect(clearedCount).toBe(3); // 清到目标即停
+    expect(clearedCount).toBeLessThan(5); // 而非全清——「清到目标为止」语义
+    expect(textOf(view[3]!)).toContain("z".repeat(40)); // 第 4、5 条原文保留
+    expect(textOf(view[4]!)).toContain("z".repeat(40));
+  });
+
+  it("leaves non-whitelisted tool results, assistant reasoning and user messages untouched", () => {
+    const assistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "thinking about it" }],
+      api: "x",
+      provider: "x",
+      model: "x",
+      usage: {},
+      stopReason: "stop",
+      timestamp: 0,
+    } as unknown as Message;
+    const msgs: Message[] = [
+      createUserMessage("user question " + "q".repeat(2000)),
+      assistant,
+      tr("bash", "BASH_OUTPUT " + "b".repeat(2000)), // 非白名单
+      tr("read", "READ_OUTPUT " + "r".repeat(2000)), // 白名单、旧
+      tr("read", "RECENT"), // 最近，保留
+    ];
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 1,
+      targetTokens: 1,
+      keepRecent: 1,
+    });
+    const { ctx } = createTestContext();
+    const view = compact.transformMessagesBeforeLlm!(msgs, ctx) as Message[];
+
+    expect(view).toBeDefined();
+    expect(textOf(view[0]!)).toContain("user question"); // user 不动
+    expect(textOf(view[1]!)).toBe("thinking about it"); // assistant 不动
+    expect(textOf(view[2]!)).toContain("BASH_OUTPUT"); // 非白名单 toolResult 不动
+    expect(textOf(view[3]!)).toContain("microcompact"); // 白名单旧条被清
+    expect(textOf(view[3]!)).toContain("read");
+    expect(textOf(view[4]!)).toBe("RECENT"); // 最近保留
+  });
+
+  it("gapMinutes: clears aggressively when the cache is cold even if volume is small", () => {
+    // 体积很小（不会按 token 触发），但最后一条 timestamp 距 now 超过 gapMinutes → 仍清白名单旧条。
+    const t0 = 1_000_000;
+    const msgs: Message[] = [
+      tr("read", "old1", t0),
+      tr("read", "old2", t0),
+      tr("read", "recent", t0 + 1000),
+    ];
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 1_000_000, // 极大 → 绝不会按体积触发
+      keepRecent: 1,
+      gapMinutes: 5,
+      now: () => t0 + 6 * 60_000, // 距最后一条 timestamp(t0+1000) 约 6 分钟 > 5
+    });
+    const { ctx } = createTestContext();
+    const view = compact.transformMessagesBeforeLlm!(msgs, ctx) as Message[];
+
+    expect(view).toBeDefined();
+    expect(textOf(view[0]!)).toContain("microcompact"); // gap 触发，旧条被清
+    expect(textOf(view[1]!)).toContain("microcompact");
+    expect(textOf(view[2]!)).toBe("recent"); // 最近保留
+  });
+
+  it("gapMinutes: does NOT trigger when within the gap window and volume small", () => {
+    const t0 = 1_000_000;
+    const msgs: Message[] = [tr("read", "a", t0), tr("read", "b", t0), tr("read", "c", t0)];
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 1_000_000,
+      keepRecent: 1,
+      gapMinutes: 5,
+      now: () => t0 + 2 * 60_000, // 才 2 分钟 < 5
+    });
+    const { ctx } = createTestContext();
+    expect(compact.transformMessagesBeforeLlm!(msgs, ctx)).toBeUndefined();
+  });
+
+  it("returns undefined (no-op) when below the trigger volume and no gap configured", () => {
+    const msgs: Message[] = [tr("read", "tiny"), tr("read", "small")];
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 1_000_000,
+      keepRecent: 1,
+    });
+    const { ctx } = createTestContext();
+    expect(compact.transformMessagesBeforeLlm!(msgs, ctx)).toBeUndefined();
+  });
+
+  it("returns undefined when over volume but nothing is clearable (all within keepRecent)", () => {
+    const msgs: Message[] = [tr("read", "x".repeat(4000)), tr("read", "y".repeat(4000))];
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 1, // 触发
+      keepRecent: 5, // 但全在保留窗口内
+    });
+    const { ctx } = createTestContext();
+    expect(compact.transformMessagesBeforeLlm!(msgs, ctx)).toBeUndefined();
+  });
+
+  it("is view-only: does not mutate the input messages array nor its elements", () => {
+    const original = tr("read", "ORIGINAL " + "x".repeat(4000));
+    const msgs: Message[] = [original, tr("read", "RECENT")];
+    const before = JSON.stringify(msgs);
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 1,
+      targetTokens: 1,
+      keepRecent: 1,
+    });
+    const { ctx } = createTestContext();
+    const view = compact.transformMessagesBeforeLlm!(msgs, ctx) as Message[];
+
+    expect(textOf(view[0]!)).toContain("microcompact"); // view 改了
+    expect(JSON.stringify(msgs)).toBe(before); // 原数组与元素未被改
+    expect(textOf(msgs[0]!)).toContain("ORIGINAL"); // 原 toolResult content 仍是原文
+    expect(view).not.toBe(msgs); // 是新数组
+  });
+
+  it("placeholder reports the original content char count", () => {
+    const body = "y".repeat(4000);
+    const msgs: Message[] = [tr("read", body), tr("read", "recent")];
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 1,
+      targetTokens: 1,
+      keepRecent: 1,
+    });
+    const { ctx } = createTestContext();
+    const view = compact.transformMessagesBeforeLlm!(msgs, ctx) as Message[];
+    expect(textOf(view[0]!)).toContain(`~${body.length} chars`);
+  });
+
+  it("accepts a custom placeholderText", () => {
+    const msgs: Message[] = [tr("read", "x".repeat(4000)), tr("read", "recent")];
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 1,
+      targetTokens: 1,
+      keepRecent: 1,
+      placeholderText: (tool, chars) => `CLEARED(${tool}/${chars})`,
+    });
+    const { ctx } = createTestContext();
+    const view = compact.transformMessagesBeforeLlm!(msgs, ctx) as Message[];
+    expect(textOf(view[0]!)).toBe(`CLEARED(read/4000)`);
+  });
+
+  it("rejects invalid options at construction", () => {
+    expect(() => microcompact({ compactableTools: ["read"], triggerTokens: 0 })).toThrow(
+      /triggerTokens/,
+    );
+    expect(() =>
+      microcompact({ compactableTools: ["read"], triggerTokens: 100, targetTokens: 0 }),
+    ).toThrow(/targetTokens/);
+    expect(() =>
+      microcompact({ compactableTools: ["read"], triggerTokens: 100, targetTokens: 200 }),
+    ).toThrow(/targetTokens/); // > triggerTokens
+    expect(() =>
+      microcompact({ compactableTools: ["read"], triggerTokens: 100, gapMinutes: 0 }),
+    ).toThrow(/gapMinutes/);
+  });
+
+  it("end-to-end: the model sees the microcompacted view while full history persists", async () => {
+    const initial: Message[] = [
+      tr("read", "FILE_A " + "a".repeat(4000)),
+      tr("read", "FILE_B " + "b".repeat(4000)),
+      tr("read", "FILE_C"), // 最近，保留
+    ];
+    const fake = createFakeModel([{ content: [{ type: "text", text: "ok" }], stopReason: "stop" }]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [],
+      initialMessages: initial,
+      hooks: [
+        microcompact({
+          compactableTools: ["read"],
+          triggerTokens: 100, // 大体积 → 触发
+          targetTokens: 1, // 尽量清
+          keepRecent: 1,
+        }),
+      ],
+    });
+    await session.run("go");
+
+    const view = fake.getCalls()[0]!.messages;
+    // view 里旧的两条 read 被占位符替换，FILE_C + "go" 原文在
+    expect(textOf(view[0]!)).toContain("microcompact");
+    expect(textOf(view[1]!)).toContain("microcompact");
+    expect(textOf(view[2]!)).toBe("FILE_C");
+    // 完整原始历史未被破坏：session.messages 里旧 read 仍是原文。
+    expect(textOf(session.messages[0]!)).toContain("FILE_A");
+    expect(textOf(session.messages[1]!)).toContain("FILE_B");
+    fake.teardown();
+  });
+});

--- a/packages/plugins/src/__tests__/microcompact.test.ts
+++ b/packages/plugins/src/__tests__/microcompact.test.ts
@@ -75,8 +75,9 @@ describe("microcompact", () => {
 
   it("stops clearing once target volume is reached (does not clear everything)", () => {
     // 5 条各 ~1000 tokens（estimateTokensByChars ≈ chars/4），keepRecent=0。总 ≈ 5000。
-    // trigger=3000（5000 > 3000 → 触发）；target=3000 → 逐条清并重估，降到 ≤3000 即停。
-    // 实测：清 2 条剩 ≈3024（仍 >3000）→ 再清 1 条剩 ≈2036（≤3000）即停 = 清 3 条；关键是**不会**全清 5 条。
+    // trigger=3000（5000 > 3000 → 触发）；target=3000 → 从最旧逐条清并重估，降到 ≤3000 即停。
+    // 契约 = 「清到目标即停、绝不全清」；断言**不耦合估算器精确算术**（清了几条随 rounding 可能微变，
+    // 真正的不变量是 0 < cleared < 5、且最近一条（早停必发生在清到它之前）幸存。）
     const msgs: Message[] = Array.from({ length: 5 }, () => tr("read", "z".repeat(4000)));
     const compact = microcompact({
       compactableTools: ["read"],
@@ -89,10 +90,9 @@ describe("microcompact", () => {
 
     expect(view).toBeDefined();
     const clearedCount = view.filter((m) => textOf(m).includes("microcompact")).length;
-    expect(clearedCount).toBe(3); // 清到目标即停
-    expect(clearedCount).toBeLessThan(5); // 而非全清——「清到目标为止」语义
-    expect(textOf(view[3]!)).toContain("z".repeat(40)); // 第 4、5 条原文保留
-    expect(textOf(view[4]!)).toContain("z".repeat(40));
+    expect(clearedCount).toBeGreaterThan(0); // 触发并清了一些
+    expect(clearedCount).toBeLessThan(5); // 但绝不全清——「清到目标为止」语义
+    expect(textOf(view[4]!)).toBe("z".repeat(4000)); // 最近一条必然幸存（早停发生在清到它之前），精确比对
   });
 
   it("leaves non-whitelisted tool results, assistant reasoning and user messages untouched", () => {
@@ -153,6 +153,53 @@ describe("microcompact", () => {
     expect(textOf(view[0]!)).toContain("microcompact"); // gap 触发，旧条被清
     expect(textOf(view[1]!)).toContain("microcompact");
     expect(textOf(view[2]!)).toBe("recent"); // 最近保留
+  });
+
+  it("gapMinutes (cold cache) clears ALL clearable, ignoring the targetTokens early-stop", () => {
+    // 区分 cold-cache 路径与 volume 路径:triggerTokens 极大 → volume 永不触发(只有 cold 路径会动);
+    // targetTokens=3000(若 cold 误用了体积早停,会停在 ~3 条);keepRecent=0(5 条全可清);gap 超阈值 → cold。
+    // cold 路径**无早停**,应把 5 条全清。防回归:若给 cold 加上 targetTokens 早停(或从 volume 去掉),清的就不足 5。
+    const t0 = 1_000_000;
+    const msgs: Message[] = Array.from({ length: 5 }, () => tr("read", "z".repeat(4000), t0));
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 1_000_000, // volume 路径永不触发
+      targetTokens: 3000, // 若 cold 误用早停会停在 ~3 条
+      keepRecent: 0,
+      gapMinutes: 5,
+      now: () => t0 + 6 * 60_000, // 距末条 6 分钟 > 5 → cold
+    });
+    const { ctx } = createTestContext();
+    const view = compact.transformMessagesBeforeLlm!(msgs, ctx) as Message[];
+
+    expect(view).toBeDefined();
+    const cleared = view.filter((m) => textOf(m).includes("microcompact")).length;
+    expect(cleared).toBe(5); // cold 路径全清,不受 targetTokens 早停约束
+  });
+
+  it("keepRecent ranks by toolResult position, skipping interspersed non-whitelisted results", () => {
+    // 布局:read(旧) / bash(非白名单,夹中间) / read(旧) / read(最近)。keepRecent=1 只保护最近 1 条 toolResult。
+    // 证明 keepRecent 按 toolResult 序位(非 raw index)算,夹中间的 bash 既不被清、也不占保护名额。
+    const msgs: Message[] = [
+      tr("read", "OLD1 " + "x".repeat(2000)),
+      tr("bash", "BASH " + "b".repeat(2000)), // 非白名单
+      tr("read", "OLD2 " + "y".repeat(2000)),
+      tr("read", "RECENT"), // 最近 toolResult,keepRecent=1 保护
+    ];
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 1,
+      targetTokens: 1,
+      keepRecent: 1,
+    });
+    const { ctx } = createTestContext();
+    const view = compact.transformMessagesBeforeLlm!(msgs, ctx) as Message[];
+
+    expect(view).toBeDefined();
+    expect(textOf(view[0]!)).toContain("microcompact"); // OLD1 清
+    expect(textOf(view[1]!)).toContain("BASH"); // 非白名单 toolResult 不动
+    expect(textOf(view[2]!)).toContain("microcompact"); // OLD2 清(夹中间的 bash 没让它逃过保护名额)
+    expect(textOf(view[3]!)).toBe("RECENT"); // 最近保留
   });
 
   it("gapMinutes: does NOT trigger when within the gap window and volume small", () => {

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -47,6 +47,9 @@ export type { CompactSummarizeOptions } from "./compact-summarize.js";
 export { autoCompaction, estimateTokensByChars } from "./auto-compaction.js";
 export type { AutoCompactionOptions } from "./auto-compaction.js";
 
+export { microcompact } from "./microcompact.js";
+export type { MicrocompactOptions } from "./microcompact.js";
+
 export { permissionGate } from "./permission-gate.js";
 export type {
   PermissionGateOptions,

--- a/packages/plugins/src/microcompact.ts
+++ b/packages/plugins/src/microcompact.ts
@@ -16,8 +16,6 @@
  *
  * **view-only（与 autoCompaction / trimHistory 同款）**：`transformMessagesBeforeLlm` 只改本次返回的 messages
  * 数组（copy-on-write），完整原始历史天然留在 store 里；不动 user 消息、assistant 推理、非白名单工具的 toolResult。
- *
- * 详见 docs/05-plugins.md。
  */
 
 import type { Hook } from "@harness-pi/core";

--- a/packages/plugins/src/microcompact.ts
+++ b/packages/plugins/src/microcompact.ts
@@ -1,0 +1,147 @@
+/**
+ * microcompact —— tool-result 级的廉价分档清理（issue #46，roadmap C2）。
+ *
+ * 借鉴 claude-code 的 microcompact：作为「full summarize」之前**便宜**的一手。它**不**调 LLM、**不**总结，
+ * 只把「旧的、可重取的」白名单工具输出换成短占位符（原文仍由内核 durable 保存，模型若真需要可重新调用工具）。
+ * 永远保留**最近 N 条** toolResult 原文不动——cache 友好、不破坏模型对近况的感知。
+ *
+ * 与 `trimHistory` 的关系：本插件是它的「按 token 体积 + 按工具白名单」升级版。trimHistory 按**条数**无条件
+ * 裁剪所有 toolResult；microcompact 只在**体积超阈值**（或 cache 已冷）时动手、只清**白名单工具**、清到**目标
+ * 体积**为止即停。两者都 view-only（只改本 turn 发给 LLM 的 view，绝不写 `session.messages`）。
+ *
+ * **⚠️ Hook 顺序：本插件必须排在 `autoCompaction` 之前。** 与「压缩型 hook 排在裁剪型 hook 之前」准则一致——
+ * microcompact 是廉价的「先清可重取的旧 tool 输出」，autoCompaction 是昂贵的「总结剩下的早期对话」。先让
+ * microcompact 把白名单工具的体积降下来，autoCompaction 再据**裁剪后**的真实 view 决定是否还需要总结。反过来
+ * 排（autoCompaction 在前）会让昂贵总结多跑、甚至把本可廉价清掉的 tool 输出也卷进 summary。
+ *
+ * **view-only（与 autoCompaction / trimHistory 同款）**：`transformMessagesBeforeLlm` 只改本次返回的 messages
+ * 数组（copy-on-write），完整原始历史天然留在 store 里；不动 user 消息、assistant 推理、非白名单工具的 toolResult。
+ *
+ * 详见 docs/05-plugins.md。
+ */
+
+import type { Hook } from "@harness-pi/core";
+import type { Message } from "@earendil-works/pi-ai";
+import { estimateTokensByChars } from "./auto-compaction.js";
+
+export interface MicrocompactOptions {
+  /** 只清这些工具产生的 toolResult。**不 hardcode 工具名**——由调用方传（domain-free）。string[] 会归一成 Set。 */
+  compactableTools: Set<string> | string[];
+  /** 估算 tokens 超过它才触发清理。须 > 0。 */
+  triggerTokens: number;
+  /**
+   * 清理目标：从最旧开始清白名单 toolResult，清到估算体积 ≤ targetTokens 即停（不必全清）。
+   * 默认 = triggerTokens（即「降回阈值以下」）。须 > 0 且 ≤ triggerTokens。
+   */
+  targetTokens?: number;
+  /** 永远保留原样的最近 N 条 toolResult（不分工具）。默认 5。负数视为 0；非整数向下取整。 */
+  keepRecent?: number;
+  /**
+   * 可选：距上次活动超过这么多分钟（cache 已冷），即使体积没超阈值也触发清理。
+   * 用最后一条消息的 timestamp 与 `now()` 比较。须 > 0。不传则只按体积触发。
+   */
+  gapMinutes?: number;
+  /** 当前时刻（ms）。默认 `Date.now`；测试可注入以走 `gapMinutes` 路径。 */
+  now?: () => number;
+  /** token 估算器。默认 {@link estimateTokensByChars}（与 autoCompaction 同款、保守高估）。 */
+  estimateTokens?: (messages: Message[]) => number;
+  /** 占位符文案（默认带工具名 + 原内容字符数提示）。 */
+  placeholderText?: (toolName: string, originalChars: number) => string;
+}
+
+type ToolResult = Extract<Message, { role: "toolResult" }>;
+
+/** toolResult 的 content 文本总字符数（占位符里给模型一个「原来多大」的提示）。 */
+function contentChars(content: ToolResult["content"]): number {
+  let n = 0;
+  for (const b of content) {
+    if (b.type === "text") n += b.text.length;
+    else if (b.type === "image") n += 1; // 图片不按 base64 长度计，象征性记 1（避免占位符里报天文数字）
+  }
+  return n;
+}
+
+/**
+ * 构造一个 microcompact hook。
+ *
+ * 触发判据（满足任一即动手）：
+ *   1. **体积**：`estimateTokens(messages) > triggerTokens` → 从最旧白名单 toolResult 起清，降到 `targetTokens` 以下即停。
+ *   2. **gap**（可选）：`now() - 最后一条消息的 timestamp > gapMinutes` 分钟（cache 已冷）→ 把**所有**可清的白名单
+ *      toolResult 清掉（cache 反正要冷启重发，激进清以缩短下次冷启动 prompt，不受 targetTokens 早停约束）。
+ *
+ * 两种动作都永远跳过**最近 keepRecent 条** toolResult 与所有非白名单工具的 toolResult。
+ */
+export function microcompact(opts: MicrocompactOptions): Hook {
+  const compactable =
+    opts.compactableTools instanceof Set
+      ? opts.compactableTools
+      : new Set(opts.compactableTools);
+  if (!(opts.triggerTokens > 0)) {
+    throw new Error("microcompact: triggerTokens must be > 0");
+  }
+  const targetTokens = opts.targetTokens ?? opts.triggerTokens;
+  if (!(targetTokens > 0 && targetTokens <= opts.triggerTokens)) {
+    throw new Error("microcompact: targetTokens must be in (0, triggerTokens]");
+  }
+  const keepRecent = Math.max(0, Math.floor(opts.keepRecent ?? 5));
+  if (opts.gapMinutes !== undefined && !(opts.gapMinutes > 0)) {
+    throw new Error("microcompact: gapMinutes must be > 0");
+  }
+  const now = opts.now ?? Date.now;
+  const estimate = opts.estimateTokens ?? estimateTokensByChars;
+  const placeholderText =
+    opts.placeholderText ??
+    ((tool, chars) => `[microcompact: ${tool} output cleared, ~${chars} chars]`);
+
+  return {
+    name: "microcompact",
+    timeout: 50,
+
+    transformMessagesBeforeLlm(messages, _ctx) {
+      // gap 判据：最后一条消息的 timestamp 距 now 超过 gapMinutes（cache 已冷）。
+      let coldCache = false;
+      if (opts.gapMinutes !== undefined && messages.length > 0) {
+        const last = messages[messages.length - 1]!;
+        const gapMs = now() - last.timestamp;
+        coldCache = gapMs > opts.gapMinutes * 60_000;
+      }
+
+      // 体积没超阈值、且 cache 不冷 → 原样返回。
+      if (estimate(messages) <= opts.triggerTokens && !coldCache) return undefined;
+
+      // 找出**可清**的白名单 toolResult 下标（排除最近 keepRecent 条 toolResult）。
+      const toolResultIdxs: number[] = [];
+      for (let i = 0; i < messages.length; i++) {
+        if (messages[i]?.role === "toolResult") toolResultIdxs.push(i);
+      }
+      const clearableLimit = toolResultIdxs.length - keepRecent; // 这之前的 toolResult 才允许清
+      const clearable: number[] = [];
+      for (let rank = 0; rank < clearableLimit; rank++) {
+        const idx = toolResultIdxs[rank]!;
+        const msg = messages[idx]!;
+        if (msg.role === "toolResult" && compactable.has(msg.toolName)) {
+          clearable.push(idx);
+        }
+      }
+      if (clearable.length === 0) return undefined; // 没有可清的（全在 keepRecent 内 / 全非白名单）
+
+      // 体积触发：从最旧开始清，清到 ≤ targetTokens 即停（不必全清）。
+      // gap 触发（coldCache）：不设早停，把所有可清的都清掉（cache 反正冷了）。
+      const out = messages.slice(); // copy-on-write，绝不改原数组 / session.messages
+      let cleared = 0;
+      for (const idx of clearable) {
+        if (!coldCache && estimate(out) <= targetTokens) break; // 体积已降到目标（gap 路径不早停）
+        const msg = out[idx]! as ToolResult;
+        const chars = contentChars(msg.content);
+        out[idx] = {
+          ...msg,
+          content: [{ type: "text" as const, text: placeholderText(msg.toolName, chars) }],
+        };
+        cleared++;
+      }
+
+      if (cleared === 0) return undefined; // 体积本就 ≤ target 且非 coldCache → 无需清
+      return out;
+    },
+  };
+}

--- a/packages/plugins/src/microcompact.ts
+++ b/packages/plugins/src/microcompact.ts
@@ -125,20 +125,28 @@ export function microcompact(opts: MicrocompactOptions): Hook {
 
       // 体积触发：从最旧开始清，清到 ≤ targetTokens 即停（不必全清）。
       // gap 触发（coldCache）：不设早停，把所有可清的都清掉（cache 反正冷了）。
+      //
+      // **增量 running total，不每轮全量重估。** estimateTokensByChars 是逐消息/逐块累加，故替换一条时
+      // `estimate([原]) - estimate([占位])` 正是整体估值的精确变化量——结果与全量重估完全一致，但复杂度从
+      // O(N·K) 降到 O(N+K)。这点很关键：本 transform 是**同步**的，`timeout:50` 拦不住同步循环（计时器在
+      // 同步阻塞期间根本没机会 fire），而本插件正是为大文件读取场景设计、harness 又是多 session 跑在单
+      // event loop（WorkPool/LeaseQueue）——全量重估的 O(N·K) 会让一个 session 的压缩同步冻住其余所有 session。
       const out = messages.slice(); // copy-on-write，绝不改原数组 / session.messages
-      let cleared = 0;
+      let total = estimate(out); // 开头估一次
       for (const idx of clearable) {
-        if (!coldCache && estimate(out) <= targetTokens) break; // 体积已降到目标（gap 路径不早停）
+        if (!coldCache && total <= targetTokens) break; // O(1) 比较；降到目标即停（gap 路径不早停）
         const msg = out[idx]! as ToolResult;
         const chars = contentChars(msg.content);
-        out[idx] = {
+        const placeholder: ToolResult = {
           ...msg,
           content: [{ type: "text" as const, text: placeholderText(msg.toolName, chars) }],
         };
-        cleared++;
+        total -= estimate([msg]) - estimate([placeholder]); // 精确减去本条清理带来的体积下降
+        out[idx] = placeholder;
       }
 
-      if (cleared === 0) return undefined; // 体积本就 ≤ target 且非 coldCache → 无需清
+      // 走到这里必然清了 ≥1 条：volume 路径的入口判据已保证 total > triggerTokens ≥ targetTokens（首轮不早停）；
+      // cold 路径不早停、且 clearable 非空。故无需 cleared===0 的死分支。
       return out;
     },
   };

--- a/packages/plugins/src/microcompact.ts
+++ b/packages/plugins/src/microcompact.ts
@@ -9,10 +9,13 @@
  * 裁剪所有 toolResult；microcompact 只在**体积超阈值**（或 cache 已冷）时动手、只清**白名单工具**、清到**目标
  * 体积**为止即停。两者都 view-only（只改本 turn 发给 LLM 的 view，绝不写 `session.messages`）。
  *
- * **⚠️ Hook 顺序：本插件必须排在 `autoCompaction` 之前。** 与「压缩型 hook 排在裁剪型 hook 之前」准则一致——
- * microcompact 是廉价的「先清可重取的旧 tool 输出」，autoCompaction 是昂贵的「总结剩下的早期对话」。先让
- * microcompact 把白名单工具的体积降下来，autoCompaction 再据**裁剪后**的真实 view 决定是否还需要总结。反过来
- * 排（autoCompaction 在前）会让昂贵总结多跑、甚至把本可廉价清掉的 tool 输出也卷进 summary。
+ * **⚠️ Hook 顺序：microcompact 应排在 `autoCompaction` 之前。** （**别**套用 `auto-compaction.ts` 里
+ * 「autoCompaction 排在 `trimHistory` 等**裁剪型** transform 之前」那条规则来反推顺序——microcompact 不是那种
+ * 无条件机械裁剪:它既不总结、也不按条数硬裁,而是**有条件地清掉可重取的白名单工具输出**,是比「总结」更廉价
+ * 的一手,所以比 autoCompaction 还靠前。）理由:先让 microcompact 把白名单工具体积降下来,autoCompaction 再据
+ * **清理后**的真实 view 决定是否还要花钱总结(体积已够低时直接 no-op)。反过来排会让昂贵总结多跑、甚至把本可
+ * 廉价清掉的 tool 输出也卷进 summary。与 `trimHistory` 的取舍见下(microcompact 是其「按 token 体积 + 白名单 +
+ * keepRecent」的升级版,一般二选一,不必同时挂)。
  *
  * **view-only（与 autoCompaction / trimHistory 同款）**：`transformMessagesBeforeLlm` 只改本次返回的 messages
  * 数组（copy-on-write），完整原始历史天然留在 store 里；不动 user 消息、assistant 推理、非白名单工具的 toolResult。


### PR DESCRIPTION
**0.3.0 Wave A · C2**(epic #43)。新增 `microcompact` 插件:full summarize 之前的廉价一手——按 token 体积或 cache 冷度,把**旧的、可重取的白名单工具输出**换成短占位符(原文仍 durable 留存),永远保留最近 N 条。借鉴 claude-code 的 microcompact。

## 改动(零内核)
- 新增 `microcompact.ts`:挂 `transformMessagesBeforeLlm`,view-only copy-on-write(绝不改 `session.messages`)。两条触发:**体积**(估算 > triggerTokens → 从最旧白名单 toolResult 起清、增量 total 降到 targetTokens 即停)/ **cold-cache**(`gapMinutes`,末条 timestamp 距 now 超阈值 → 无早停全清)。`compactableTools` 白名单(不 hardcode 工具名,domain-free)、`keepRecent` 保护最近 N 条、占位符带工具名+原字符数。
- `index.ts` +3 导出。

## review-gate:4 轮,修了 3 件实质问题
1. **test-review**:cold-cache「无视 targetTokens 早停、全清」语义缺区分测试 → 补(triggerTokens 极大令 volume 不触发、断言 5 条全清,防分支交换回归)。
2. **linus**:volume 路径每轮 `estimate(out)` 全量重估 = **O(N·K)**,且 transform 同步 → `timeout:50` 失效、在多 session 单 event loop harness 里冻住其余 session → 改**增量 running total** O(N+K)(estimateTokensByChars 逐消息累加故增量精确等价,行为不变);移除死分支。
3. **code-review+linus**:hook 排序文档自相矛盾(自贴「压缩型」标签)→ 修正,明确 microcompact 是廉价清理预通道、排 autoCompaction 前。
- 终轮 **3/3 PASS**。

## 验证
plugins build → typecheck → test 全绿(microcompact **15 测试** / 全包 **248**)。

## 非阻塞 follow-up(review 列,不阻塞合并)
- docs(00-overview/roadmap/05-plugins)插件目录补登记 microcompact + 「排在 autoCompaction 之前」(本仓 docs 走独立同步 PR 惯例)。
- 默认值(keepRecent=5 / targetTokens=trigger)清理场景、image-content 占位符计数、自定义 estimateTokens 注入 的覆盖测试。
- `estimateTokens` 选项 JSDoc 注明「增量早停假设 per-message additive」。

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)