### PR TITLE
feat(core): C1 — compaction_boundary 写入(return-based onAfterFlush seam)(#43 C1)

### DIFF
--- a/packages/core/src/__tests__/after-flush.test.ts
+++ b/packages/core/src/__tests__/after-flush.test.ts
@@ -1,0 +1,321 @@
+/**
+ * onAfterFlush 内核 seam（C1 redesign，docs/09 §4.2）。
+ *
+ * collect-return 语义：hook **返回** `{ compactionBoundary }`，内核在 _flushToStore 之后 in-band、
+ * awaited、串行地把它 append 进 store。hook **没有**任何「可调用写能力」——这是上一版 detached
+ * 写设计被 review 抓出 data-loss / store-corruption 后的重做。核心回归（超时的 summarize 不致数据
+ * 丢失/乱序）见最后两个用例。
+ */
+
+import { describe, it, expect } from "vitest";
+import { AgentSession } from "../session.js";
+import { MemorySessionStore } from "../session-store.js";
+import { createFakeModel } from "../testing.js";
+import { createUserMessage } from "../types.js";
+import type { Hook, OnAfterFlushInput } from "../hook.js";
+import type { Message } from "@earendil-works/pi-ai";
+
+const noopTool = {
+  name: "noop",
+  description: "noop",
+  parameters: { type: "object", properties: {} } as never,
+  async execute() {
+    return { content: [{ type: "text" as const, text: "ok" }] };
+  },
+};
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("onAfterFlush kernel seam (C1 redesign)", () => {
+  it("fires after each turn's flush with the correct turnIdx and persistedCount", async () => {
+    const store = new MemorySessionStore();
+    // two turns: turn 0 makes a tool call (assistant + toolResult), turn 1 finishes.
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "text", text: "done" }] },
+    ]);
+    const seen: Array<{ turnIdx: number; persistedCount: number }> = [];
+    const observer: Hook = {
+      name: "observer",
+      onAfterFlush(input: OnAfterFlushInput) {
+        seen.push({ turnIdx: input.turnIdx, persistedCount: input.persistedCount });
+      },
+    };
+    const session = new AgentSession({
+      model: fake,
+      tools: [noopTool],
+      store,
+      hooks: [observer],
+    });
+
+    await session.run("go");
+
+    // turn 0: user + assistant(toolCall) + toolResult = 3 persisted; turn 1: + assistant(text) = 4.
+    expect(seen).toEqual([
+      { turnIdx: 0, persistedCount: 3 },
+      { turnIdx: 1, persistedCount: 4 },
+    ]);
+    const msgEntries = (await store.getPathToLeaf(session.id)).filter(
+      (e) => e.entry.kind === "message",
+    );
+    expect(msgEntries).toHaveLength(4);
+    fake.teardown();
+  });
+
+  it("a returned compactionBoundary is written by the kernel WITHOUT touching the HWM / session.messages", async () => {
+    const store = new MemorySessionStore();
+    const fake = createFakeModel([{ content: [{ type: "text", text: "a1" }] }]);
+    const summary = createUserMessage("SUMMARY");
+    const boundaryHook: Hook = {
+      name: "boundary-writer",
+      onAfterFlush() {
+        return { compactionBoundary: summary };
+      },
+    };
+    const session = new AgentSession({
+      model: fake,
+      tools: [],
+      store,
+      hooks: [boundaryHook],
+    });
+
+    await session.run("q1");
+
+    // live session keeps the full history (HWM unaffected: boundary is a store-only entry)
+    expect(session.messages.map((m) => m.role)).toEqual(["user", "assistant"]);
+
+    const path = await store.getPathToLeaf(session.id);
+    expect(path.filter((e) => e.entry.kind === "compaction_boundary")).toHaveLength(1);
+    // none of the messages were re-appended / duplicated
+    expect(path.filter((e) => e.entry.kind === "message")).toHaveLength(2);
+    fake.teardown();
+  });
+
+  it("the kernel writes the boundary in-band BEFORE the terminal entry (ordering)", async () => {
+    const store = new MemorySessionStore();
+    const fake = createFakeModel([{ content: [{ type: "text", text: "a" }] }]);
+    const summary = createUserMessage("SUMMARY");
+    const session = new AgentSession({
+      model: fake,
+      tools: [],
+      store,
+      hooks: [
+        {
+          name: "b",
+          onAfterFlush: () => ({ compactionBoundary: summary }),
+        },
+      ],
+    });
+    await session.run("q");
+
+    const path = await store.getPathToLeaf(session.id);
+    const kinds = path.map((e) => e.entry.kind);
+    // boundary must precede terminal; seq must be strictly monotone (single serial chain).
+    const bIdx = kinds.indexOf("compaction_boundary");
+    const tIdx = kinds.indexOf("terminal");
+    expect(bIdx).toBeGreaterThanOrEqual(0);
+    expect(tIdx).toBeGreaterThanOrEqual(0);
+    expect(bIdx).toBeLessThan(tIdx);
+    const seqs = path.map((e) => e.seq);
+    expect(seqs).toEqual([...seqs].sort((a, c) => a - c));
+    fake.teardown();
+  });
+
+  it("multiple hooks returning boundaries are appended in registration order", async () => {
+    const store = new MemorySessionStore();
+    const fake = createFakeModel([{ content: [{ type: "text", text: "a" }] }]);
+    const s1 = createUserMessage("S1");
+    const s2 = createUserMessage("S2");
+    const session = new AgentSession({
+      model: fake,
+      tools: [],
+      store,
+      hooks: [
+        { name: "h1", onAfterFlush: () => ({ compactionBoundary: s1 }) },
+        { name: "h2", onAfterFlush: () => ({ compactionBoundary: s2 }) },
+      ],
+    });
+    await session.run("q");
+
+    const boundaries = (await store.getPathToLeaf(session.id))
+      .filter((e) => e.entry.kind === "compaction_boundary")
+      .map((e) => (e.entry as { kind: "compaction_boundary"; summary: Message }).summary);
+    expect(boundaries).toEqual([s1, s2]);
+    fake.teardown();
+  });
+
+  it("does not fire when there is no store (parity with 0.2.1)", async () => {
+    const fake = createFakeModel([{ content: [{ type: "text", text: "a" }] }]);
+    let fired = false;
+    const observer: Hook = {
+      name: "observer",
+      onAfterFlush() {
+        fired = true;
+      },
+    };
+    const session = new AgentSession({ model: fake, tools: [], hooks: [observer] }); // no store
+    const summary = await session.run("hi");
+    expect(summary.reason).toBe("done");
+    expect(fired).toBe(false);
+    fake.teardown();
+  });
+
+  it("is fire-and-observe: a throwing onAfterFlush hook does NOT kill the run, and writes no boundary", async () => {
+    const store = new MemorySessionStore();
+    const fake = createFakeModel([{ content: [{ type: "text", text: "a" }] }]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [],
+      store,
+      hooks: [{ name: "exploder", onAfterFlush: () => { throw new Error("boom"); } }],
+      hookFailureSink: () => {}, // swallow the recorded failure
+    });
+    const summary = await session.run("q");
+    expect(summary.reason).toBe("done");
+    const path = await store.getPathToLeaf(session.id);
+    // messages still persisted despite the hook throwing; no boundary from a throwing hook.
+    expect(path.filter((e) => e.entry.kind === "message")).toHaveLength(2);
+    expect(path.filter((e) => e.entry.kind === "compaction_boundary")).toHaveLength(0);
+    fake.teardown();
+  });
+
+  it("a returned boundary makes resume rebuild [summary, ...post-boundary]", async () => {
+    const store = new MemorySessionStore();
+    // turn 0 tool call, turn 1 text. Return the boundary after turn 0's flush.
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "text", text: "final" }] },
+    ]);
+    const summary: Message = createUserMessage("BOUNDARY-SUMMARY");
+    const oneShot: Hook = {
+      name: "one-shot-boundary",
+      onAfterFlush(input: OnAfterFlushInput) {
+        if (input.turnIdx === 0) return { compactionBoundary: summary };
+      },
+    };
+    const session = new AgentSession({
+      model: fake,
+      tools: [noopTool],
+      store,
+      hooks: [oneShot],
+    });
+    await session.run("go");
+
+    const fake2 = createFakeModel([{ content: [{ type: "text", text: "z" }] }]);
+    const resumed = await AgentSession.resume(store, session.id, {
+      model: fake2,
+      tools: [noopTool],
+    });
+    // resume drops the pre-boundary prefix (user + assistant(toolCall) + toolResult),
+    // keeps summary + the post-boundary turn-1 assistant message.
+    expect(resumed.messages.map((m) => m.role)).toEqual(["user", "assistant"]);
+    expect(resumed.messages[0]).toBe(summary);
+    fake.teardown();
+    fake2.teardown();
+  });
+
+  /* ───────────────── 核心回归：超时不致数据丢失 / 乱序 ───────────────── */
+
+  it("REGRESSION: a timed-out slow summarize produces NO boundary, NO out-of-order write, NO data loss", async () => {
+    // 上一版 detached 设计：hook 超时 → fireEvent 立即 resolve、loop 进下一轮，detached 的
+    // append 仍在飞，乱序落在后续 turn / terminal 之后 → resume 把它当「丢弃之前一切」→ 静默删
+    // 已完成 turn。本设计：超时的 hook 返回被 race 丢弃 → 内核拿不到 boundary → 不写。
+    const store = new MemorySessionStore();
+    // turn 0: tool call (3 persisted). turn 1: text → done (4 persisted).
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "text", text: "final" }] },
+    ]);
+    const slowSummary = createUserMessage("SLOW-SHOULD-NEVER-LAND");
+    const failures: string[] = [];
+    const slowHook: Hook = {
+      name: "slow-boundary",
+      timeout: 30, // hook 超时阈值
+      async onAfterFlush(input: OnAfterFlushInput) {
+        if (input.turnIdx === 0) {
+          await sleep(80); // 远超 30ms → 被 dispatcher race 丢弃
+          return { compactionBoundary: slowSummary };
+        }
+      },
+    };
+    const session = new AgentSession({
+      model: fake,
+      tools: [noopTool],
+      store,
+      hooks: [slowHook],
+      hookFailureSink: (info) => failures.push(`${info.method}:${info.errorMessage}`),
+    });
+    const result = await session.run("go");
+
+    // run 不被超时杀掉（fire-and-observe）
+    expect(result.reason).toBe("done");
+    // dispatcher 记录了一次 timeout（observe，不杀 run）
+    expect(failures.some((f) => /onAfterFlush/.test(f))).toBe(true);
+
+    const path = await store.getPathToLeaf(session.id);
+    // 关键：超时的 boundary 绝不落盘 —— store 里零 compaction_boundary。
+    expect(path.filter((e) => e.entry.kind === "compaction_boundary")).toHaveLength(0);
+    // seq 单调（无并发损坏迹象：没有两条 appendEntry 并发同 session 撞号）。
+    const seqs = path.map((e) => e.seq);
+    expect(seqs).toEqual([...seqs].sort((a, c) => a - c));
+
+    // 即使等待远超 slow summarize 的 80ms，仍然没有迟到的 detached 写偷偷落进 store。
+    await sleep(120);
+    const path2 = await store.getPathToLeaf(session.id);
+    expect(path2.filter((e) => e.entry.kind === "compaction_boundary")).toHaveLength(0);
+
+    // resume 不丢任何已完成 turn：全量 [user, assistant(toolCall), toolResult, assistant]。
+    const fake2 = createFakeModel([{ content: [{ type: "text", text: "z" }] }]);
+    const resumed = await AgentSession.resume(store, session.id, {
+      model: fake2,
+      tools: [noopTool],
+    });
+    expect(resumed.messages.map((m) => m.role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+      "assistant",
+    ]);
+    fake.teardown();
+    fake2.teardown();
+  });
+
+  it("REGRESSION: a slow hook on turn 0 cannot reorder a boundary AFTER turn 1's messages", async () => {
+    // 上一版：turn-0 的 detached append 与 turn-1 的 _flushToStore 并发同 session → 链损坏 / 乱序。
+    // 本设计：内核在「下一轮 flush 之前」就已 await 完 boundary 写，串行 in-band，故即使 hook 极慢
+    // 也只是被超时丢弃，永远不会出现 boundary 排在后续 turn 消息之后。
+    const store = new MemorySessionStore();
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "text", text: "final" }] },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [noopTool],
+      store,
+      hooks: [
+        {
+          name: "slow",
+          timeout: 25,
+          async onAfterFlush(input: OnAfterFlushInput) {
+            if (input.turnIdx === 0) {
+              await sleep(70);
+              return { compactionBoundary: createUserMessage("LATE") };
+            }
+          },
+        },
+      ],
+      hookFailureSink: () => {},
+    });
+    await session.run("go");
+    await sleep(120);
+
+    const path = await store.getPathToLeaf(session.id);
+    // turn-1 的 assistant(text) 是最后一条 message；它之后只能是 terminal，绝不能有迟到 boundary。
+    const kinds = path.map((e) => e.entry.kind);
+    const lastMsgIdx = kinds.lastIndexOf("message");
+    const after = kinds.slice(lastMsgIdx + 1);
+    expect(after).not.toContain("compaction_boundary");
+    fake.teardown();
+  });
+});

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -28,6 +28,8 @@ import type {
   HookResult,
   LlmEndInput,
   MergedHookResult,
+  OnAfterFlushInput,
+  OnAfterFlushResult,
   PostToolUseInput,
   PreToolUseInput,
   SessionEndInput,
@@ -160,6 +162,45 @@ export class HookDispatcher {
         this._invokeSafe<void>(h, "onError", [input, ctx], "event"),
       ),
     );
+  }
+
+  /**
+   * Special: onAfterFlush —— **collect-return** 语义（C1）。并行问每个 hook（event 形态、per-hook
+   * timeout、fire-and-observe），把它们**返回**的 `compactionBoundary` 按注册顺序收集成数组交给内核。
+   *
+   * 关键不变量：dispatcher 只负责「拿到非超时/非抛错 hook 的返回值」，**不持有任何 store 写能力**。
+   * 超时的 hook 经 `_invokeSafe` 的 `Promise.race` 被丢弃（`error != null` / `value === undefined`），
+   * 其返回的 boundary 永远到不了这个数组 → 内核拿不到 → 不写。这是「超时绝不产生 detached store 写」的
+   * 机制根基（替换上一版给 hook detached 写能力的错误设计）。返回值的写入由内核 in-band、awaited、
+   * 串行执行（见 session.ts），dispatcher 不碰 store。
+   *
+   * timeout：默认走 event 类（100ms）；但 summarize 可调 LLM，挂此 hook 的 plugin 应自设较长 `timeout`。
+   */
+  async fireAfterFlush(
+    input: OnAfterFlushInput,
+    ctx: HookContext,
+  ): Promise<Message[]> {
+    const matched = this.hooks.filter(
+      (h) => typeof h.onAfterFlush === "function",
+    );
+    const results = await Promise.all(
+      matched.map((h) =>
+        this._invokeSafe<OnAfterFlushResult | void>(
+          h,
+          "onAfterFlush",
+          [input, ctx],
+          "event",
+        ),
+      ),
+    );
+    const boundaries: Message[] = [];
+    for (const r of results) {
+      // 超时 / 抛错的 hook：value === undefined（race 丢弃），其 boundary 永不入列。
+      if (r.value && r.value.compactionBoundary) {
+        boundaries.push(r.value.compactionBoundary);
+      }
+    }
+    return boundaries;
   }
 
   /* ────────────── Decision: 顺序 short-circuit ────────────── */

--- a/packages/core/src/hook.ts
+++ b/packages/core/src/hook.ts
@@ -138,6 +138,38 @@ export interface ContextOverflowInput {
   messageCount: number;
 }
 
+/**
+ * After-flush 信号（C1，docs/09 §4.2「写 compaction 边界进 store」的内核 seam）。每个 turn 在
+ * `_flushToStore()` 之后 fire（仅当 session 有 store）。
+ *
+ * **collect-return 语义（区别于普通 event）**：hook 可**返回** `{ compactionBoundary }` 让**内核**在
+ * in-band、awaited、串行的路径上把它当作一条 `compaction_boundary` entry append 进 store——hook 自己
+ * **没有**任何「可调用的写能力」。这是上一版设计（给 hook 一个 detached `appendCompactionBoundary`）
+ * 被 review 三轮抓出 data-loss / store-corruption 后的重做：detached 写在 hook 超时时仍在飞，会乱序落在
+ * 后续 turn / terminal 之后（resume 当成「丢弃之前一切」→ 静默删已完成 turn），且与下一轮 flush 的
+ * appendEntry 并发打同一 sessionId（违反串行契约）。改成「hook 返回、内核串行写」后，**超时的 hook 其
+ * 返回被 dispatcher 的 race 丢弃 → 内核拿不到 boundary → 不写 → 干净跳过，绝不产生 detached 写**。
+ *
+ * boundary 是 store 侧的额外 entry，**绝不动** `_persistedCount` / `_messages`：live session 继续用全量
+ * `_messages`；只有 `resume()` 重建时才用 boundary 把前缀裁成 summary。与 view-only 压缩
+ * （compactSummarize / autoCompaction 改的是「模型 view」、保 tail）是不同层、正交：那些省 token，
+ * 这里省 resume 重放。
+ */
+export interface OnAfterFlushInput {
+  turnIdx: number;
+  /** 本次 flush 后已持久化的 message 数（= `_persistedCount`）。 */
+  persistedCount: number;
+}
+
+/**
+ * `onAfterFlush` 的返回 envelope。返回 `void` = 本 turn 不落 boundary；返回 `{ compactionBoundary }`
+ * = 请内核在 store 末尾串行 append 一条覆盖全部已持久化前缀的 `compaction_boundary`。
+ */
+export interface OnAfterFlushResult {
+  /** 内核据此 append 一条 `compaction_boundary{summary}`（in-band、awaited、串行）。 */
+  compactionBoundary?: Message;
+}
+
 export interface PreToolUseInput {
   call: ToolCall;
   tool: HarnessTool;
@@ -418,6 +450,15 @@ export interface Hook {
     input: ContextOverflowInput,
     ctx: HookContext,
   ): HookResult | void | Promise<HookResult | void>;
+  /**
+   * After-flush 观测点：每 turn flush 到 store 后 fire（仅有 store 时）。**collect-return**：返回
+   * `{ compactionBoundary }` 让内核在 store 末尾串行落一条 boundary（无「可调用写能力」，超时即被丢弃，
+   * 见 `OnAfterFlushInput` / `OnAfterFlushResult`）。`summarize` 可调 LLM，故应设较长 `timeout`。
+   */
+  onAfterFlush?(
+    input: OnAfterFlushInput,
+    ctx: HookContext,
+  ): OnAfterFlushResult | void | Promise<OnAfterFlushResult | void>;
   onPostToolUse?(
     input: PostToolUseInput,
     ctx: HookContext,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,8 @@ export type {
   SteerInput,
   LlmEndInput,
   ContextOverflowInput,
+  OnAfterFlushInput,
+  OnAfterFlushResult,
   PreToolUseInput,
   PostToolUseInput,
   UserPromptSubmitInput,

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -1102,6 +1102,40 @@ export class AgentSession {
       // 每个 turn 结束把新 messages append 进 store（durable resume；no-op if no store）。
       await this._flushToStore();
 
+      // After-flush 观测点（C1，docs/09 §4.2）：仅有 store 时 fire。**collect-return**：hook 不持有
+      // 任何写能力，只**返回** boundary；内核在这里 in-band、awaited、串行地把它写进 store——在进入
+      // 下一轮 loop / 下一次 _flushToStore / terminal **之前**完成。这保证：boundary 永远落在「它之后
+      // 的消息 flush」之前，且绝无两个 appendEntry 并发同 session（满足 SessionStore 串行契约）。
+      //
+      // 超时的 hook 其返回被 dispatcher 的 race 丢弃 → fireAfterFlush 拿不到它的 boundary → 这里不写
+      // → 该 turn 无 boundary（干净跳过，**绝不产生 detached store 写**）。这是上一版「detached 写能力」
+      // 设计导致 data-loss/乱序的根因修复。
+      //
+      // boundary 是 store 侧额外 entry，**不动** _persistedCount / _messages（HWM 不变量保持）。
+      // append 抛错按 best-effort 处理（记 failureSink、不杀 run），与 _flushToStore 一致。
+      if (this._store) {
+        const boundaries = await this._dispatcher.fireAfterFlush(
+          {
+            // 刚跑完并 flush 的那个 turn 的序号（_ctx.turnIdx 仍是 :setTurnIdx 设的值，
+            // 而局部 turnIdx 已 ++ 指向下一轮）—— 与 onContextOverflow 取 _ctx.turnIdx 一致。
+            turnIdx: this._ctx.turnIdx,
+            persistedCount: this._persistedCount,
+          },
+          this._ctx,
+        );
+        // 多个 hook 都返回 boundary 时按顺序逐条 append（正常只 1 个）。
+        for (const summary of boundaries) {
+          try {
+            await this._store.appendEntry(this.id, {
+              kind: "compaction_boundary",
+              summary,
+            });
+          } catch (err) {
+            this._reportStoreError("appendEntry(compaction_boundary)", err);
+          }
+        }
+      }
+
       if (outcome === "done") return { turnIdx, reason: "done" };
       if (outcome === "abort") return { turnIdx, reason: "aborted" };
       if (outcome === "error") return { turnIdx, reason: "error" };

--- a/packages/plugins/src/__tests__/persist-compaction-boundary.test.ts
+++ b/packages/plugins/src/__tests__/persist-compaction-boundary.test.ts
@@ -1,0 +1,350 @@
+/**
+ * persistCompactionBoundary controller integration —— C1 redesign (docs/09 §4.2).
+ *
+ * 端到端：跑几个 turn → shouldCompact 触发 → 控制器**返回** summary → 内核 in-band 串行落 boundary →
+ * AgentSession.resume 从 boundary 重建出 [summary, ...post-boundary]（而非全量）。
+ *
+ * 核心回归（锁住上一版 detached 写的 data-loss / store-corruption）：超时的 summarize 不致 boundary
+ * 乱序落在 terminal 之后、不丢已完成 turn、store 顺序单调、run 不被杀。见最后两个用例。
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  AgentSession,
+  MemorySessionStore,
+  createUserMessage,
+  type HarnessTool,
+  type Message,
+} from "@harness-pi/core";
+import { createFakeModel } from "@harness-pi/core/testing";
+import { persistCompactionBoundary } from "../controllers/index.js";
+
+const noopTool: HarnessTool = {
+  name: "noop",
+  description: "noop",
+  parameters: { type: "object", properties: {} } as never,
+  async execute() {
+    return { content: [{ type: "text", text: "ok" }] };
+  },
+};
+
+const roles = (msgs: ReadonlyArray<Message>) => msgs.map((m) => m.role);
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("persistCompactionBoundary controller (return-based)", () => {
+  it("triggers a boundary → resume rebuilds [summary, ...post-boundary], not the full history", async () => {
+    const store = new MemorySessionStore();
+    // turn 0: tool call (assistant + toolResult). turn 1: text → done.
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "text", text: "final" }] },
+    ]);
+    const summary = createUserMessage("SUMMARY-OF-PREFIX");
+    const hook = persistCompactionBoundary({
+      // only compact after turn 0's flush (exactly 3 persisted: user + assistant + toolResult);
+      // turn 1's flush (4 persisted) won't re-trigger, leaving turn-1 messages after the boundary.
+      shouldCompact: ({ persistedCount }) => persistedCount === 3,
+      summarize: () => summary,
+    });
+    const session = new AgentSession({
+      model: fake,
+      tools: [noopTool],
+      store,
+      hooks: [hook],
+    });
+    await session.run("go");
+
+    // live session keeps the full history (HWM unaffected)
+    expect(roles(session.messages)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+      "assistant",
+    ]);
+
+    const path = await store.getPathToLeaf(session.id);
+    expect(path.filter((e) => e.entry.kind === "compaction_boundary")).toHaveLength(1);
+
+    // resume drops the pre-boundary prefix, keeps summary + post-boundary turn-1 assistant
+    const fake2 = createFakeModel([{ content: [{ type: "text", text: "z" }] }]);
+    const resumed = await AgentSession.resume(store, session.id, {
+      model: fake2,
+      tools: [noopTool],
+    });
+    expect(roles(resumed.messages)).toEqual(["user", "assistant"]);
+    expect(resumed.messages[0]).toBe(summary);
+    fake.teardown();
+    fake2.teardown();
+  });
+
+  it("shouldCompact=false never writes a boundary (resume == full history)", async () => {
+    const store = new MemorySessionStore();
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "text", text: "final" }] },
+    ]);
+    const hook = persistCompactionBoundary({
+      shouldCompact: () => false,
+      summarize: () => createUserMessage("never"),
+    });
+    const session = new AgentSession({
+      model: fake,
+      tools: [noopTool],
+      store,
+      hooks: [hook],
+    });
+    await session.run("go");
+
+    const path = await store.getPathToLeaf(session.id);
+    expect(path.filter((e) => e.entry.kind === "compaction_boundary")).toHaveLength(0);
+    fake.teardown();
+  });
+
+  it("shouldCompact receives only the flushed prefix (length === persistedCount)", async () => {
+    const store = new MemorySessionStore();
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "text", text: "final" }] },
+    ]);
+    let seen: { persistedCount: number; len: number } | undefined;
+    const hook = persistCompactionBoundary({
+      shouldCompact: ({ persistedCount, messages }) => {
+        seen = { persistedCount, len: messages.length };
+        return false;
+      },
+      summarize: () => createUserMessage("x"),
+    });
+    const session = new AgentSession({ model: fake, tools: [noopTool], store, hooks: [hook] });
+    await session.run("go");
+
+    expect(seen).toBeDefined();
+    expect(seen!.len).toBe(seen!.persistedCount); // 传入的是已持久化前缀,非全量 ctx.messages
+    fake.teardown();
+  });
+
+  it("minTurnsBetween throttles: not every qualifying turn writes a boundary", async () => {
+    const store = new MemorySessionStore();
+    // three turns, each a tool call then the loop ends at maxTurns.
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+    ]);
+    let summarizeCalls = 0;
+    const hook = persistCompactionBoundary({
+      shouldCompact: () => true, // every turn qualifies
+      summarize: () => {
+        summarizeCalls++;
+        return createUserMessage(`S${summarizeCalls}`);
+      },
+      minTurnsBetween: 2,
+    });
+    const session = new AgentSession({
+      model: fake,
+      tools: [noopTool],
+      store,
+      hooks: [hook],
+      maxTurns: 3,
+    });
+    await session.run("go");
+
+    // turns flushed at idx 0,1,2. minTurnsBetween=2: boundary at turn 0 (first),
+    // then turn 1 skipped (1-0 < 2), turn 2 allowed (2-0 >= 2) → 2 boundaries, 2 summarize calls.
+    const boundaries = (await store.getPathToLeaf(session.id)).filter(
+      (e) => e.entry.kind === "compaction_boundary",
+    );
+    expect(boundaries).toHaveLength(2);
+    expect(summarizeCalls).toBe(2);
+    fake.teardown();
+  });
+
+  it("throttle high-water-mark advances before the await, so a failing summarize can't defeat minTurnsBetween", async () => {
+    // 节流高水位若在 await 之后才 set,summarize 抛错会让它漏更新 → 每个 qualifying turn 都重新触发。
+    // 控制器「先提交节流、再做 async 慢活」。summarize 总抛错(fire-and-observe,不杀 run):
+    //   set 先行 → 节流照常 → 4 个 qualifying turn 只调 2 次 summarize。
+    const store = new MemorySessionStore();
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+    ]);
+    let calls = 0;
+    const hook = persistCompactionBoundary({
+      shouldCompact: () => true,
+      summarize: () => {
+        calls++;
+        throw new Error("summarize boom");
+      },
+      minTurnsBetween: 2,
+    });
+    const session = new AgentSession({
+      model: fake,
+      tools: [noopTool],
+      store,
+      hooks: [hook],
+      maxTurns: 4,
+      hookFailureSink: () => {}, // swallow recorded summarize failure
+    });
+    await session.run("go"); // summarize 抛错被 fire-and-observe 吞,run 不被杀
+
+    // turns 0,1,2,3;minTurnsBetween=2 → 触发于 0 与 2(2 次),即使 summarize 每次抛错。
+    expect(calls).toBe(2);
+    fake.teardown();
+  });
+
+  it("rejects minTurnsBetween < 1 at construction", () => {
+    expect(() =>
+      persistCompactionBoundary({
+        shouldCompact: () => true,
+        summarize: () => createUserMessage("x"),
+        minTurnsBetween: 0,
+      }),
+    ).toThrow(/minTurnsBetween/);
+  });
+
+  it("async (LLM-latency) summarize beyond the 100ms event default still writes a boundary", async () => {
+    // onAfterFlush 走 event 类、dispatcher 默认超时仅 100ms;summarize 调 LLM 是秒级。控制器把 hook
+    // timeout 放宽(默认 60s),否则真 summarize 必超时、其返回被丢弃 → 零 boundary。这里 ~150ms async
+    // summarize:>100ms(旧默认会超时)、远 < 放宽后默认 → boundary 必落。
+    const store = new MemorySessionStore();
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "text", text: "final" }] },
+    ]);
+    const summary = createUserMessage("ASYNC-SUMMARY");
+    const hook = persistCompactionBoundary({
+      shouldCompact: ({ persistedCount }) => persistedCount === 3,
+      summarize: () => new Promise<Message>((r) => setTimeout(() => r(summary), 150)),
+    });
+    const session = new AgentSession({ model: fake, tools: [noopTool], store, hooks: [hook] });
+    const result = await session.run("go");
+
+    expect(result.reason).toBe("done");
+    const boundaries = (await store.getPathToLeaf(session.id)).filter(
+      (e) => e.entry.kind === "compaction_boundary",
+    );
+    expect(boundaries).toHaveLength(1);
+    fake.teardown();
+  });
+
+  /* ───────────────── 核心回归：超时不致数据丢失 / 乱序 ───────────────── */
+
+  it("REGRESSION: a timed-out summarize loses no data, leaves no out-of-order boundary, doesn't kill the run", async () => {
+    // 上一版 detached 设计在这里会失败:hook 超时 → detached summarize+append 仍在飞 → boundary 乱序
+    // 落在后续 turn / terminal 之后 → resume 把它当「丢弃之前一切」→ 静默删已完成 turn。
+    // 本设计:超时的 summarize 返回被 dispatcher race 丢弃 → 控制器返回到不了内核 → 不写 boundary。
+    const store = new MemorySessionStore();
+    // turn 0: tool call (3 persisted). turn 1: text → done (4 persisted).
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "text", text: "final" }] },
+    ]);
+    let summarizeStarted = 0;
+    const failures: string[] = [];
+    const hook = persistCompactionBoundary({
+      shouldCompact: ({ persistedCount }) => persistedCount === 3, // 只 turn 0 触发
+      // 慢 summarize(80ms)远超下方 30ms hook timeout → 被 race 丢弃。
+      summarize: async () => {
+        summarizeStarted++;
+        await sleep(80);
+        return createUserMessage("SLOW-SHOULD-NEVER-LAND");
+      },
+      timeout: 30, // 小超时,故意让 summarize 来不及完成
+    });
+    const session = new AgentSession({
+      model: fake,
+      tools: [noopTool],
+      store,
+      hooks: [hook],
+      hookFailureSink: (info) => failures.push(`${info.method}:${info.errorMessage}`),
+    });
+    const result = await session.run("go");
+
+    // run 没被超时杀掉(fire-and-observe)。
+    expect(result.reason).toBe("done");
+    // summarize 确实被启动过(证明触发逻辑生效),且 dispatcher 记到一次 onAfterFlush 超时。
+    expect(summarizeStarted).toBe(1);
+    expect(failures.some((f) => /onAfterFlush/.test(f))).toBe(true);
+
+    // 即使等到远超 slow summarize 的 80ms,也没有迟到的 detached 写偷偷落进 store。
+    await sleep(120);
+    const path = await store.getPathToLeaf(session.id);
+    // 关键:超时 → 零 boundary 落盘。
+    expect(path.filter((e) => e.entry.kind === "compaction_boundary")).toHaveLength(0);
+    // store 顺序单调(无并发损坏:没有两条 appendEntry 并发同 session 撞号)。
+    const seqs = path.map((e) => e.seq);
+    expect(seqs).toEqual([...seqs].sort((a, c) => a - c));
+    // terminal 之后没有任何 entry(乱序的 boundary 本会落在这里)。
+    expect(path[path.length - 1]!.entry.kind).toBe("terminal");
+
+    // resume 不丢任何已完成 turn:全量重建。
+    const fake2 = createFakeModel([{ content: [{ type: "text", text: "z" }] }]);
+    const resumed = await AgentSession.resume(store, session.id, {
+      model: fake2,
+      tools: [noopTool],
+    });
+    expect(roles(resumed.messages)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+      "assistant",
+    ]);
+    fake.teardown();
+    fake2.teardown();
+  });
+
+  it("REGRESSION: even with throttle set before the slow await, a timed-out turn writes nothing and resume is whole", async () => {
+    // 多 turn:turn 0 慢 summarize 被超时丢弃(无 boundary),turn 1 正常完成。验证超时的 turn 既不破坏
+    // store 顺序、也不阻断后续 turn 的正常 boundary;resume 完整。
+    const store = new MemorySessionStore();
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "text", text: "final" }] },
+    ]);
+    const fastSummary = createUserMessage("FAST");
+    const hook = persistCompactionBoundary({
+      shouldCompact: () => true,
+      summarize: async (flushed) => {
+        // turn 0 的前缀有 3 条(含 toolResult)→ 慢;turn 1 前缀 4 条 → 快。
+        if (flushed.length === 3) {
+          await sleep(80); // 被 30ms timeout 丢弃
+          return createUserMessage("SLOW");
+        }
+        return fastSummary;
+      },
+      timeout: 30,
+      minTurnsBetween: 1,
+    });
+    const session = new AgentSession({
+      model: fake,
+      tools: [noopTool],
+      store,
+      hooks: [hook],
+      hookFailureSink: () => {},
+    });
+    await session.run("go");
+    await sleep(120);
+
+    const path = await store.getPathToLeaf(session.id);
+    // 仅 turn 1 的 fast boundary 落盘(turn 0 超时被丢)。
+    const boundaries = path
+      .filter((e) => e.entry.kind === "compaction_boundary")
+      .map((e) => (e.entry as { kind: "compaction_boundary"; summary: Message }).summary);
+    expect(boundaries).toEqual([fastSummary]);
+    // 顺序单调,terminal 收尾。
+    const seqs = path.map((e) => e.seq);
+    expect(seqs).toEqual([...seqs].sort((a, c) => a - c));
+    expect(path[path.length - 1]!.entry.kind).toBe("terminal");
+
+    // resume:turn-1 的 fast boundary 覆盖全部前缀 → [summary]（turn 1 assistant 在 boundary 之前 flush）。
+    const fake2 = createFakeModel([{ content: [{ type: "text", text: "z" }] }]);
+    const resumed = await AgentSession.resume(store, session.id, {
+      model: fake2,
+      tools: [noopTool],
+    });
+    expect(resumed.messages[0]).toBe(fastSummary);
+    fake.teardown();
+    fake2.teardown();
+  });
+});

--- a/packages/plugins/src/controllers/index.ts
+++ b/packages/plugins/src/controllers/index.ts
@@ -51,6 +51,9 @@ export type {
 export { subAgentTool } from "./sub-agent-tool.js";
 export type { SubAgentToolOptions } from "./sub-agent-tool.js";
 
+export { persistCompactionBoundary } from "./persist-compaction-boundary.js";
+export type { PersistCompactionBoundaryOptions } from "./persist-compaction-boundary.js";
+
 export { GapExplorer } from "./gap-explorer.js";
 export type {
   Gap,

--- a/packages/plugins/src/controllers/persist-compaction-boundary.ts
+++ b/packages/plugins/src/controllers/persist-compaction-boundary.ts
@@ -1,0 +1,107 @@
+/**
+ * persistCompactionBoundary —— C1 控制器（docs/09 §4.2「写 compaction 边界进 store」）。
+ *
+ * 挂内核 `onAfterFlush`（每 turn flush 到 store 之后 fire）：当 `shouldCompact` 为真且距上次 boundary
+ * 足够远时，把**已持久化前缀**总结成一条 summary 并**返回** `{ compactionBoundary: summary }`。**内核**
+ * 在 in-band、awaited、串行的路径上把它当作 store 末尾的一条 `compaction_boundary` 写盘。这是一个
+ * **durable resume 优化**。
+ *
+ * ── return-based，不持有写能力（务必看清）──
+ * 本控制器**只返回** summary，**不调用任何 store 写**。上一版给 hook 一个 detached
+ * `appendCompactionBoundary(summary)`，被 review 三轮抓出 data-loss / store-corruption：hook 超时时
+ * detached 的 append 仍在飞、乱序落在后续 turn / terminal 之后（resume 当成「丢弃之前一切」→ 静默删已
+ * 完成 turn），且与下一轮 flush 的 appendEntry 并发打同一 sessionId（违反串行契约）。改成「返回 → 内核
+ * 串行写」后：**summarize 超时（被 dispatcher 的 race 丢弃）只是返回被忽略，绝不产生 detached 写**。
+ *
+ * ── boundary 覆盖语义 ──
+ * onAfterFlush 在 flush 之后 fire，此刻**全部消息已落盘**，故 boundary 落在 store 末尾、覆盖**全部已
+ * 持久化前缀**（不保留 tail）。resume 重建 = `[summary, boundary 之后的新 turn]` —— 比 live session 的
+ * 全量 `_messages` 更激进的压缩，是**有意**的：live session 不受影响（继续用全量历史），只有从 store
+ * 重建时才省下重放。这与 view-only 压缩（compactSummarize / autoCompaction 改「模型 view」、保 tail）
+ * 是不同层、正交：那些省 token，这里省 resume 重放。内核 in-band 串行写保证 boundary 永远在「它之后的
+ * 消息 flush」之前落盘，且绝无两个 appendEntry 并发同 session。
+ *
+ * ── HWM 不变量 ──
+ * 内核写 boundary 只往 store 加一条 entry，**不动** `_persistedCount` / `_messages`。所以本控制器不破坏
+ * 「逐条推进的高水位」——live session 的全量历史与续跑行为完全不变。
+ *
+ * `summarize` 由调用方提供（可调 LLM）——domain-free，控制器/内核都不内置 LLM 调用。
+ */
+
+import type { Hook, HookContext, OnAfterFlushInput } from "@harness-pi/core";
+import type { Message } from "@earendil-works/pi-ai";
+
+declare module "@harness-pi/core" {
+  interface HookStateRegistry {
+    "persist-compaction-boundary.lastTurnIdx": number;
+  }
+}
+
+const KEY = "persist-compaction-boundary.lastTurnIdx" as const;
+
+export interface PersistCompactionBoundaryOptions {
+  /**
+   * 判断此刻是否该落 boundary（如 estimate(messages) > 阈值）。返回 false 则跳过。
+   * `messages` 是已持久化前缀（= live history 的前 `persistedCount` 条）。
+   */
+  shouldCompact: (input: {
+    persistedCount: number;
+    messages: Message[];
+  }) => boolean;
+  /**
+   * 把「已持久化前缀」总结成一条 summary message —— summary 覆盖**全部已持久化消息**（见覆盖语义）。
+   * 可 async（调 LLM）。
+   */
+  summarize: (flushedMessages: Message[]) => Promise<Message> | Message;
+  /**
+   * 两次 boundary 之间至少间隔多少次 flush/turn，避免每 turn 都落。默认 1（相邻 turn 不重复落）。
+   */
+  minTurnsBetween?: number;
+  /**
+   * 本 hook 的超时(ms)。**默认放宽到 60_000**——`summarize` 可调 LLM(秒级),而 `onAfterFlush` 走 event
+   * 类、dispatcher 默认超时仅 100ms,不放宽真 LLM summarize 会**必定超时 → 该 hook 返回被丢弃 → 零
+   * boundary 落盘**(但不会数据损坏——内核拿不到返回就不写)。按你的 summarize 后端调整。
+   */
+  timeout?: number;
+}
+
+export function persistCompactionBoundary(
+  opts: PersistCompactionBoundaryOptions,
+): Hook {
+  const minTurnsBetween = opts.minTurnsBetween ?? 1;
+  if (minTurnsBetween < 1) {
+    throw new Error(
+      "persistCompactionBoundary: minTurnsBetween must be >= 1",
+    );
+  }
+
+  return {
+    name: "persist-compaction-boundary",
+    // 见 timeout 选项注释：onAfterFlush 走 event 类(默认 100ms),LLM summarize 必须放宽超时,否则零 boundary。
+    timeout: opts.timeout ?? 60_000,
+
+    async onAfterFlush(input: OnAfterFlushInput, ctx: HookContext) {
+      // 已持久化前缀 = live history 的前 persistedCount 条（boundary 覆盖这整段）。
+      const flushed = ctx.messages.slice(0, input.persistedCount);
+
+      if (!opts.shouldCompact({ persistedCount: input.persistedCount, messages: flushed })) {
+        return;
+      }
+
+      // minTurnsBetween：距上次落 boundary 不够远就跳过。首次（无记录）总是允许。
+      const last = ctx.state.get(KEY);
+      if (last !== undefined && input.turnIdx - last < minTurnsBetween) {
+        return;
+      }
+
+      // **先提交节流高水位,再做慢活。** summarize 可能秒级、甚至被 hook 超时中断(此时返回被 dispatcher
+      // 的 race 丢弃、内核不写)。若把 set 放在 await 之后,超时让 await reject → set 不执行 → 节流高水位
+      // 不前进 → 下一 turn 又触发 summarize,minTurnsBetween 形同虚设、反复调 LLM。先 set:即使本轮
+      // summarize 失败/超时,后续 turn 仍正确节流。boundary 是 best-effort 优化,跳过一次无碍。
+      ctx.state.set(KEY, input.turnIdx);
+      const summary = await opts.summarize(flushed);
+      // 只返回 summary —— 由内核 in-band、awaited、串行写进 store。控制器不持有任何写能力。
+      return { compactionBoundary: summary };
+    },
+  };
+}


### PR DESCRIPTION
**0.3.0 Wave A · C1**(epic #43)。补 `compaction_boundary` 的写入方,让长会话 `resume()` 从压缩边界起算而非重放全量历史。**本 PR 是重设计**——原 capability-based 设计被 review-gate 抓到 data-loss/store-corruption(见 #47 评论),已根治。

## 设计(return-based seam,内核足迹小)
- `onAfterFlush` 不再给 hook 「可调用的写能力」:`OnAfterFlushInput = {turnIdx, persistedCount}`,hook **返回** `{compactionBoundary?: Message}`。
- `dispatcher.fireAfterFlush` 收集各 hook 返回的 boundary(超时/抛错的 hook 返回 undefined 不入列),**dispatcher 不持有任何 store 写能力**。
- `session.ts` 在 `_flushToStore` 后,内核**自己 in-band、awaited、串行** append boundary,全部在进入下一轮 flush/terminal **之前**完成。
- 控制器 `persistCompactionBoundary({shouldCompact, summarize, minTurnsBetween, timeout})` 改为 `return {compactionBoundary}`;先节流后 summarize。

## 根治了什么(原设计的 data-loss/corruption)
原设计 `appendCompactionBoundary` 是 detached 写(`appendEntry().then()`),hook 超时时 detached 写仍在飞 → boundary 乱序落在后续消息/terminal 之后 → **resume 静默删除已完成 turn**;且与下一轮 flush 并发 append 同 session → **违反串行契约、Postgres 链损坏**。**新设计:超时 hook 的返回被 `_invokeSafe` 的 race 丢弃 → 内核拿不到 → 不写。没有任何 store 写脱离内核 awaited 路径** → 无乱序、无并发。HWM 不变量保持(boundary 不动 `_persistedCount`/`_messages`)。

## 测试 / 验证
- core after-flush **9**(含超时回归:超时→**0 boundary**、`seq` 单调、`terminal` 末位、resume 不丢已完成 turn、迟到后台 summarize 不偷写)。
- plugins persist-compaction-boundary **9**(resume=[summary,post-boundary]、节流在 summarize 抛错下仍精确、shouldCompact 收已持久化前缀)。
- core **278** / plugins **264** / core+plugins typecheck 全绿;`pnpm -r build`+`-r typecheck` 10 包全过。
- **review-gate 3/3 PASS**(linus:「彻底根治…零阻塞」)。

## 非阻塞 follow-up(review 列,不阻塞)
- `MicrocompactOptions.estimateTokens` / 增量估算的「逐消息可加」契约写进 JSDoc。
- 生产接 LLM 时 `timeout` 设贴近真实 P99(默认 60s 偏大,失败时拖慢整轮)。
- timing-based 回归测试加大间隔(timeout:30 vs sleep:300)降 CI flaky。
- 注释去重(4 处近逐字重复 → 留一处 canonical)+ `boundaries`/`summary` 命名统一。

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)