### PR TITLE
release: v0.2.2 — Wave A (context/sub-agent/compaction hardening)

### DIFF
--- a/apps/coding-agent/package.json
+++ b/apps/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-pi/coding-agent",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Dogfood coding agent built on harness-pi — usable pi-tui CLI showcasing the harness-pi kernel",
   "license": "MIT",
   "repository": {

--- a/docs/09-bidding-core-parity-design.md
+++ b/docs/09-bidding-core-parity-design.md
@@ -397,8 +397,10 @@ interface AgentSessionOptions {
 // #10 compactSummarize（插件，§4.2）：transformMessagesBeforeLlm hook，超阈值时用注入的 summarize(可调
 // LLM)把早期消息总结成一条 + recent tail；按覆盖前缀缓存(resummarizeEvery 节奏)；只改模型 view 省 token，
 // 不动 _messages。summarize 抛错被内核 pipe fail-open 吞掉 → 退化为不压缩(run 不中断)。
-// 实现说明：doc 原文「写 compaction 边界进 store」未做——HookContext 刻意无 store 写权限(护 _flushToStore
-// 高水位不变量)，store-boundary 属编排层职责。本 hook 压缩 view（与 trim-history 互补：语义压缩 vs 机械占位）。
+// 实现说明：本 hook 只压 view（与 trim-history 互补：语义压缩 vs 机械占位）。「写 compaction 边界进 store」
+// 由 C1 的 `persistCompactionBoundary` 控制器经内核 `onAfterFlush` collect-return seam 落地(0.2.2，#47)——
+// 仍守住「HookContext 无 store 写权限/不破 _flushToStore 高水位」:hook 只**返回** summary,内核在 flush 后
+// in-band 串行写 boundary,store-boundary 仍属编排层职责。
 
 // ── #7 fail-closed 分类 ─────────────────────────────────────
 // 实现说明：草案的 `decisionHook(..., { critical })` wrapper 落地成 Hook 上的两个字段 + 一个注册期硬校验，

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-pi/adapters",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "SessionStore adapters for harness-pi (JSONL file + Postgres). Concrete I/O behind the kernel SessionStore protocol.",
   "license": "MIT",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-pi/core",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Agent kernel — pi-ai loop + first-class hook system",
   "license": "MIT",
   "repository": {

--- a/packages/core/src/__tests__/after-flush.test.ts
+++ b/packages/core/src/__tests__/after-flush.test.ts
@@ -1,0 +1,321 @@
+/**
+ * onAfterFlush 内核 seam（C1 redesign，docs/09 §4.2）。
+ *
+ * collect-return 语义：hook **返回** `{ compactionBoundary }`，内核在 _flushToStore 之后 in-band、
+ * awaited、串行地把它 append 进 store。hook **没有**任何「可调用写能力」——这是上一版 detached
+ * 写设计被 review 抓出 data-loss / store-corruption 后的重做。核心回归（超时的 summarize 不致数据
+ * 丢失/乱序）见最后两个用例。
+ */
+
+import { describe, it, expect } from "vitest";
+import { AgentSession } from "../session.js";
+import { MemorySessionStore } from "../session-store.js";
+import { createFakeModel } from "../testing.js";
+import { createUserMessage } from "../types.js";
+import type { Hook, OnAfterFlushInput } from "../hook.js";
+import type { Message } from "@earendil-works/pi-ai";
+
+const noopTool = {
+  name: "noop",
+  description: "noop",
+  parameters: { type: "object", properties: {} } as never,
+  async execute() {
+    return { content: [{ type: "text" as const, text: "ok" }] };
+  },
+};
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("onAfterFlush kernel seam (C1 redesign)", () => {
+  it("fires after each turn's flush with the correct turnIdx and persistedCount", async () => {
+    const store = new MemorySessionStore();
+    // two turns: turn 0 makes a tool call (assistant + toolResult), turn 1 finishes.
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "text", text: "done" }] },
+    ]);
+    const seen: Array<{ turnIdx: number; persistedCount: number }> = [];
+    const observer: Hook = {
+      name: "observer",
+      onAfterFlush(input: OnAfterFlushInput) {
+        seen.push({ turnIdx: input.turnIdx, persistedCount: input.persistedCount });
+      },
+    };
+    const session = new AgentSession({
+      model: fake,
+      tools: [noopTool],
+      store,
+      hooks: [observer],
+    });
+
+    await session.run("go");
+
+    // turn 0: user + assistant(toolCall) + toolResult = 3 persisted; turn 1: + assistant(text) = 4.
+    expect(seen).toEqual([
+      { turnIdx: 0, persistedCount: 3 },
+      { turnIdx: 1, persistedCount: 4 },
+    ]);
+    const msgEntries = (await store.getPathToLeaf(session.id)).filter(
+      (e) => e.entry.kind === "message",
+    );
+    expect(msgEntries).toHaveLength(4);
+    fake.teardown();
+  });
+
+  it("a returned compactionBoundary is written by the kernel WITHOUT touching the HWM / session.messages", async () => {
+    const store = new MemorySessionStore();
+    const fake = createFakeModel([{ content: [{ type: "text", text: "a1" }] }]);
+    const summary = createUserMessage("SUMMARY");
+    const boundaryHook: Hook = {
+      name: "boundary-writer",
+      onAfterFlush() {
+        return { compactionBoundary: summary };
+      },
+    };
+    const session = new AgentSession({
+      model: fake,
+      tools: [],
+      store,
+      hooks: [boundaryHook],
+    });
+
+    await session.run("q1");
+
+    // live session keeps the full history (HWM unaffected: boundary is a store-only entry)
+    expect(session.messages.map((m) => m.role)).toEqual(["user", "assistant"]);
+
+    const path = await store.getPathToLeaf(session.id);
+    expect(path.filter((e) => e.entry.kind === "compaction_boundary")).toHaveLength(1);
+    // none of the messages were re-appended / duplicated
+    expect(path.filter((e) => e.entry.kind === "message")).toHaveLength(2);
+    fake.teardown();
+  });
+
+  it("the kernel writes the boundary in-band BEFORE the terminal entry (ordering)", async () => {
+    const store = new MemorySessionStore();
+    const fake = createFakeModel([{ content: [{ type: "text", text: "a" }] }]);
+    const summary = createUserMessage("SUMMARY");
+    const session = new AgentSession({
+      model: fake,
+      tools: [],
+      store,
+      hooks: [
+        {
+          name: "b",
+          onAfterFlush: () => ({ compactionBoundary: summary }),
+        },
+      ],
+    });
+    await session.run("q");
+
+    const path = await store.getPathToLeaf(session.id);
+    const kinds = path.map((e) => e.entry.kind);
+    // boundary must precede terminal; seq must be strictly monotone (single serial chain).
+    const bIdx = kinds.indexOf("compaction_boundary");
+    const tIdx = kinds.indexOf("terminal");
+    expect(bIdx).toBeGreaterThanOrEqual(0);
+    expect(tIdx).toBeGreaterThanOrEqual(0);
+    expect(bIdx).toBeLessThan(tIdx);
+    const seqs = path.map((e) => e.seq);
+    expect(seqs).toEqual([...seqs].sort((a, c) => a - c));
+    fake.teardown();
+  });
+
+  it("multiple hooks returning boundaries are appended in registration order", async () => {
+    const store = new MemorySessionStore();
+    const fake = createFakeModel([{ content: [{ type: "text", text: "a" }] }]);
+    const s1 = createUserMessage("S1");
+    const s2 = createUserMessage("S2");
+    const session = new AgentSession({
+      model: fake,
+      tools: [],
+      store,
+      hooks: [
+        { name: "h1", onAfterFlush: () => ({ compactionBoundary: s1 }) },
+        { name: "h2", onAfterFlush: () => ({ compactionBoundary: s2 }) },
+      ],
+    });
+    await session.run("q");
+
+    const boundaries = (await store.getPathToLeaf(session.id))
+      .filter((e) => e.entry.kind === "compaction_boundary")
+      .map((e) => (e.entry as { kind: "compaction_boundary"; summary: Message }).summary);
+    expect(boundaries).toEqual([s1, s2]);
+    fake.teardown();
+  });
+
+  it("does not fire when there is no store (parity with 0.2.1)", async () => {
+    const fake = createFakeModel([{ content: [{ type: "text", text: "a" }] }]);
+    let fired = false;
+    const observer: Hook = {
+      name: "observer",
+      onAfterFlush() {
+        fired = true;
+      },
+    };
+    const session = new AgentSession({ model: fake, tools: [], hooks: [observer] }); // no store
+    const summary = await session.run("hi");
+    expect(summary.reason).toBe("done");
+    expect(fired).toBe(false);
+    fake.teardown();
+  });
+
+  it("is fire-and-observe: a throwing onAfterFlush hook does NOT kill the run, and writes no boundary", async () => {
+    const store = new MemorySessionStore();
+    const fake = createFakeModel([{ content: [{ type: "text", text: "a" }] }]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [],
+      store,
+      hooks: [{ name: "exploder", onAfterFlush: () => { throw new Error("boom"); } }],
+      hookFailureSink: () => {}, // swallow the recorded failure
+    });
+    const summary = await session.run("q");
+    expect(summary.reason).toBe("done");
+    const path = await store.getPathToLeaf(session.id);
+    // messages still persisted despite the hook throwing; no boundary from a throwing hook.
+    expect(path.filter((e) => e.entry.kind === "message")).toHaveLength(2);
+    expect(path.filter((e) => e.entry.kind === "compaction_boundary")).toHaveLength(0);
+    fake.teardown();
+  });
+
+  it("a returned boundary makes resume rebuild [summary, ...post-boundary]", async () => {
+    const store = new MemorySessionStore();
+    // turn 0 tool call, turn 1 text. Return the boundary after turn 0's flush.
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "text", text: "final" }] },
+    ]);
+    const summary: Message = createUserMessage("BOUNDARY-SUMMARY");
+    const oneShot: Hook = {
+      name: "one-shot-boundary",
+      onAfterFlush(input: OnAfterFlushInput) {
+        if (input.turnIdx === 0) return { compactionBoundary: summary };
+      },
+    };
+    const session = new AgentSession({
+      model: fake,
+      tools: [noopTool],
+      store,
+      hooks: [oneShot],
+    });
+    await session.run("go");
+
+    const fake2 = createFakeModel([{ content: [{ type: "text", text: "z" }] }]);
+    const resumed = await AgentSession.resume(store, session.id, {
+      model: fake2,
+      tools: [noopTool],
+    });
+    // resume drops the pre-boundary prefix (user + assistant(toolCall) + toolResult),
+    // keeps summary + the post-boundary turn-1 assistant message.
+    expect(resumed.messages.map((m) => m.role)).toEqual(["user", "assistant"]);
+    expect(resumed.messages[0]).toBe(summary);
+    fake.teardown();
+    fake2.teardown();
+  });
+
+  /* ───────────────── 核心回归：超时不致数据丢失 / 乱序 ───────────────── */
+
+  it("REGRESSION: a timed-out slow summarize produces NO boundary, NO out-of-order write, NO data loss", async () => {
+    // 上一版 detached 设计：hook 超时 → fireEvent 立即 resolve、loop 进下一轮，detached 的
+    // append 仍在飞，乱序落在后续 turn / terminal 之后 → resume 把它当「丢弃之前一切」→ 静默删
+    // 已完成 turn。本设计：超时的 hook 返回被 race 丢弃 → 内核拿不到 boundary → 不写。
+    const store = new MemorySessionStore();
+    // turn 0: tool call (3 persisted). turn 1: text → done (4 persisted).
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "text", text: "final" }] },
+    ]);
+    const slowSummary = createUserMessage("SLOW-SHOULD-NEVER-LAND");
+    const failures: string[] = [];
+    const slowHook: Hook = {
+      name: "slow-boundary",
+      timeout: 30, // hook 超时阈值
+      async onAfterFlush(input: OnAfterFlushInput) {
+        if (input.turnIdx === 0) {
+          await sleep(80); // 远超 30ms → 被 dispatcher race 丢弃
+          return { compactionBoundary: slowSummary };
+        }
+      },
+    };
+    const session = new AgentSession({
+      model: fake,
+      tools: [noopTool],
+      store,
+      hooks: [slowHook],
+      hookFailureSink: (info) => failures.push(`${info.method}:${info.errorMessage}`),
+    });
+    const result = await session.run("go");
+
+    // run 不被超时杀掉（fire-and-observe）
+    expect(result.reason).toBe("done");
+    // dispatcher 记录了一次 timeout（observe，不杀 run）
+    expect(failures.some((f) => /onAfterFlush/.test(f))).toBe(true);
+
+    const path = await store.getPathToLeaf(session.id);
+    // 关键：超时的 boundary 绝不落盘 —— store 里零 compaction_boundary。
+    expect(path.filter((e) => e.entry.kind === "compaction_boundary")).toHaveLength(0);
+    // seq 单调（无并发损坏迹象：没有两条 appendEntry 并发同 session 撞号）。
+    const seqs = path.map((e) => e.seq);
+    expect(seqs).toEqual([...seqs].sort((a, c) => a - c));
+
+    // 即使等待远超 slow summarize 的 80ms，仍然没有迟到的 detached 写偷偷落进 store。
+    await sleep(120);
+    const path2 = await store.getPathToLeaf(session.id);
+    expect(path2.filter((e) => e.entry.kind === "compaction_boundary")).toHaveLength(0);
+
+    // resume 不丢任何已完成 turn：全量 [user, assistant(toolCall), toolResult, assistant]。
+    const fake2 = createFakeModel([{ content: [{ type: "text", text: "z" }] }]);
+    const resumed = await AgentSession.resume(store, session.id, {
+      model: fake2,
+      tools: [noopTool],
+    });
+    expect(resumed.messages.map((m) => m.role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+      "assistant",
+    ]);
+    fake.teardown();
+    fake2.teardown();
+  });
+
+  it("REGRESSION: a slow hook on turn 0 cannot reorder a boundary AFTER turn 1's messages", async () => {
+    // 上一版：turn-0 的 detached append 与 turn-1 的 _flushToStore 并发同 session → 链损坏 / 乱序。
+    // 本设计：内核在「下一轮 flush 之前」就已 await 完 boundary 写，串行 in-band，故即使 hook 极慢
+    // 也只是被超时丢弃，永远不会出现 boundary 排在后续 turn 消息之后。
+    const store = new MemorySessionStore();
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "text", text: "final" }] },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [noopTool],
+      store,
+      hooks: [
+        {
+          name: "slow",
+          timeout: 25,
+          async onAfterFlush(input: OnAfterFlushInput) {
+            if (input.turnIdx === 0) {
+              await sleep(70);
+              return { compactionBoundary: createUserMessage("LATE") };
+            }
+          },
+        },
+      ],
+      hookFailureSink: () => {},
+    });
+    await session.run("go");
+    await sleep(120);
+
+    const path = await store.getPathToLeaf(session.id);
+    // turn-1 的 assistant(text) 是最后一条 message；它之后只能是 terminal，绝不能有迟到 boundary。
+    const kinds = path.map((e) => e.entry.kind);
+    const lastMsgIdx = kinds.lastIndexOf("message");
+    const after = kinds.slice(lastMsgIdx + 1);
+    expect(after).not.toContain("compaction_boundary");
+    fake.teardown();
+  });
+});

--- a/packages/core/src/__tests__/filter-incomplete-toolcalls.test.ts
+++ b/packages/core/src/__tests__/filter-incomplete-toolcalls.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { filterIncompleteToolCalls, type Message } from "../index.js";
+
+// filterIncompleteToolCalls 只读 role / content / toolCallId / block.type / block.id，
+// 故用最小构造（其余 provider/usage/stopReason 等字段无关，cast 掉）。
+const user = (t: string): Message =>
+  ({ role: "user", content: t, timestamp: 0 }) as unknown as Message;
+const toolCall = (id: string) => ({ type: "toolCall", id, name: "read", arguments: {} });
+const text = (t: string) => ({ type: "text", text: t });
+const asst = (blocks: unknown[]): Message =>
+  ({ role: "assistant", content: blocks, timestamp: 0 }) as unknown as Message;
+const toolResult = (toolCallId: string): Message =>
+  ({
+    role: "toolResult",
+    toolCallId,
+    toolName: "read",
+    content: [],
+    isError: false,
+    timestamp: 0,
+  }) as unknown as Message;
+
+describe("filterIncompleteToolCalls", () => {
+  it("丢掉含未被 result 的 toolCall 的 assistant（悬挂 tool_use）", () => {
+    const msgs = [user("hi"), asst([text("calling"), toolCall("tc1")])];
+    expect(filterIncompleteToolCalls(msgs)).toEqual([msgs[0]]);
+  });
+
+  it("保留所有 toolCall 都有 result 的 assistant", () => {
+    const msgs = [user("hi"), asst([toolCall("tc1")]), toolResult("tc1")];
+    expect(filterIncompleteToolCalls(msgs)).toHaveLength(3);
+  });
+
+  it("partial batch：整条 assistant 被丢 + 随之产生的 orphan result 也被丢", () => {
+    // tc1 有 result、tc2 悬挂 → 整条 assistant 丢 → tc1 的 result 变 orphan → 丢
+    const msgs = [
+      user("hi"),
+      asst([toolCall("tc1"), toolCall("tc2")]),
+      toolResult("tc1"),
+    ];
+    expect(filterIncompleteToolCalls(msgs)).toEqual([msgs[0]]);
+  });
+
+  it("丢掉本就存在的 orphan toolResult（result 无对应 toolCall）", () => {
+    const msgs = [user("hi"), toolResult("ghost")];
+    expect(filterIncompleteToolCalls(msgs)).toEqual([msgs[0]]);
+  });
+
+  it("无悬挂时返回内容等价的新数组（始终 copy）", () => {
+    const msgs = [user("hi"), asst([text("done")])];
+    const out = filterIncompleteToolCalls(msgs);
+    expect(out).toEqual(msgs);
+    expect(out).not.toBe(msgs);
+  });
+
+  it("non-assistant 与纯文本 assistant 原样保留", () => {
+    const msgs = [user("a"), asst([text("t")]), user("b")];
+    expect(filterIncompleteToolCalls(msgs)).toEqual(msgs);
+  });
+
+  it("多 toolCall 全部 resolved 的 assistant 保留，其 result 不被误删", () => {
+    const msgs = [
+      user("hi"),
+      asst([toolCall("tc1"), toolCall("tc2")]),
+      toolResult("tc1"),
+      toolResult("tc2"),
+    ];
+    expect(filterIncompleteToolCalls(msgs)).toHaveLength(4);
+  });
+});

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -28,6 +28,8 @@ import type {
   HookResult,
   LlmEndInput,
   MergedHookResult,
+  OnAfterFlushInput,
+  OnAfterFlushResult,
   PostToolUseInput,
   PreToolUseInput,
   SessionEndInput,
@@ -160,6 +162,45 @@ export class HookDispatcher {
         this._invokeSafe<void>(h, "onError", [input, ctx], "event"),
       ),
     );
+  }
+
+  /**
+   * Special: onAfterFlush —— **collect-return** 语义（C1）。并行问每个 hook（event 形态、per-hook
+   * timeout、fire-and-observe），把它们**返回**的 `compactionBoundary` 按注册顺序收集成数组交给内核。
+   *
+   * 关键不变量：dispatcher 只负责「拿到非超时/非抛错 hook 的返回值」，**不持有任何 store 写能力**。
+   * 超时的 hook 经 `_invokeSafe` 的 `Promise.race` 被丢弃（`error != null` / `value === undefined`），
+   * 其返回的 boundary 永远到不了这个数组 → 内核拿不到 → 不写。这是「超时绝不产生 detached store 写」的
+   * 机制根基（替换上一版给 hook detached 写能力的错误设计）。返回值的写入由内核 in-band、awaited、
+   * 串行执行（见 session.ts），dispatcher 不碰 store。
+   *
+   * timeout：默认走 event 类（100ms）；但 summarize 可调 LLM，挂此 hook 的 plugin 应自设较长 `timeout`。
+   */
+  async fireAfterFlush(
+    input: OnAfterFlushInput,
+    ctx: HookContext,
+  ): Promise<Message[]> {
+    const matched = this.hooks.filter(
+      (h) => typeof h.onAfterFlush === "function",
+    );
+    const results = await Promise.all(
+      matched.map((h) =>
+        this._invokeSafe<OnAfterFlushResult | void>(
+          h,
+          "onAfterFlush",
+          [input, ctx],
+          "event",
+        ),
+      ),
+    );
+    const boundaries: Message[] = [];
+    for (const r of results) {
+      // 超时 / 抛错的 hook：value === undefined（race 丢弃），其 boundary 永不入列。
+      if (r.value && r.value.compactionBoundary) {
+        boundaries.push(r.value.compactionBoundary);
+      }
+    }
+    return boundaries;
   }
 
   /* ────────────── Decision: 顺序 short-circuit ────────────── */

--- a/packages/core/src/hook.ts
+++ b/packages/core/src/hook.ts
@@ -138,6 +138,38 @@ export interface ContextOverflowInput {
   messageCount: number;
 }
 
+/**
+ * After-flush 信号（C1，docs/09 §4.2「写 compaction 边界进 store」的内核 seam）。每个 turn 在
+ * `_flushToStore()` 之后 fire（仅当 session 有 store）。
+ *
+ * **collect-return 语义（区别于普通 event）**：hook 可**返回** `{ compactionBoundary }` 让**内核**在
+ * in-band、awaited、串行的路径上把它当作一条 `compaction_boundary` entry append 进 store——hook 自己
+ * **没有**任何「可调用的写能力」。这是上一版设计（给 hook 一个 detached `appendCompactionBoundary`）
+ * 被 review 三轮抓出 data-loss / store-corruption 后的重做：detached 写在 hook 超时时仍在飞，会乱序落在
+ * 后续 turn / terminal 之后（resume 当成「丢弃之前一切」→ 静默删已完成 turn），且与下一轮 flush 的
+ * appendEntry 并发打同一 sessionId（违反串行契约）。改成「hook 返回、内核串行写」后，**超时的 hook 其
+ * 返回被 dispatcher 的 race 丢弃 → 内核拿不到 boundary → 不写 → 干净跳过，绝不产生 detached 写**。
+ *
+ * boundary 是 store 侧的额外 entry，**绝不动** `_persistedCount` / `_messages`：live session 继续用全量
+ * `_messages`；只有 `resume()` 重建时才用 boundary 把前缀裁成 summary。与 view-only 压缩
+ * （compactSummarize / autoCompaction 改的是「模型 view」、保 tail）是不同层、正交：那些省 token，
+ * 这里省 resume 重放。
+ */
+export interface OnAfterFlushInput {
+  turnIdx: number;
+  /** 本次 flush 后已持久化的 message 数（= `_persistedCount`）。 */
+  persistedCount: number;
+}
+
+/**
+ * `onAfterFlush` 的返回 envelope。返回 `void` = 本 turn 不落 boundary；返回 `{ compactionBoundary }`
+ * = 请内核在 store 末尾串行 append 一条覆盖全部已持久化前缀的 `compaction_boundary`。
+ */
+export interface OnAfterFlushResult {
+  /** 内核据此 append 一条 `compaction_boundary{summary}`（in-band、awaited、串行）。 */
+  compactionBoundary?: Message;
+}
+
 export interface PreToolUseInput {
   call: ToolCall;
   tool: HarnessTool;
@@ -418,6 +450,15 @@ export interface Hook {
     input: ContextOverflowInput,
     ctx: HookContext,
   ): HookResult | void | Promise<HookResult | void>;
+  /**
+   * After-flush 观测点：每 turn flush 到 store 后 fire（仅有 store 时）。**collect-return**：返回
+   * `{ compactionBoundary }` 让内核在 store 末尾串行落一条 boundary（无「可调用写能力」，超时即被丢弃，
+   * 见 `OnAfterFlushInput` / `OnAfterFlushResult`）。`summarize` 可调 LLM，故应设较长 `timeout`。
+   */
+  onAfterFlush?(
+    input: OnAfterFlushInput,
+    ctx: HookContext,
+  ): OnAfterFlushResult | void | Promise<OnAfterFlushResult | void>;
   onPostToolUse?(
     input: PostToolUseInput,
     ctx: HookContext,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,7 +47,11 @@ export { defaultIsContextOverflow } from "./context-overflow.js";
 
 // ─────────── Tool 形态 + message helpers ───────────
 export type { HarnessTool } from "./types.js";
-export { createUserMessage, createAttachmentMessage } from "./types.js";
+export {
+  createUserMessage,
+  createAttachmentMessage,
+  filterIncompleteToolCalls,
+} from "./types.js";
 
 // ─────────── Session persistence (协议在内核，落盘实现在 adapter) ───────────
 export { MemorySessionStore } from "./session-store.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,8 @@ export type {
   SteerInput,
   LlmEndInput,
   ContextOverflowInput,
+  OnAfterFlushInput,
+  OnAfterFlushResult,
   PreToolUseInput,
   PostToolUseInput,
   UserPromptSubmitInput,

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -1102,6 +1102,40 @@ export class AgentSession {
       // 每个 turn 结束把新 messages append 进 store（durable resume；no-op if no store）。
       await this._flushToStore();
 
+      // After-flush 观测点（C1，docs/09 §4.2）：仅有 store 时 fire。**collect-return**：hook 不持有
+      // 任何写能力，只**返回** boundary；内核在这里 in-band、awaited、串行地把它写进 store——在进入
+      // 下一轮 loop / 下一次 _flushToStore / terminal **之前**完成。这保证：boundary 永远落在「它之后
+      // 的消息 flush」之前，且绝无两个 appendEntry 并发同 session（满足 SessionStore 串行契约）。
+      //
+      // 超时的 hook 其返回被 dispatcher 的 race 丢弃 → fireAfterFlush 拿不到它的 boundary → 这里不写
+      // → 该 turn 无 boundary（干净跳过，**绝不产生 detached store 写**）。这是上一版「detached 写能力」
+      // 设计导致 data-loss/乱序的根因修复。
+      //
+      // boundary 是 store 侧额外 entry，**不动** _persistedCount / _messages（HWM 不变量保持）。
+      // append 抛错按 best-effort 处理（记 failureSink、不杀 run），与 _flushToStore 一致。
+      if (this._store) {
+        const boundaries = await this._dispatcher.fireAfterFlush(
+          {
+            // 刚跑完并 flush 的那个 turn 的序号（_ctx.turnIdx 仍是 :setTurnIdx 设的值，
+            // 而局部 turnIdx 已 ++ 指向下一轮）—— 与 onContextOverflow 取 _ctx.turnIdx 一致。
+            turnIdx: this._ctx.turnIdx,
+            persistedCount: this._persistedCount,
+          },
+          this._ctx,
+        );
+        // 多个 hook 都返回 boundary 时按顺序逐条 append（正常只 1 个）。
+        for (const summary of boundaries) {
+          try {
+            await this._store.appendEntry(this.id, {
+              kind: "compaction_boundary",
+              summary,
+            });
+          } catch (err) {
+            this._reportStoreError("appendEntry(compaction_boundary)", err);
+          }
+        }
+      }
+
       if (outcome === "done") return { turnIdx, reason: "done" };
       if (outcome === "abort") return { turnIdx, reason: "aborted" };
       if (outcome === "error") return { turnIdx, reason: "error" };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -116,3 +116,52 @@ export function createAttachmentMessage(opts: {
     },
   } as Message & { _meta?: Record<string, unknown> };
 }
+
+/**
+ * 剔除「悬挂的 tool 调用」，让一段 messages snapshot 重新喂给 pi-ai 时合法。
+ *
+ * 背景：snapshot 可能停在 tool batch 中途——assistant 已发出 `toolCall`，但对应的
+ * `toolResult` 还没 append。把这种带「无 result 的 toolCall」的消息直接喂 provider 会
+ * 报错（orphan tool_use 400）。fork / sub-agent 这类「拿父 snapshot 当 initialMessages」
+ * 的路径必须先过一遍本函数。借鉴 Claude Code `filterIncompleteToolCalls`
+ * （[08-claude-code-lessons](docs/08-claude-code-lessons.md)），并补齐对称的 orphan-result 清理。
+ *
+ * 三遍、纯函数（不改入参）：
+ *   1. 收集所有 `toolResult` 的 `toolCallId`。
+ *   2. 丢掉「含任一未被 result 的 `toolCall`」的整条 assistant（连同其 text/thinking——
+ *      与 pi-ai 消息原子性一致：assistant 的 content 块不可拆开发）。
+ *   3. 丢掉 orphan `toolResult`（其 `toolCallId` 对应的 assistant 已在第 2 步被丢）。
+ *
+ * snapshot 无悬挂时返回**内容等价**的新数组（始终是 copy，不返回原引用）。
+ */
+export function filterIncompleteToolCalls(messages: Message[]): Message[] {
+  // Pass 1：已有 result 的 toolCallId。
+  const resolved = new Set<string>();
+  for (const m of messages) {
+    if (m.role === "toolResult") resolved.add(m.toolCallId);
+  }
+
+  // Pass 2：保留 non-assistant + 所有 toolCall 都有 result 的 assistant；
+  // 记录存活的 toolCall id 供 Pass 3 清理 orphan result。
+  const survivingToolCallIds = new Set<string>();
+  const afterAssistantFilter = messages.filter((m) => {
+    if (m.role !== "assistant") return true;
+    let hasIncomplete = false;
+    for (const block of m.content) {
+      if (block.type === "toolCall" && !resolved.has(block.id)) {
+        hasIncomplete = true;
+        break;
+      }
+    }
+    if (hasIncomplete) return false;
+    for (const block of m.content) {
+      if (block.type === "toolCall") survivingToolCallIds.add(block.id);
+    }
+    return true;
+  });
+
+  // Pass 3：丢掉 toolCall 已被丢弃的 orphan toolResult。
+  return afterAssistantFilter.filter(
+    (m) => m.role !== "toolResult" || survivingToolCallIds.has(m.toolCallId),
+  );
+}

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-pi/plugins",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Standard library of harness-pi plugins + controllers + sinks",
   "license": "MIT",
   "repository": {

--- a/packages/plugins/src/__tests__/gap-explorer.test.ts
+++ b/packages/plugins/src/__tests__/gap-explorer.test.ts
@@ -129,6 +129,178 @@ describe("subAgentTool", () => {
   });
 });
 
+/* ──────────────── subAgentTool 跨层递归深度闸 (#45) ──────────────── */
+
+describe("subAgentTool depth gate (#45)", () => {
+  /**
+   * 造一个**会嵌套挂 subAgentTool** 的 session：每层 fake model 先 toolCall("subAgent") 把任务再下派一层，
+   * 子层 done 后本层回一句 text。所有 fake 收集起来供 teardown。`depthsSeen` 记录每次 spawn 时**父读到的当前深度**。
+   * 这样从顶层（depth 0）run 起来，深度会沿 lineage 透传、自增，直到 maxDepth 把某层的 spawn 挡掉。
+   */
+  function makeNestedFactory(opts: {
+    maxDepth?: number;
+    maxSubAgents?: number;
+    depthsSeen: number[];
+    fakes: Array<ReturnType<typeof createFakeModel>>;
+  }) {
+    const build = (): AgentSession => {
+      // 这层 model：先要求 spawn 一个 subAgent，拿到结果后回一句 text 收尾。
+      const fake = createFakeModel([
+        { content: [{ type: "toolCall", name: "subAgent", arguments: { task: "go deeper" } }] },
+        { content: [{ type: "text", text: "layer done" }], stopReason: "stop" },
+      ]);
+      opts.fakes.push(fake);
+      const tool = subAgentTool({
+        ...(opts.maxDepth !== undefined ? { maxDepth: opts.maxDepth } : {}),
+        ...(opts.maxSubAgents !== undefined ? { maxSubAgents: opts.maxSubAgents } : {}),
+        // sessionFactory 拿到父 ctx → 记录父此刻读到的深度，再递归造下一层。
+        sessionFactory: (_task, c) => {
+          opts.depthsSeen.push(c.state.get("subAgent.depth") ?? 0);
+          return build();
+        },
+      });
+      return new AgentSession({ model: fake, tools: [tool] });
+    };
+    return build;
+  }
+
+  it("3rd layer spawn throws a readable depth-limit error (maxDepth=2)", async () => {
+    // depth: 主(0)→子(1)→孙(2)。孙这层 execute 读到 depth=2 >= maxDepth=2 → throw，不再 spawn 第 4 层。
+    const fakes: Array<ReturnType<typeof createFakeModel>> = [];
+    const depthsSeen: number[] = [];
+    const build = makeNestedFactory({ maxDepth: 2, depthsSeen, fakes });
+    const root = build();
+    const res = await root.run("start");
+    expect(res.reason).toBe("done");
+
+    // 孙(depth 2)层的 subAgent execute 抛错 → kernel 包成 isError toolResult 回灌孙的 model。
+    // 在某个 fake 的收到的 context 里能找到这条可读错误。
+    const allToolResults = fakes
+      .flatMap((f) => f.getCalls())
+      .flatMap((ctx) => ctx.messages)
+      .filter((m) => m.role === "toolResult");
+    const errText = allToolResults
+      .map((m) => blockText((m as { content: unknown }).content))
+      .join("\n");
+    expect(errText).toContain("depth limit (maxDepth=2) reached");
+
+    // spawn 只发生在 depth 0 和 1 两层（孙那层被挡，不进 sessionFactory）。
+    expect(depthsSeen).toEqual([0, 1]);
+    fakes.forEach((f) => f.teardown());
+  });
+
+  it("depth limit fires at the top level too when maxDepth=0 (no spawn at all)", async () => {
+    // maxDepth=0：顶层（depth 0）execute 立刻读到 0 >= 0 → 直接 throw，sessionFactory 一次都不调。
+    const subFake = createFakeModel([{ content: [{ type: "text", text: "x" }], stopReason: "stop" }]);
+    let factoryCalls = 0;
+    const tool = subAgentTool({
+      maxDepth: 0,
+      sessionFactory: () => {
+        factoryCalls++;
+        return new AgentSession({ model: subFake, tools: [] });
+      },
+    });
+    const { ctx } = createTestContext();
+    await expect(
+      tool.execute({ task: "t" }, ctx, new AbortController().signal),
+    ).rejects.toThrow(/depth limit \(maxDepth=0\) reached/);
+    expect(factoryCalls).toBe(0);
+    subFake.teardown();
+  });
+
+  it("horizontal maxSubAgents gate stays independent of the vertical depth gate", async () => {
+    // 同一层（depth 0）连派 2 个 sub-agent：maxSubAgents=1 拦第 2 个（横向），而 maxDepth=2 这层（depth 0<2）
+    // 本不该拦——证明两闸正交：横向耗尽不是「深度到顶」，错误文案也各自独立。
+    const subFake = createFakeModel([
+      { content: [{ type: "text", text: "1" }], stopReason: "stop" },
+    ]);
+    const tool = subAgentTool({
+      maxSubAgents: 1,
+      maxDepth: 2,
+      sessionFactory: () => new AgentSession({ model: subFake, tools: [] }),
+    });
+    const { ctx } = createTestContext(); // depth 缺省 0
+    const sig = new AbortController().signal;
+    await tool.execute({ task: "a" }, ctx, sig); // spawned=1，depth 0<2 → OK
+    await expect(tool.execute({ task: "b" }, ctx, sig)).rejects.toThrow(/budget exhausted/);
+    subFake.teardown();
+  });
+
+  it("depth增量沿 lineage 透传：每层 = 父+1，闸停在 maxDepth", async () => {
+    // 直接观察注入机制：每嵌套一层，子 session 的 ctx.state 深度比父 +1。makeNestedFactory 会一直递归下钻，
+    // 故深度从 0 起逐层自增，直到读到 depth>=maxDepth 把该层 spawn 挡掉。maxDepth=5 → spawn 发生在 depth 0..4，
+    // 严格连续自增的 [0,1,2,3,4] 同时钉死「逐层 +1 透传」与「闸恰在 maxDepth 截断」。
+    const fakes: Array<ReturnType<typeof createFakeModel>> = [];
+    const depthsSeen: number[] = [];
+    const build = makeNestedFactory({ maxDepth: 5, depthsSeen, fakes });
+    const root = build();
+    await root.run("start");
+    expect(depthsSeen).toEqual([0, 1, 2, 3, 4]);
+    fakes.forEach((f) => f.teardown());
+  });
+
+  it("multi-branch siblings don't cross-talk: each child inherits parent depth independently", async () => {
+    // 顶层（depth 0）连 spawn 两个**兄弟**子：两个子各自从父继承 depth+1=1，互不串扰（独立 ctx.state）。
+    // 每个兄弟子里再 spawn 一层，应都读到 depth=1（而非把彼此的递增累加成 1、2）。
+    const childDepths: number[] = [];
+    const subFakes: Array<ReturnType<typeof createFakeModel>> = [];
+    // 兄弟子的 model：spawn 一层孙后收尾。
+    const buildChild = (): AgentSession => {
+      const f = createFakeModel([
+        { content: [{ type: "toolCall", name: "subAgent", arguments: { task: "grandchild" } }] },
+        { content: [{ type: "text", text: "child done" }], stopReason: "stop" },
+      ]);
+      subFakes.push(f);
+      const childTool = subAgentTool({
+        maxDepth: 10,
+        sessionFactory: (_t, c) => {
+          childDepths.push(c.state.get("subAgent.depth") ?? 0); // 子里 spawn 孙时读到的深度
+          const gf = createFakeModel([{ content: [{ type: "text", text: "gc" }], stopReason: "stop" }]);
+          subFakes.push(gf);
+          return new AgentSession({ model: gf, tools: [] });
+        },
+      });
+      return new AgentSession({ model: f, tools: [childTool] });
+    };
+
+    // 顶层 model：连发两个 subAgent toolCall（同一 turn 内两次），再收尾。
+    const rootFake = createFakeModel([
+      {
+        content: [
+          { type: "toolCall", name: "subAgent", arguments: { task: "branch-A" } },
+          { type: "toolCall", name: "subAgent", arguments: { task: "branch-B" } },
+        ],
+      },
+      { content: [{ type: "text", text: "root done" }], stopReason: "stop" },
+    ]);
+    const rootTool = subAgentTool({
+      maxDepth: 10,
+      sessionFactory: () => buildChild(),
+    });
+    const root = new AgentSession({ model: rootFake, tools: [rootTool] });
+    await root.run("start");
+
+    // 两个兄弟子各自在自己层 spawn 孙，都应读到 depth=1（从顶层 0 各自 +1），不互相污染。
+    expect(childDepths).toEqual([1, 1]);
+    rootFake.teardown();
+    subFakes.forEach((f) => f.teardown());
+  });
+
+  it("default maxDepth (=2) is harmless for existing single-level usage (regression)", async () => {
+    // 不传 maxDepth：顶层（depth 0）spawn 一个子（depth 1）这类**现有**单层用法照常工作，不被默认闸误伤。
+    const subFake = createFakeModel([
+      { content: [{ type: "text", text: "ok" }], stopReason: "stop" },
+    ]);
+    const tool = subAgentTool({
+      sessionFactory: () => new AgentSession({ model: subFake, tools: [] }),
+    });
+    const { ctx } = createTestContext(); // depth 缺省 0
+    const result = await tool.execute({ task: "t" }, ctx, new AbortController().signal);
+    expect(blockText(result.content)).toContain("ok");
+    subFake.teardown();
+  });
+});
+
 /* ──────────────── GapExplorer ──────────────── */
 
 describe("GapExplorer", () => {

--- a/packages/plugins/src/__tests__/microcompact.test.ts
+++ b/packages/plugins/src/__tests__/microcompact.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect } from "vitest";
+import { AgentSession, createUserMessage } from "@harness-pi/core";
+import { createTestContext, createFakeModel } from "@harness-pi/core/testing";
+import type { Message } from "@earendil-works/pi-ai";
+import { microcompact } from "../microcompact.js";
+
+function textOf(m: Message): string {
+  return typeof m.content === "string"
+    ? m.content
+    : m.content.map((b) => ("text" in b ? b.text : "")).join("");
+}
+
+/** 造一条 toolResult message。 */
+function tr(toolName: string, text: string, ts = 0): Message {
+  return {
+    role: "toolResult",
+    toolCallId: `c-${Math.random()}`,
+    toolName,
+    content: [{ type: "text", text }],
+    isError: false,
+    timestamp: ts,
+  };
+}
+
+describe("microcompact", () => {
+  it("keeps the most recent N tool results verbatim, clears older whitelisted ones with a named placeholder", () => {
+    // 20 条 'read' 的 toolResult，keepRecent=5；triggerTokens 极小确保触发、targetTokens 极小确保清到最多。
+    const msgs: Message[] = Array.from({ length: 20 }, (_, i) =>
+      tr("read", `RESULT_${i}_` + "x".repeat(40)),
+    );
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 1,
+      targetTokens: 1,
+      keepRecent: 5,
+    });
+    const { ctx } = createTestContext();
+    const view = compact.transformMessagesBeforeLlm!(msgs, ctx) as Message[];
+
+    expect(view).toBeDefined();
+    // 最近 5 条原文保留
+    for (let i = 15; i < 20; i++) {
+      expect(textOf(view[i]!)).toBe(textOf(msgs[i]!));
+    }
+    // 其余 15 条被占位符替换，且占位符含工具名
+    for (let i = 0; i < 15; i++) {
+      const t = textOf(view[i]!);
+      expect(t).toContain("microcompact");
+      expect(t).toContain("read"); // 工具名
+      expect(t).not.toContain("RESULT_"); // 原文已清
+    }
+  });
+
+  it("triggers on token volume even with few-but-huge results", () => {
+    // 只有 3 条，但单条巨大：按条数测不出，按体积能触发。keepRecent=1 → 留最后 1 条。
+    const msgs: Message[] = [
+      tr("read", "A".repeat(4000)),
+      tr("read", "B".repeat(4000)),
+      tr("read", "C".repeat(40)), // 最近，保留
+    ];
+    const compact = microcompact({
+      compactableTools: new Set(["read"]),
+      triggerTokens: 500, // 估算 (4000+4000)/4 ≈ 2000 > 500 → 触发
+      targetTokens: 100,
+      keepRecent: 1,
+    });
+    const { ctx } = createTestContext();
+    const view = compact.transformMessagesBeforeLlm!(msgs, ctx) as Message[];
+
+    expect(view).toBeDefined();
+    expect(textOf(view[0]!)).toContain("microcompact"); // 巨大旧条被清
+    expect(textOf(view[1]!)).toContain("microcompact");
+    expect(textOf(view[2]!)).toBe("C".repeat(40)); // 最近 1 条原文保留
+  });
+
+  it("stops clearing once target volume is reached (does not clear everything)", () => {
+    // 5 条各 ~1000 tokens（estimateTokensByChars ≈ chars/4），keepRecent=0。总 ≈ 5000。
+    // trigger=3000（5000 > 3000 → 触发）；target=3000 → 逐条清并重估，降到 ≤3000 即停。
+    // 实测：清 2 条剩 ≈3024（仍 >3000）→ 再清 1 条剩 ≈2036（≤3000）即停 = 清 3 条；关键是**不会**全清 5 条。
+    const msgs: Message[] = Array.from({ length: 5 }, () => tr("read", "z".repeat(4000)));
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 3000, // 低于总体积 → 触发
+      targetTokens: 3000, // 清到 ≤3000 即停
+      keepRecent: 0,
+    });
+    const { ctx } = createTestContext();
+    const view = compact.transformMessagesBeforeLlm!(msgs, ctx) as Message[];
+
+    expect(view).toBeDefined();
+    const clearedCount = view.filter((m) => textOf(m).includes("microcompact")).length;
+    expect(clearedCount).toBe(3); // 清到目标即停
+    expect(clearedCount).toBeLessThan(5); // 而非全清——「清到目标为止」语义
+    expect(textOf(view[3]!)).toContain("z".repeat(40)); // 第 4、5 条原文保留
+    expect(textOf(view[4]!)).toContain("z".repeat(40));
+  });
+
+  it("leaves non-whitelisted tool results, assistant reasoning and user messages untouched", () => {
+    const assistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "thinking about it" }],
+      api: "x",
+      provider: "x",
+      model: "x",
+      usage: {},
+      stopReason: "stop",
+      timestamp: 0,
+    } as unknown as Message;
+    const msgs: Message[] = [
+      createUserMessage("user question " + "q".repeat(2000)),
+      assistant,
+      tr("bash", "BASH_OUTPUT " + "b".repeat(2000)), // 非白名单
+      tr("read", "READ_OUTPUT " + "r".repeat(2000)), // 白名单、旧
+      tr("read", "RECENT"), // 最近，保留
+    ];
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 1,
+      targetTokens: 1,
+      keepRecent: 1,
+    });
+    const { ctx } = createTestContext();
+    const view = compact.transformMessagesBeforeLlm!(msgs, ctx) as Message[];
+
+    expect(view).toBeDefined();
+    expect(textOf(view[0]!)).toContain("user question"); // user 不动
+    expect(textOf(view[1]!)).toBe("thinking about it"); // assistant 不动
+    expect(textOf(view[2]!)).toContain("BASH_OUTPUT"); // 非白名单 toolResult 不动
+    expect(textOf(view[3]!)).toContain("microcompact"); // 白名单旧条被清
+    expect(textOf(view[3]!)).toContain("read");
+    expect(textOf(view[4]!)).toBe("RECENT"); // 最近保留
+  });
+
+  it("gapMinutes: clears aggressively when the cache is cold even if volume is small", () => {
+    // 体积很小（不会按 token 触发），但最后一条 timestamp 距 now 超过 gapMinutes → 仍清白名单旧条。
+    const t0 = 1_000_000;
+    const msgs: Message[] = [
+      tr("read", "old1", t0),
+      tr("read", "old2", t0),
+      tr("read", "recent", t0 + 1000),
+    ];
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 1_000_000, // 极大 → 绝不会按体积触发
+      keepRecent: 1,
+      gapMinutes: 5,
+      now: () => t0 + 6 * 60_000, // 距最后一条 timestamp(t0+1000) 约 6 分钟 > 5
+    });
+    const { ctx } = createTestContext();
+    const view = compact.transformMessagesBeforeLlm!(msgs, ctx) as Message[];
+
+    expect(view).toBeDefined();
+    expect(textOf(view[0]!)).toContain("microcompact"); // gap 触发，旧条被清
+    expect(textOf(view[1]!)).toContain("microcompact");
+    expect(textOf(view[2]!)).toBe("recent"); // 最近保留
+  });
+
+  it("gapMinutes: does NOT trigger when within the gap window and volume small", () => {
+    const t0 = 1_000_000;
+    const msgs: Message[] = [tr("read", "a", t0), tr("read", "b", t0), tr("read", "c", t0)];
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 1_000_000,
+      keepRecent: 1,
+      gapMinutes: 5,
+      now: () => t0 + 2 * 60_000, // 才 2 分钟 < 5
+    });
+    const { ctx } = createTestContext();
+    expect(compact.transformMessagesBeforeLlm!(msgs, ctx)).toBeUndefined();
+  });
+
+  it("returns undefined (no-op) when below the trigger volume and no gap configured", () => {
+    const msgs: Message[] = [tr("read", "tiny"), tr("read", "small")];
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 1_000_000,
+      keepRecent: 1,
+    });
+    const { ctx } = createTestContext();
+    expect(compact.transformMessagesBeforeLlm!(msgs, ctx)).toBeUndefined();
+  });
+
+  it("returns undefined when over volume but nothing is clearable (all within keepRecent)", () => {
+    const msgs: Message[] = [tr("read", "x".repeat(4000)), tr("read", "y".repeat(4000))];
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 1, // 触发
+      keepRecent: 5, // 但全在保留窗口内
+    });
+    const { ctx } = createTestContext();
+    expect(compact.transformMessagesBeforeLlm!(msgs, ctx)).toBeUndefined();
+  });
+
+  it("is view-only: does not mutate the input messages array nor its elements", () => {
+    const original = tr("read", "ORIGINAL " + "x".repeat(4000));
+    const msgs: Message[] = [original, tr("read", "RECENT")];
+    const before = JSON.stringify(msgs);
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 1,
+      targetTokens: 1,
+      keepRecent: 1,
+    });
+    const { ctx } = createTestContext();
+    const view = compact.transformMessagesBeforeLlm!(msgs, ctx) as Message[];
+
+    expect(textOf(view[0]!)).toContain("microcompact"); // view 改了
+    expect(JSON.stringify(msgs)).toBe(before); // 原数组与元素未被改
+    expect(textOf(msgs[0]!)).toContain("ORIGINAL"); // 原 toolResult content 仍是原文
+    expect(view).not.toBe(msgs); // 是新数组
+  });
+
+  it("placeholder reports the original content char count", () => {
+    const body = "y".repeat(4000);
+    const msgs: Message[] = [tr("read", body), tr("read", "recent")];
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 1,
+      targetTokens: 1,
+      keepRecent: 1,
+    });
+    const { ctx } = createTestContext();
+    const view = compact.transformMessagesBeforeLlm!(msgs, ctx) as Message[];
+    expect(textOf(view[0]!)).toContain(`~${body.length} chars`);
+  });
+
+  it("accepts a custom placeholderText", () => {
+    const msgs: Message[] = [tr("read", "x".repeat(4000)), tr("read", "recent")];
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 1,
+      targetTokens: 1,
+      keepRecent: 1,
+      placeholderText: (tool, chars) => `CLEARED(${tool}/${chars})`,
+    });
+    const { ctx } = createTestContext();
+    const view = compact.transformMessagesBeforeLlm!(msgs, ctx) as Message[];
+    expect(textOf(view[0]!)).toBe(`CLEARED(read/4000)`);
+  });
+
+  it("rejects invalid options at construction", () => {
+    expect(() => microcompact({ compactableTools: ["read"], triggerTokens: 0 })).toThrow(
+      /triggerTokens/,
+    );
+    expect(() =>
+      microcompact({ compactableTools: ["read"], triggerTokens: 100, targetTokens: 0 }),
+    ).toThrow(/targetTokens/);
+    expect(() =>
+      microcompact({ compactableTools: ["read"], triggerTokens: 100, targetTokens: 200 }),
+    ).toThrow(/targetTokens/); // > triggerTokens
+    expect(() =>
+      microcompact({ compactableTools: ["read"], triggerTokens: 100, gapMinutes: 0 }),
+    ).toThrow(/gapMinutes/);
+  });
+
+  it("end-to-end: the model sees the microcompacted view while full history persists", async () => {
+    const initial: Message[] = [
+      tr("read", "FILE_A " + "a".repeat(4000)),
+      tr("read", "FILE_B " + "b".repeat(4000)),
+      tr("read", "FILE_C"), // 最近，保留
+    ];
+    const fake = createFakeModel([{ content: [{ type: "text", text: "ok" }], stopReason: "stop" }]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [],
+      initialMessages: initial,
+      hooks: [
+        microcompact({
+          compactableTools: ["read"],
+          triggerTokens: 100, // 大体积 → 触发
+          targetTokens: 1, // 尽量清
+          keepRecent: 1,
+        }),
+      ],
+    });
+    await session.run("go");
+
+    const view = fake.getCalls()[0]!.messages;
+    // view 里旧的两条 read 被占位符替换，FILE_C + "go" 原文在
+    expect(textOf(view[0]!)).toContain("microcompact");
+    expect(textOf(view[1]!)).toContain("microcompact");
+    expect(textOf(view[2]!)).toBe("FILE_C");
+    // 完整原始历史未被破坏：session.messages 里旧 read 仍是原文。
+    expect(textOf(session.messages[0]!)).toContain("FILE_A");
+    expect(textOf(session.messages[1]!)).toContain("FILE_B");
+    fake.teardown();
+  });
+});

--- a/packages/plugins/src/__tests__/microcompact.test.ts
+++ b/packages/plugins/src/__tests__/microcompact.test.ts
@@ -75,8 +75,9 @@ describe("microcompact", () => {
 
   it("stops clearing once target volume is reached (does not clear everything)", () => {
     // 5 条各 ~1000 tokens（estimateTokensByChars ≈ chars/4），keepRecent=0。总 ≈ 5000。
-    // trigger=3000（5000 > 3000 → 触发）；target=3000 → 逐条清并重估，降到 ≤3000 即停。
-    // 实测：清 2 条剩 ≈3024（仍 >3000）→ 再清 1 条剩 ≈2036（≤3000）即停 = 清 3 条；关键是**不会**全清 5 条。
+    // trigger=3000（5000 > 3000 → 触发）；target=3000 → 从最旧逐条清并重估，降到 ≤3000 即停。
+    // 契约 = 「清到目标即停、绝不全清」；断言**不耦合估算器精确算术**（清了几条随 rounding 可能微变，
+    // 真正的不变量是 0 < cleared < 5、且最近一条（早停必发生在清到它之前）幸存。）
     const msgs: Message[] = Array.from({ length: 5 }, () => tr("read", "z".repeat(4000)));
     const compact = microcompact({
       compactableTools: ["read"],
@@ -89,10 +90,9 @@ describe("microcompact", () => {
 
     expect(view).toBeDefined();
     const clearedCount = view.filter((m) => textOf(m).includes("microcompact")).length;
-    expect(clearedCount).toBe(3); // 清到目标即停
-    expect(clearedCount).toBeLessThan(5); // 而非全清——「清到目标为止」语义
-    expect(textOf(view[3]!)).toContain("z".repeat(40)); // 第 4、5 条原文保留
-    expect(textOf(view[4]!)).toContain("z".repeat(40));
+    expect(clearedCount).toBeGreaterThan(0); // 触发并清了一些
+    expect(clearedCount).toBeLessThan(5); // 但绝不全清——「清到目标为止」语义
+    expect(textOf(view[4]!)).toBe("z".repeat(4000)); // 最近一条必然幸存（早停发生在清到它之前），精确比对
   });
 
   it("leaves non-whitelisted tool results, assistant reasoning and user messages untouched", () => {
@@ -153,6 +153,53 @@ describe("microcompact", () => {
     expect(textOf(view[0]!)).toContain("microcompact"); // gap 触发，旧条被清
     expect(textOf(view[1]!)).toContain("microcompact");
     expect(textOf(view[2]!)).toBe("recent"); // 最近保留
+  });
+
+  it("gapMinutes (cold cache) clears ALL clearable, ignoring the targetTokens early-stop", () => {
+    // 区分 cold-cache 路径与 volume 路径:triggerTokens 极大 → volume 永不触发(只有 cold 路径会动);
+    // targetTokens=3000(若 cold 误用了体积早停,会停在 ~3 条);keepRecent=0(5 条全可清);gap 超阈值 → cold。
+    // cold 路径**无早停**,应把 5 条全清。防回归:若给 cold 加上 targetTokens 早停(或从 volume 去掉),清的就不足 5。
+    const t0 = 1_000_000;
+    const msgs: Message[] = Array.from({ length: 5 }, () => tr("read", "z".repeat(4000), t0));
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 1_000_000, // volume 路径永不触发
+      targetTokens: 3000, // 若 cold 误用早停会停在 ~3 条
+      keepRecent: 0,
+      gapMinutes: 5,
+      now: () => t0 + 6 * 60_000, // 距末条 6 分钟 > 5 → cold
+    });
+    const { ctx } = createTestContext();
+    const view = compact.transformMessagesBeforeLlm!(msgs, ctx) as Message[];
+
+    expect(view).toBeDefined();
+    const cleared = view.filter((m) => textOf(m).includes("microcompact")).length;
+    expect(cleared).toBe(5); // cold 路径全清,不受 targetTokens 早停约束
+  });
+
+  it("keepRecent ranks by toolResult position, skipping interspersed non-whitelisted results", () => {
+    // 布局:read(旧) / bash(非白名单,夹中间) / read(旧) / read(最近)。keepRecent=1 只保护最近 1 条 toolResult。
+    // 证明 keepRecent 按 toolResult 序位(非 raw index)算,夹中间的 bash 既不被清、也不占保护名额。
+    const msgs: Message[] = [
+      tr("read", "OLD1 " + "x".repeat(2000)),
+      tr("bash", "BASH " + "b".repeat(2000)), // 非白名单
+      tr("read", "OLD2 " + "y".repeat(2000)),
+      tr("read", "RECENT"), // 最近 toolResult,keepRecent=1 保护
+    ];
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 1,
+      targetTokens: 1,
+      keepRecent: 1,
+    });
+    const { ctx } = createTestContext();
+    const view = compact.transformMessagesBeforeLlm!(msgs, ctx) as Message[];
+
+    expect(view).toBeDefined();
+    expect(textOf(view[0]!)).toContain("microcompact"); // OLD1 清
+    expect(textOf(view[1]!)).toContain("BASH"); // 非白名单 toolResult 不动
+    expect(textOf(view[2]!)).toContain("microcompact"); // OLD2 清(夹中间的 bash 没让它逃过保护名额)
+    expect(textOf(view[3]!)).toBe("RECENT"); // 最近保留
   });
 
   it("gapMinutes: does NOT trigger when within the gap window and volume small", () => {

--- a/packages/plugins/src/__tests__/persist-compaction-boundary.test.ts
+++ b/packages/plugins/src/__tests__/persist-compaction-boundary.test.ts
@@ -1,0 +1,350 @@
+/**
+ * persistCompactionBoundary controller integration —— C1 redesign (docs/09 §4.2).
+ *
+ * 端到端：跑几个 turn → shouldCompact 触发 → 控制器**返回** summary → 内核 in-band 串行落 boundary →
+ * AgentSession.resume 从 boundary 重建出 [summary, ...post-boundary]（而非全量）。
+ *
+ * 核心回归（锁住上一版 detached 写的 data-loss / store-corruption）：超时的 summarize 不致 boundary
+ * 乱序落在 terminal 之后、不丢已完成 turn、store 顺序单调、run 不被杀。见最后两个用例。
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  AgentSession,
+  MemorySessionStore,
+  createUserMessage,
+  type HarnessTool,
+  type Message,
+} from "@harness-pi/core";
+import { createFakeModel } from "@harness-pi/core/testing";
+import { persistCompactionBoundary } from "../controllers/index.js";
+
+const noopTool: HarnessTool = {
+  name: "noop",
+  description: "noop",
+  parameters: { type: "object", properties: {} } as never,
+  async execute() {
+    return { content: [{ type: "text", text: "ok" }] };
+  },
+};
+
+const roles = (msgs: ReadonlyArray<Message>) => msgs.map((m) => m.role);
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("persistCompactionBoundary controller (return-based)", () => {
+  it("triggers a boundary → resume rebuilds [summary, ...post-boundary], not the full history", async () => {
+    const store = new MemorySessionStore();
+    // turn 0: tool call (assistant + toolResult). turn 1: text → done.
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "text", text: "final" }] },
+    ]);
+    const summary = createUserMessage("SUMMARY-OF-PREFIX");
+    const hook = persistCompactionBoundary({
+      // only compact after turn 0's flush (exactly 3 persisted: user + assistant + toolResult);
+      // turn 1's flush (4 persisted) won't re-trigger, leaving turn-1 messages after the boundary.
+      shouldCompact: ({ persistedCount }) => persistedCount === 3,
+      summarize: () => summary,
+    });
+    const session = new AgentSession({
+      model: fake,
+      tools: [noopTool],
+      store,
+      hooks: [hook],
+    });
+    await session.run("go");
+
+    // live session keeps the full history (HWM unaffected)
+    expect(roles(session.messages)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+      "assistant",
+    ]);
+
+    const path = await store.getPathToLeaf(session.id);
+    expect(path.filter((e) => e.entry.kind === "compaction_boundary")).toHaveLength(1);
+
+    // resume drops the pre-boundary prefix, keeps summary + post-boundary turn-1 assistant
+    const fake2 = createFakeModel([{ content: [{ type: "text", text: "z" }] }]);
+    const resumed = await AgentSession.resume(store, session.id, {
+      model: fake2,
+      tools: [noopTool],
+    });
+    expect(roles(resumed.messages)).toEqual(["user", "assistant"]);
+    expect(resumed.messages[0]).toBe(summary);
+    fake.teardown();
+    fake2.teardown();
+  });
+
+  it("shouldCompact=false never writes a boundary (resume == full history)", async () => {
+    const store = new MemorySessionStore();
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "text", text: "final" }] },
+    ]);
+    const hook = persistCompactionBoundary({
+      shouldCompact: () => false,
+      summarize: () => createUserMessage("never"),
+    });
+    const session = new AgentSession({
+      model: fake,
+      tools: [noopTool],
+      store,
+      hooks: [hook],
+    });
+    await session.run("go");
+
+    const path = await store.getPathToLeaf(session.id);
+    expect(path.filter((e) => e.entry.kind === "compaction_boundary")).toHaveLength(0);
+    fake.teardown();
+  });
+
+  it("shouldCompact receives only the flushed prefix (length === persistedCount)", async () => {
+    const store = new MemorySessionStore();
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "text", text: "final" }] },
+    ]);
+    let seen: { persistedCount: number; len: number } | undefined;
+    const hook = persistCompactionBoundary({
+      shouldCompact: ({ persistedCount, messages }) => {
+        seen = { persistedCount, len: messages.length };
+        return false;
+      },
+      summarize: () => createUserMessage("x"),
+    });
+    const session = new AgentSession({ model: fake, tools: [noopTool], store, hooks: [hook] });
+    await session.run("go");
+
+    expect(seen).toBeDefined();
+    expect(seen!.len).toBe(seen!.persistedCount); // 传入的是已持久化前缀,非全量 ctx.messages
+    fake.teardown();
+  });
+
+  it("minTurnsBetween throttles: not every qualifying turn writes a boundary", async () => {
+    const store = new MemorySessionStore();
+    // three turns, each a tool call then the loop ends at maxTurns.
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+    ]);
+    let summarizeCalls = 0;
+    const hook = persistCompactionBoundary({
+      shouldCompact: () => true, // every turn qualifies
+      summarize: () => {
+        summarizeCalls++;
+        return createUserMessage(`S${summarizeCalls}`);
+      },
+      minTurnsBetween: 2,
+    });
+    const session = new AgentSession({
+      model: fake,
+      tools: [noopTool],
+      store,
+      hooks: [hook],
+      maxTurns: 3,
+    });
+    await session.run("go");
+
+    // turns flushed at idx 0,1,2. minTurnsBetween=2: boundary at turn 0 (first),
+    // then turn 1 skipped (1-0 < 2), turn 2 allowed (2-0 >= 2) → 2 boundaries, 2 summarize calls.
+    const boundaries = (await store.getPathToLeaf(session.id)).filter(
+      (e) => e.entry.kind === "compaction_boundary",
+    );
+    expect(boundaries).toHaveLength(2);
+    expect(summarizeCalls).toBe(2);
+    fake.teardown();
+  });
+
+  it("throttle high-water-mark advances before the await, so a failing summarize can't defeat minTurnsBetween", async () => {
+    // 节流高水位若在 await 之后才 set,summarize 抛错会让它漏更新 → 每个 qualifying turn 都重新触发。
+    // 控制器「先提交节流、再做 async 慢活」。summarize 总抛错(fire-and-observe,不杀 run):
+    //   set 先行 → 节流照常 → 4 个 qualifying turn 只调 2 次 summarize。
+    const store = new MemorySessionStore();
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+    ]);
+    let calls = 0;
+    const hook = persistCompactionBoundary({
+      shouldCompact: () => true,
+      summarize: () => {
+        calls++;
+        throw new Error("summarize boom");
+      },
+      minTurnsBetween: 2,
+    });
+    const session = new AgentSession({
+      model: fake,
+      tools: [noopTool],
+      store,
+      hooks: [hook],
+      maxTurns: 4,
+      hookFailureSink: () => {}, // swallow recorded summarize failure
+    });
+    await session.run("go"); // summarize 抛错被 fire-and-observe 吞,run 不被杀
+
+    // turns 0,1,2,3;minTurnsBetween=2 → 触发于 0 与 2(2 次),即使 summarize 每次抛错。
+    expect(calls).toBe(2);
+    fake.teardown();
+  });
+
+  it("rejects minTurnsBetween < 1 at construction", () => {
+    expect(() =>
+      persistCompactionBoundary({
+        shouldCompact: () => true,
+        summarize: () => createUserMessage("x"),
+        minTurnsBetween: 0,
+      }),
+    ).toThrow(/minTurnsBetween/);
+  });
+
+  it("async (LLM-latency) summarize beyond the 100ms event default still writes a boundary", async () => {
+    // onAfterFlush 走 event 类、dispatcher 默认超时仅 100ms;summarize 调 LLM 是秒级。控制器把 hook
+    // timeout 放宽(默认 60s),否则真 summarize 必超时、其返回被丢弃 → 零 boundary。这里 ~150ms async
+    // summarize:>100ms(旧默认会超时)、远 < 放宽后默认 → boundary 必落。
+    const store = new MemorySessionStore();
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "text", text: "final" }] },
+    ]);
+    const summary = createUserMessage("ASYNC-SUMMARY");
+    const hook = persistCompactionBoundary({
+      shouldCompact: ({ persistedCount }) => persistedCount === 3,
+      summarize: () => new Promise<Message>((r) => setTimeout(() => r(summary), 150)),
+    });
+    const session = new AgentSession({ model: fake, tools: [noopTool], store, hooks: [hook] });
+    const result = await session.run("go");
+
+    expect(result.reason).toBe("done");
+    const boundaries = (await store.getPathToLeaf(session.id)).filter(
+      (e) => e.entry.kind === "compaction_boundary",
+    );
+    expect(boundaries).toHaveLength(1);
+    fake.teardown();
+  });
+
+  /* ───────────────── 核心回归：超时不致数据丢失 / 乱序 ───────────────── */
+
+  it("REGRESSION: a timed-out summarize loses no data, leaves no out-of-order boundary, doesn't kill the run", async () => {
+    // 上一版 detached 设计在这里会失败:hook 超时 → detached summarize+append 仍在飞 → boundary 乱序
+    // 落在后续 turn / terminal 之后 → resume 把它当「丢弃之前一切」→ 静默删已完成 turn。
+    // 本设计:超时的 summarize 返回被 dispatcher race 丢弃 → 控制器返回到不了内核 → 不写 boundary。
+    const store = new MemorySessionStore();
+    // turn 0: tool call (3 persisted). turn 1: text → done (4 persisted).
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "text", text: "final" }] },
+    ]);
+    let summarizeStarted = 0;
+    const failures: string[] = [];
+    const hook = persistCompactionBoundary({
+      shouldCompact: ({ persistedCount }) => persistedCount === 3, // 只 turn 0 触发
+      // 慢 summarize(80ms)远超下方 30ms hook timeout → 被 race 丢弃。
+      summarize: async () => {
+        summarizeStarted++;
+        await sleep(80);
+        return createUserMessage("SLOW-SHOULD-NEVER-LAND");
+      },
+      timeout: 30, // 小超时,故意让 summarize 来不及完成
+    });
+    const session = new AgentSession({
+      model: fake,
+      tools: [noopTool],
+      store,
+      hooks: [hook],
+      hookFailureSink: (info) => failures.push(`${info.method}:${info.errorMessage}`),
+    });
+    const result = await session.run("go");
+
+    // run 没被超时杀掉(fire-and-observe)。
+    expect(result.reason).toBe("done");
+    // summarize 确实被启动过(证明触发逻辑生效),且 dispatcher 记到一次 onAfterFlush 超时。
+    expect(summarizeStarted).toBe(1);
+    expect(failures.some((f) => /onAfterFlush/.test(f))).toBe(true);
+
+    // 即使等到远超 slow summarize 的 80ms,也没有迟到的 detached 写偷偷落进 store。
+    await sleep(120);
+    const path = await store.getPathToLeaf(session.id);
+    // 关键:超时 → 零 boundary 落盘。
+    expect(path.filter((e) => e.entry.kind === "compaction_boundary")).toHaveLength(0);
+    // store 顺序单调(无并发损坏:没有两条 appendEntry 并发同 session 撞号)。
+    const seqs = path.map((e) => e.seq);
+    expect(seqs).toEqual([...seqs].sort((a, c) => a - c));
+    // terminal 之后没有任何 entry(乱序的 boundary 本会落在这里)。
+    expect(path[path.length - 1]!.entry.kind).toBe("terminal");
+
+    // resume 不丢任何已完成 turn:全量重建。
+    const fake2 = createFakeModel([{ content: [{ type: "text", text: "z" }] }]);
+    const resumed = await AgentSession.resume(store, session.id, {
+      model: fake2,
+      tools: [noopTool],
+    });
+    expect(roles(resumed.messages)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+      "assistant",
+    ]);
+    fake.teardown();
+    fake2.teardown();
+  });
+
+  it("REGRESSION: even with throttle set before the slow await, a timed-out turn writes nothing and resume is whole", async () => {
+    // 多 turn:turn 0 慢 summarize 被超时丢弃(无 boundary),turn 1 正常完成。验证超时的 turn 既不破坏
+    // store 顺序、也不阻断后续 turn 的正常 boundary;resume 完整。
+    const store = new MemorySessionStore();
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }] },
+      { content: [{ type: "text", text: "final" }] },
+    ]);
+    const fastSummary = createUserMessage("FAST");
+    const hook = persistCompactionBoundary({
+      shouldCompact: () => true,
+      summarize: async (flushed) => {
+        // turn 0 的前缀有 3 条(含 toolResult)→ 慢;turn 1 前缀 4 条 → 快。
+        if (flushed.length === 3) {
+          await sleep(80); // 被 30ms timeout 丢弃
+          return createUserMessage("SLOW");
+        }
+        return fastSummary;
+      },
+      timeout: 30,
+      minTurnsBetween: 1,
+    });
+    const session = new AgentSession({
+      model: fake,
+      tools: [noopTool],
+      store,
+      hooks: [hook],
+      hookFailureSink: () => {},
+    });
+    await session.run("go");
+    await sleep(120);
+
+    const path = await store.getPathToLeaf(session.id);
+    // 仅 turn 1 的 fast boundary 落盘(turn 0 超时被丢)。
+    const boundaries = path
+      .filter((e) => e.entry.kind === "compaction_boundary")
+      .map((e) => (e.entry as { kind: "compaction_boundary"; summary: Message }).summary);
+    expect(boundaries).toEqual([fastSummary]);
+    // 顺序单调,terminal 收尾。
+    const seqs = path.map((e) => e.seq);
+    expect(seqs).toEqual([...seqs].sort((a, c) => a - c));
+    expect(path[path.length - 1]!.entry.kind).toBe("terminal");
+
+    // resume:turn-1 的 fast boundary 覆盖全部前缀 → [summary]（turn 1 assistant 在 boundary 之前 flush）。
+    const fake2 = createFakeModel([{ content: [{ type: "text", text: "z" }] }]);
+    const resumed = await AgentSession.resume(store, session.id, {
+      model: fake2,
+      tools: [noopTool],
+    });
+    expect(resumed.messages[0]).toBe(fastSummary);
+    fake.teardown();
+    fake2.teardown();
+  });
+});

--- a/packages/plugins/src/__tests__/phase3.test.ts
+++ b/packages/plugins/src/__tests__/phase3.test.ts
@@ -4,7 +4,13 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { AgentSession, Type, type HarnessTool } from "@harness-pi/core";
+import {
+  AgentSession,
+  Type,
+  createUserMessage,
+  type HarnessTool,
+  type Message,
+} from "@harness-pi/core";
 import { createFakeModel } from "@harness-pi/core/testing";
 import { costTracker, getCostStats } from "../cost-tracker.js";
 import { forkSession, forkSessionAll } from "../controllers/fork-session.js";
@@ -145,6 +151,56 @@ describe("Phase 3: forkSession controller", () => {
     expect(parent.messages.length).toBe(parentBeforeFork);
     // 子拿到父历史 + 自己新增
     expect(result.messages.length).toBeGreaterThan(parentBeforeFork);
+    expect(result.summary.reason).toBe("done");
+    parentFake.teardown();
+    childFake.teardown();
+  });
+
+  it("fork 过滤父 snapshot 里悬挂的 tool_use（S1 真 bug）", async () => {
+    // 父 snapshot 停在 tool batch 中途：assistant 发了 toolCall 但还没 toolResult。
+    // 裸拷这段当子 initialMessages 喂 pi-ai 会 400；forkSession 必须先过滤掉。
+    const hangingAssistant = {
+      role: "assistant",
+      content: [{ type: "toolCall", id: "tc1", name: "read", arguments: {} }],
+      timestamp: 0,
+    } as unknown as Message;
+    const parentFake = createFakeModel([
+      { content: [{ type: "text", text: "unused" }] },
+    ]);
+    const parent = new AgentSession({
+      model: parentFake,
+      tools: [],
+      initialMessages: [createUserMessage("hi"), hangingAssistant],
+    });
+
+    let received: Message[] | undefined;
+    const childFake = createFakeModel([
+      { content: [{ type: "text", text: "child done" }] },
+    ]);
+    const result = await forkSession(
+      parent,
+      (init) => {
+        received = init;
+        return new AgentSession({
+          model: childFake,
+          tools: [],
+          initialMessages: init,
+        });
+      },
+      { prompt: "child prompt" },
+    );
+
+    // factory 收到的 init 不含任何悬挂 toolCall（fake model 不校验消息，故断言过滤本身）
+    const hasHangingToolCall = (received ?? []).some(
+      (m) =>
+        m.role === "assistant" &&
+        m.content.some(
+          (b: { type: string }) => b.type === "toolCall",
+        ),
+    );
+    expect(hasHangingToolCall).toBe(false);
+    // 但 user 历史保留
+    expect((received ?? []).some((m) => m.role === "user")).toBe(true);
     expect(result.summary.reason).toBe("done");
     parentFake.teardown();
     childFake.teardown();

--- a/packages/plugins/src/controllers/fork-session.ts
+++ b/packages/plugins/src/controllers/fork-session.ts
@@ -15,6 +15,7 @@
  * 借鉴 Claude Code `forkedAgent` + `CacheSafeParams`（[08-claude-code-lessons](docs/08-claude-code-lessons.md) §4.1）。
  */
 
+import { filterIncompleteToolCalls } from "@harness-pi/core";
 import type { AgentSession, Message, RunSummary } from "@harness-pi/core";
 
 export interface ForkOptions {
@@ -53,9 +54,11 @@ export async function forkSession(
   factory: (initialMessages: Message[]) => AgentSession,
   opts: ForkOptions = {},
 ): Promise<ForkResult> {
-  // 拷贝 snapshot —— 父 session 不会被 child 影响（initialMessages 是 [...父messages] copy）
+  // 拷贝 snapshot —— 父 session 不会被 child 影响（initialMessages 是 [...父messages] copy）。
+  // 过滤悬挂的 tool 调用：父若在 tool batch 中途被 fork，snapshot 会含「无 result 的 toolCall」，
+  // 直接当子 initialMessages 喂 pi-ai 会 400。filterIncompleteToolCalls 也始终返回 copy。
   const snapshot = parent.snapshot();
-  const child = factory(snapshot.messages);
+  const child = factory(filterIncompleteToolCalls(snapshot.messages));
 
   // M4：防 self-fork。factory 必须返回新的 AgentSession 实例，否则 child.run() 会
   // 直接 mutate 父，破坏 fork 语义。

--- a/packages/plugins/src/controllers/index.ts
+++ b/packages/plugins/src/controllers/index.ts
@@ -51,6 +51,9 @@ export type {
 export { subAgentTool } from "./sub-agent-tool.js";
 export type { SubAgentToolOptions } from "./sub-agent-tool.js";
 
+export { persistCompactionBoundary } from "./persist-compaction-boundary.js";
+export type { PersistCompactionBoundaryOptions } from "./persist-compaction-boundary.js";
+
 export { GapExplorer } from "./gap-explorer.js";
 export type {
   Gap,

--- a/packages/plugins/src/controllers/persist-compaction-boundary.ts
+++ b/packages/plugins/src/controllers/persist-compaction-boundary.ts
@@ -1,0 +1,107 @@
+/**
+ * persistCompactionBoundary —— C1 控制器（docs/09 §4.2「写 compaction 边界进 store」）。
+ *
+ * 挂内核 `onAfterFlush`（每 turn flush 到 store 之后 fire）：当 `shouldCompact` 为真且距上次 boundary
+ * 足够远时，把**已持久化前缀**总结成一条 summary 并**返回** `{ compactionBoundary: summary }`。**内核**
+ * 在 in-band、awaited、串行的路径上把它当作 store 末尾的一条 `compaction_boundary` 写盘。这是一个
+ * **durable resume 优化**。
+ *
+ * ── return-based，不持有写能力（务必看清）──
+ * 本控制器**只返回** summary，**不调用任何 store 写**。上一版给 hook 一个 detached
+ * `appendCompactionBoundary(summary)`，被 review 三轮抓出 data-loss / store-corruption：hook 超时时
+ * detached 的 append 仍在飞、乱序落在后续 turn / terminal 之后（resume 当成「丢弃之前一切」→ 静默删已
+ * 完成 turn），且与下一轮 flush 的 appendEntry 并发打同一 sessionId（违反串行契约）。改成「返回 → 内核
+ * 串行写」后：**summarize 超时（被 dispatcher 的 race 丢弃）只是返回被忽略，绝不产生 detached 写**。
+ *
+ * ── boundary 覆盖语义 ──
+ * onAfterFlush 在 flush 之后 fire，此刻**全部消息已落盘**，故 boundary 落在 store 末尾、覆盖**全部已
+ * 持久化前缀**（不保留 tail）。resume 重建 = `[summary, boundary 之后的新 turn]` —— 比 live session 的
+ * 全量 `_messages` 更激进的压缩，是**有意**的：live session 不受影响（继续用全量历史），只有从 store
+ * 重建时才省下重放。这与 view-only 压缩（compactSummarize / autoCompaction 改「模型 view」、保 tail）
+ * 是不同层、正交：那些省 token，这里省 resume 重放。内核 in-band 串行写保证 boundary 永远在「它之后的
+ * 消息 flush」之前落盘，且绝无两个 appendEntry 并发同 session。
+ *
+ * ── HWM 不变量 ──
+ * 内核写 boundary 只往 store 加一条 entry，**不动** `_persistedCount` / `_messages`。所以本控制器不破坏
+ * 「逐条推进的高水位」——live session 的全量历史与续跑行为完全不变。
+ *
+ * `summarize` 由调用方提供（可调 LLM）——domain-free，控制器/内核都不内置 LLM 调用。
+ */
+
+import type { Hook, HookContext, OnAfterFlushInput } from "@harness-pi/core";
+import type { Message } from "@earendil-works/pi-ai";
+
+declare module "@harness-pi/core" {
+  interface HookStateRegistry {
+    "persist-compaction-boundary.lastTurnIdx": number;
+  }
+}
+
+const KEY = "persist-compaction-boundary.lastTurnIdx" as const;
+
+export interface PersistCompactionBoundaryOptions {
+  /**
+   * 判断此刻是否该落 boundary（如 estimate(messages) > 阈值）。返回 false 则跳过。
+   * `messages` 是已持久化前缀（= live history 的前 `persistedCount` 条）。
+   */
+  shouldCompact: (input: {
+    persistedCount: number;
+    messages: Message[];
+  }) => boolean;
+  /**
+   * 把「已持久化前缀」总结成一条 summary message —— summary 覆盖**全部已持久化消息**（见覆盖语义）。
+   * 可 async（调 LLM）。
+   */
+  summarize: (flushedMessages: Message[]) => Promise<Message> | Message;
+  /**
+   * 两次 boundary 之间至少间隔多少次 flush/turn，避免每 turn 都落。默认 1（相邻 turn 不重复落）。
+   */
+  minTurnsBetween?: number;
+  /**
+   * 本 hook 的超时(ms)。**默认放宽到 60_000**——`summarize` 可调 LLM(秒级),而 `onAfterFlush` 走 event
+   * 类、dispatcher 默认超时仅 100ms,不放宽真 LLM summarize 会**必定超时 → 该 hook 返回被丢弃 → 零
+   * boundary 落盘**(但不会数据损坏——内核拿不到返回就不写)。按你的 summarize 后端调整。
+   */
+  timeout?: number;
+}
+
+export function persistCompactionBoundary(
+  opts: PersistCompactionBoundaryOptions,
+): Hook {
+  const minTurnsBetween = opts.minTurnsBetween ?? 1;
+  if (minTurnsBetween < 1) {
+    throw new Error(
+      "persistCompactionBoundary: minTurnsBetween must be >= 1",
+    );
+  }
+
+  return {
+    name: "persist-compaction-boundary",
+    // 见 timeout 选项注释：onAfterFlush 走 event 类(默认 100ms),LLM summarize 必须放宽超时,否则零 boundary。
+    timeout: opts.timeout ?? 60_000,
+
+    async onAfterFlush(input: OnAfterFlushInput, ctx: HookContext) {
+      // 已持久化前缀 = live history 的前 persistedCount 条（boundary 覆盖这整段）。
+      const flushed = ctx.messages.slice(0, input.persistedCount);
+
+      if (!opts.shouldCompact({ persistedCount: input.persistedCount, messages: flushed })) {
+        return;
+      }
+
+      // minTurnsBetween：距上次落 boundary 不够远就跳过。首次（无记录）总是允许。
+      const last = ctx.state.get(KEY);
+      if (last !== undefined && input.turnIdx - last < minTurnsBetween) {
+        return;
+      }
+
+      // **先提交节流高水位,再做慢活。** summarize 可能秒级、甚至被 hook 超时中断(此时返回被 dispatcher
+      // 的 race 丢弃、内核不写)。若把 set 放在 await 之后,超时让 await reject → set 不执行 → 节流高水位
+      // 不前进 → 下一 turn 又触发 summarize,minTurnsBetween 形同虚设、反复调 LLM。先 set:即使本轮
+      // summarize 失败/超时,后续 turn 仍正确节流。boundary 是 best-effort 优化,跳过一次无碍。
+      ctx.state.set(KEY, input.turnIdx);
+      const summary = await opts.summarize(flushed);
+      // 只返回 summary —— 由内核 in-band、awaited、串行写进 store。控制器不持有任何写能力。
+      return { compactionBoundary: summary };
+    },
+  };
+}

--- a/packages/plugins/src/controllers/sub-agent-tool.ts
+++ b/packages/plugins/src/controllers/sub-agent-tool.ts
@@ -9,8 +9,21 @@
  * `sessionFactory` 里。父 session 的 abort signal 透传给 sub-agent（协作式取消）。
  */
 
-import type { AgentSession, HarnessTool, HookContext, Message } from "@harness-pi/core";
+import type { AgentSession, Hook, HarnessTool, HookContext, Message } from "@harness-pi/core";
 import { Type } from "@earendil-works/pi-ai";
+
+/**
+ * 跨层递归深度透传 key（#45）。父 session execute 时读它（缺省 0）；spawn 子 session 时把
+ * 子 ctx.state 的同 key 设为 当前+1，故子若也挂 subAgentTool 读到的已是递增后的深度。
+ * 注册进 HookStateRegistry → `ctx.state.get/set` 自动推断成 number，无需 cast。
+ */
+const DEPTH_KEY = "subAgent.depth";
+
+declare module "@harness-pi/core" {
+  interface HookStateRegistry {
+    "subAgent.depth": number;
+  }
+}
 
 export interface SubAgentToolOptions {
   /** tool name（默认 "subAgent"）。 */
@@ -19,8 +32,14 @@ export interface SubAgentToolOptions {
   description?: string;
   /** 造一个 sub-agent AgentSession 的工厂（拿到子任务 + 父 ctx）。bounded 由这里造的 session 自限轮数。 */
   sessionFactory: (task: string, ctx: HookContext) => AgentSession;
-  /** 本 tool 实例最多派多少个 sub-agent（防失控递归/扇出）。默认 8。 */
+  /** 本 tool 实例最多派多少个 sub-agent（**横向**闸：防单层失控扇出）。默认 8。 */
   maxSubAgents?: number;
+  /**
+   * 跨层递归**纵向**深度闸（#45）：从顶层 session（depth 0）算起，最多嵌套到多少层 subAgent。
+   * 默认 2 —— 主 session(0) → 子(1) → 孙(2) 这层 spawn 即被挡（孙再 spawn 才报错）。与 `maxSubAgents`
+   * 正交：一纵一横，互不干扰。
+   */
+  maxDepth?: number;
 }
 
 /** 取一条 message 的纯文本（content 可能是 string 或 block 数组）。 */
@@ -35,6 +54,7 @@ function messageText(m: Message | undefined): string {
 
 export function subAgentTool(opts: SubAgentToolOptions): HarnessTool {
   const max = opts.maxSubAgents ?? 8;
+  const maxDepth = opts.maxDepth ?? 2;
   let spawned = 0;
 
   return {
@@ -50,10 +70,17 @@ export function subAgentTool(opts: SubAgentToolOptions): HarnessTool {
 
     async execute(args, ctx, signal) {
       const task = typeof args.task === "string" ? args.task : "";
-      // throw 是 HarnessTool 的错误合约（kernel 包成 isError 回灌模型）——空任务 / 超预算都 fail-loud。
+      // throw 是 HarnessTool 的错误合约（kernel 包成 isError 回灌模型）——空任务 / 超预算 / 超深都 fail-loud。
       if (task.trim().length === 0) {
         throw new Error("subAgent: empty task");
       }
+      // 纵向闸（#45）：读**当前** session 深度（缺省 0）。到顶就不 spawn——挡在横向计数之前，
+      // 让超深的尝试不消耗本层 maxSubAgents 预算（二闸正交）。
+      const depth = ctx.state.get(DEPTH_KEY) ?? 0;
+      if (depth >= maxDepth) {
+        throw new Error(`subAgent: depth limit (maxDepth=${maxDepth}) reached`);
+      }
+      // 横向闸：本 tool 实例的扇出预算。
       if (spawned >= max) {
         throw new Error(`subAgent: budget exhausted (max ${max} sub-agents per tool)`);
       }
@@ -61,6 +88,17 @@ export function subAgentTool(opts: SubAgentToolOptions): HarnessTool {
 
       // 父 signal 透传 → sub-agent 可被父的 abort 协作式取消。
       const sub = opts.sessionFactory(task, ctx);
+      // 纵向深度透传：给子 session 挂一个 onSessionStart hook，把子 ctx.state 的深度设为 当前+1。
+      // 子 session 自己的 subAgentTool（若有）execute 时就读到递增后的深度——多分支各自从父继承，
+      // 互不串扰（每个子 session 有独立 ctx.state）。零内核改动：只用现成的 use()/onSessionStart。
+      const depthInjector: Hook = {
+        name: "subAgent.depth-injector",
+        internal: true,
+        onSessionStart(_input, subCtx) {
+          subCtx.state.set(DEPTH_KEY, depth + 1);
+        },
+      };
+      sub.use(depthInjector);
       const summary = await sub.run(task, { signal });
       const text = messageText(summary.lastMessage) || "(sub-agent produced no text output)";
 

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -47,6 +47,9 @@ export type { CompactSummarizeOptions } from "./compact-summarize.js";
 export { autoCompaction, estimateTokensByChars } from "./auto-compaction.js";
 export type { AutoCompactionOptions } from "./auto-compaction.js";
 
+export { microcompact } from "./microcompact.js";
+export type { MicrocompactOptions } from "./microcompact.js";
+
 export { permissionGate } from "./permission-gate.js";
 export type {
   PermissionGateOptions,

--- a/packages/plugins/src/microcompact.ts
+++ b/packages/plugins/src/microcompact.ts
@@ -16,8 +16,6 @@
  *
  * **view-only（与 autoCompaction / trimHistory 同款）**：`transformMessagesBeforeLlm` 只改本次返回的 messages
  * 数组（copy-on-write），完整原始历史天然留在 store 里；不动 user 消息、assistant 推理、非白名单工具的 toolResult。
- *
- * 详见 docs/05-plugins.md。
  */
 
 import type { Hook } from "@harness-pi/core";

--- a/packages/plugins/src/microcompact.ts
+++ b/packages/plugins/src/microcompact.ts
@@ -1,0 +1,147 @@
+/**
+ * microcompact —— tool-result 级的廉价分档清理（issue #46，roadmap C2）。
+ *
+ * 借鉴 claude-code 的 microcompact：作为「full summarize」之前**便宜**的一手。它**不**调 LLM、**不**总结，
+ * 只把「旧的、可重取的」白名单工具输出换成短占位符（原文仍由内核 durable 保存，模型若真需要可重新调用工具）。
+ * 永远保留**最近 N 条** toolResult 原文不动——cache 友好、不破坏模型对近况的感知。
+ *
+ * 与 `trimHistory` 的关系：本插件是它的「按 token 体积 + 按工具白名单」升级版。trimHistory 按**条数**无条件
+ * 裁剪所有 toolResult；microcompact 只在**体积超阈值**（或 cache 已冷）时动手、只清**白名单工具**、清到**目标
+ * 体积**为止即停。两者都 view-only（只改本 turn 发给 LLM 的 view，绝不写 `session.messages`）。
+ *
+ * **⚠️ Hook 顺序：本插件必须排在 `autoCompaction` 之前。** 与「压缩型 hook 排在裁剪型 hook 之前」准则一致——
+ * microcompact 是廉价的「先清可重取的旧 tool 输出」，autoCompaction 是昂贵的「总结剩下的早期对话」。先让
+ * microcompact 把白名单工具的体积降下来，autoCompaction 再据**裁剪后**的真实 view 决定是否还需要总结。反过来
+ * 排（autoCompaction 在前）会让昂贵总结多跑、甚至把本可廉价清掉的 tool 输出也卷进 summary。
+ *
+ * **view-only（与 autoCompaction / trimHistory 同款）**：`transformMessagesBeforeLlm` 只改本次返回的 messages
+ * 数组（copy-on-write），完整原始历史天然留在 store 里；不动 user 消息、assistant 推理、非白名单工具的 toolResult。
+ *
+ * 详见 docs/05-plugins.md。
+ */
+
+import type { Hook } from "@harness-pi/core";
+import type { Message } from "@earendil-works/pi-ai";
+import { estimateTokensByChars } from "./auto-compaction.js";
+
+export interface MicrocompactOptions {
+  /** 只清这些工具产生的 toolResult。**不 hardcode 工具名**——由调用方传（domain-free）。string[] 会归一成 Set。 */
+  compactableTools: Set<string> | string[];
+  /** 估算 tokens 超过它才触发清理。须 > 0。 */
+  triggerTokens: number;
+  /**
+   * 清理目标：从最旧开始清白名单 toolResult，清到估算体积 ≤ targetTokens 即停（不必全清）。
+   * 默认 = triggerTokens（即「降回阈值以下」）。须 > 0 且 ≤ triggerTokens。
+   */
+  targetTokens?: number;
+  /** 永远保留原样的最近 N 条 toolResult（不分工具）。默认 5。负数视为 0；非整数向下取整。 */
+  keepRecent?: number;
+  /**
+   * 可选：距上次活动超过这么多分钟（cache 已冷），即使体积没超阈值也触发清理。
+   * 用最后一条消息的 timestamp 与 `now()` 比较。须 > 0。不传则只按体积触发。
+   */
+  gapMinutes?: number;
+  /** 当前时刻（ms）。默认 `Date.now`；测试可注入以走 `gapMinutes` 路径。 */
+  now?: () => number;
+  /** token 估算器。默认 {@link estimateTokensByChars}（与 autoCompaction 同款、保守高估）。 */
+  estimateTokens?: (messages: Message[]) => number;
+  /** 占位符文案（默认带工具名 + 原内容字符数提示）。 */
+  placeholderText?: (toolName: string, originalChars: number) => string;
+}
+
+type ToolResult = Extract<Message, { role: "toolResult" }>;
+
+/** toolResult 的 content 文本总字符数（占位符里给模型一个「原来多大」的提示）。 */
+function contentChars(content: ToolResult["content"]): number {
+  let n = 0;
+  for (const b of content) {
+    if (b.type === "text") n += b.text.length;
+    else if (b.type === "image") n += 1; // 图片不按 base64 长度计，象征性记 1（避免占位符里报天文数字）
+  }
+  return n;
+}
+
+/**
+ * 构造一个 microcompact hook。
+ *
+ * 触发判据（满足任一即动手）：
+ *   1. **体积**：`estimateTokens(messages) > triggerTokens` → 从最旧白名单 toolResult 起清，降到 `targetTokens` 以下即停。
+ *   2. **gap**（可选）：`now() - 最后一条消息的 timestamp > gapMinutes` 分钟（cache 已冷）→ 把**所有**可清的白名单
+ *      toolResult 清掉（cache 反正要冷启重发，激进清以缩短下次冷启动 prompt，不受 targetTokens 早停约束）。
+ *
+ * 两种动作都永远跳过**最近 keepRecent 条** toolResult 与所有非白名单工具的 toolResult。
+ */
+export function microcompact(opts: MicrocompactOptions): Hook {
+  const compactable =
+    opts.compactableTools instanceof Set
+      ? opts.compactableTools
+      : new Set(opts.compactableTools);
+  if (!(opts.triggerTokens > 0)) {
+    throw new Error("microcompact: triggerTokens must be > 0");
+  }
+  const targetTokens = opts.targetTokens ?? opts.triggerTokens;
+  if (!(targetTokens > 0 && targetTokens <= opts.triggerTokens)) {
+    throw new Error("microcompact: targetTokens must be in (0, triggerTokens]");
+  }
+  const keepRecent = Math.max(0, Math.floor(opts.keepRecent ?? 5));
+  if (opts.gapMinutes !== undefined && !(opts.gapMinutes > 0)) {
+    throw new Error("microcompact: gapMinutes must be > 0");
+  }
+  const now = opts.now ?? Date.now;
+  const estimate = opts.estimateTokens ?? estimateTokensByChars;
+  const placeholderText =
+    opts.placeholderText ??
+    ((tool, chars) => `[microcompact: ${tool} output cleared, ~${chars} chars]`);
+
+  return {
+    name: "microcompact",
+    timeout: 50,
+
+    transformMessagesBeforeLlm(messages, _ctx) {
+      // gap 判据：最后一条消息的 timestamp 距 now 超过 gapMinutes（cache 已冷）。
+      let coldCache = false;
+      if (opts.gapMinutes !== undefined && messages.length > 0) {
+        const last = messages[messages.length - 1]!;
+        const gapMs = now() - last.timestamp;
+        coldCache = gapMs > opts.gapMinutes * 60_000;
+      }
+
+      // 体积没超阈值、且 cache 不冷 → 原样返回。
+      if (estimate(messages) <= opts.triggerTokens && !coldCache) return undefined;
+
+      // 找出**可清**的白名单 toolResult 下标（排除最近 keepRecent 条 toolResult）。
+      const toolResultIdxs: number[] = [];
+      for (let i = 0; i < messages.length; i++) {
+        if (messages[i]?.role === "toolResult") toolResultIdxs.push(i);
+      }
+      const clearableLimit = toolResultIdxs.length - keepRecent; // 这之前的 toolResult 才允许清
+      const clearable: number[] = [];
+      for (let rank = 0; rank < clearableLimit; rank++) {
+        const idx = toolResultIdxs[rank]!;
+        const msg = messages[idx]!;
+        if (msg.role === "toolResult" && compactable.has(msg.toolName)) {
+          clearable.push(idx);
+        }
+      }
+      if (clearable.length === 0) return undefined; // 没有可清的（全在 keepRecent 内 / 全非白名单）
+
+      // 体积触发：从最旧开始清，清到 ≤ targetTokens 即停（不必全清）。
+      // gap 触发（coldCache）：不设早停，把所有可清的都清掉（cache 反正冷了）。
+      const out = messages.slice(); // copy-on-write，绝不改原数组 / session.messages
+      let cleared = 0;
+      for (const idx of clearable) {
+        if (!coldCache && estimate(out) <= targetTokens) break; // 体积已降到目标（gap 路径不早停）
+        const msg = out[idx]! as ToolResult;
+        const chars = contentChars(msg.content);
+        out[idx] = {
+          ...msg,
+          content: [{ type: "text" as const, text: placeholderText(msg.toolName, chars) }],
+        };
+        cleared++;
+      }
+
+      if (cleared === 0) return undefined; // 体积本就 ≤ target 且非 coldCache → 无需清
+      return out;
+    },
+  };
+}

--- a/packages/plugins/src/microcompact.ts
+++ b/packages/plugins/src/microcompact.ts
@@ -125,20 +125,28 @@ export function microcompact(opts: MicrocompactOptions): Hook {
 
       // 体积触发：从最旧开始清，清到 ≤ targetTokens 即停（不必全清）。
       // gap 触发（coldCache）：不设早停，把所有可清的都清掉（cache 反正冷了）。
+      //
+      // **增量 running total，不每轮全量重估。** estimateTokensByChars 是逐消息/逐块累加，故替换一条时
+      // `estimate([原]) - estimate([占位])` 正是整体估值的精确变化量——结果与全量重估完全一致，但复杂度从
+      // O(N·K) 降到 O(N+K)。这点很关键：本 transform 是**同步**的，`timeout:50` 拦不住同步循环（计时器在
+      // 同步阻塞期间根本没机会 fire），而本插件正是为大文件读取场景设计、harness 又是多 session 跑在单
+      // event loop（WorkPool/LeaseQueue）——全量重估的 O(N·K) 会让一个 session 的压缩同步冻住其余所有 session。
       const out = messages.slice(); // copy-on-write，绝不改原数组 / session.messages
-      let cleared = 0;
+      let total = estimate(out); // 开头估一次
       for (const idx of clearable) {
-        if (!coldCache && estimate(out) <= targetTokens) break; // 体积已降到目标（gap 路径不早停）
+        if (!coldCache && total <= targetTokens) break; // O(1) 比较；降到目标即停（gap 路径不早停）
         const msg = out[idx]! as ToolResult;
         const chars = contentChars(msg.content);
-        out[idx] = {
+        const placeholder: ToolResult = {
           ...msg,
           content: [{ type: "text" as const, text: placeholderText(msg.toolName, chars) }],
         };
-        cleared++;
+        total -= estimate([msg]) - estimate([placeholder]); // 精确减去本条清理带来的体积下降
+        out[idx] = placeholder;
       }
 
-      if (cleared === 0) return undefined; // 体积本就 ≤ target 且非 coldCache → 无需清
+      // 走到这里必然清了 ≥1 条：volume 路径的入口判据已保证 total > triggerTokens ≥ targetTokens（首轮不早停）；
+      // cold 路径不早停、且 clearable 非空。故无需 cleared===0 的死分支。
       return out;
     },
   };

--- a/packages/plugins/src/microcompact.ts
+++ b/packages/plugins/src/microcompact.ts
@@ -9,10 +9,13 @@
  * 裁剪所有 toolResult；microcompact 只在**体积超阈值**（或 cache 已冷）时动手、只清**白名单工具**、清到**目标
  * 体积**为止即停。两者都 view-only（只改本 turn 发给 LLM 的 view，绝不写 `session.messages`）。
  *
- * **⚠️ Hook 顺序：本插件必须排在 `autoCompaction` 之前。** 与「压缩型 hook 排在裁剪型 hook 之前」准则一致——
- * microcompact 是廉价的「先清可重取的旧 tool 输出」，autoCompaction 是昂贵的「总结剩下的早期对话」。先让
- * microcompact 把白名单工具的体积降下来，autoCompaction 再据**裁剪后**的真实 view 决定是否还需要总结。反过来
- * 排（autoCompaction 在前）会让昂贵总结多跑、甚至把本可廉价清掉的 tool 输出也卷进 summary。
+ * **⚠️ Hook 顺序：microcompact 应排在 `autoCompaction` 之前。** （**别**套用 `auto-compaction.ts` 里
+ * 「autoCompaction 排在 `trimHistory` 等**裁剪型** transform 之前」那条规则来反推顺序——microcompact 不是那种
+ * 无条件机械裁剪:它既不总结、也不按条数硬裁,而是**有条件地清掉可重取的白名单工具输出**,是比「总结」更廉价
+ * 的一手,所以比 autoCompaction 还靠前。）理由:先让 microcompact 把白名单工具体积降下来,autoCompaction 再据
+ * **清理后**的真实 view 决定是否还要花钱总结(体积已够低时直接 no-op)。反过来排会让昂贵总结多跑、甚至把本可
+ * 廉价清掉的 tool 输出也卷进 summary。与 `trimHistory` 的取舍见下(microcompact 是其「按 token 体积 + 白名单 +
+ * keepRecent」的升级版,一般二选一,不必同时挂)。
  *
  * **view-only（与 autoCompaction / trimHistory 同款）**：`transformMessagesBeforeLlm` 只改本次返回的 messages
  * 数组（copy-on-write），完整原始历史天然留在 store 里；不动 user 消息、assistant 推理、非白名单工具的 toolResult。

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-pi/tools",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "First-party coding tools for harness-pi agents",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
把 `dev` 发布到 `main`(v0.2.2)。内容 = 0.3.0 Wave A 的四个切片,均各自 + **整体**过 review-gate(3/3,零 blocking)。

## 内容
- **fix(plugins): forkSession 过滤悬挂 tool_use(#48 / S1)** — 父 tool batch 中途 fork 不再带 orphan tool_use 喂炸 pi-ai;core 新增导出 `filterIncompleteToolCalls`。
- **feat(plugins): subAgentTool 跨层递归深度闸(#45 / S2)** — `maxDepth` 防 8^N 失控,ctx.state 透传 depth,与横向 `maxSubAgents` 正交。
- **feat(plugins): microcompact(#46 / C2)** — tool-result 级廉价分档清理(token 体积/cold-cache 触发、白名单、keepRecent、view-only、O(N+K) 增量估算)。
- **feat(core): compaction_boundary 写入 — return-based onAfterFlush seam(#47 / C1)** — 补 durable resume 裁前缀的写入方;hook 返回 summary、内核 in-band 串行写(根治原 detached 设计的 data-loss/store-corruption)。
- docs(09): §4.2 同步 as-built。
- chore(release): 5 包 bump 0.2.1 → 0.2.2。

## 验证
全仓 build → typecheck → test 全绿(core 278 / plugins 264 / adapters 61+18skip / tools 51 / coding-agent 240 / examples)。整体 Wave A diff review-gate **3/3 PASS**(linus:「C1 重做从数据流上根除 data-loss/乱序,品味到位,无阻断」)。

## 发布后(owner 手动)
`pnpm -r publish`(发布集 5 包,lark-bot `private` 排除)+ 打 tag v0.2.2。

🤖 Generated with [Claude Code](https://claude.com/claude-code)