### PR TITLE
feat(plugins): X1 — request-level token 估算(计入 tools/system,D0 校准)(#43 X1)

### DIFF
--- a/packages/core/src/__tests__/phase1-foundation.test.ts
+++ b/packages/core/src/__tests__/phase1-foundation.test.ts
@@ -208,6 +208,7 @@ describe("Phase 1: ctx.config", () => {
       model: fake,
       tools: [echo],
       hooks: [probe],
+      systemPrompt: "You are a test agent.",
       maxTurns: 12,
       maxContinuations: 3,
     });
@@ -219,6 +220,56 @@ describe("Phase 1: ctx.config", () => {
     expect(captured!.maxContinuations).toBe(3);
     expect(Array.from(captured!.toolNames)).toEqual(["echo"]);
     expect(captured!.model.id).toMatch(/^fake-model-/);
+    // X1(#55):真 session 把完整 tool schema + systemPrompt 灌进 ctx.config —— 这是请求级估算修 7x 低估的本体。
+    expect(captured!.tools).toHaveLength(1);
+    expect(captured!.tools[0]!.name).toBe("echo");
+    expect(captured!.tools[0]!.description).toBe("echo");
+    expect(captured!.tools[0]!.parameters).toBe(echo.parameters); // schema 原样透传(引用)
+    expect(captured!.systemPrompt).toBe("You are a test agent.");
+    fake.teardown();
+  });
+
+  it("config.systemPrompt 默认空串(未配置时)— 估算不应误把 undefined 当内容", async () => {
+    let captured: HookContext["config"] | null = null;
+    const probe: Hook = {
+      name: "probe",
+      onSessionStart(_input, ctx) {
+        captured = ctx.config;
+      },
+    };
+    const fake = createFakeModel([{ content: [{ type: "text", text: "done" }] }]);
+    const session = new AgentSession({ model: fake, tools: [], hooks: [probe] });
+    await session.run("go");
+    expect(captured!.systemPrompt).toBe("");
+    expect(captured!.tools).toEqual([]);
+    fake.teardown();
+  });
+
+  it("config.tools 逐元素冻结 — plugin 不能增删元素或改 tool 字段", async () => {
+    const echo: HarnessTool = {
+      name: "echo",
+      description: "echo",
+      parameters: Type.Object({}),
+      async execute() {
+        return { content: [{ type: "text", text: "hi" }] };
+      },
+    };
+    const probe: Hook = {
+      name: "probe",
+      onSessionStart(_input, ctx) {
+        // 数组冻结:不能 push
+        expect(() => {
+          (ctx.config.tools as unknown as unknown[]).push({});
+        }).toThrow();
+        // 元素冻结:不能改 name/description
+        expect(() => {
+          (ctx.config.tools[0] as unknown as { name: string }).name = "hack";
+        }).toThrow();
+      },
+    };
+    const fake = createFakeModel([{ content: [{ type: "text", text: "done" }] }]);
+    const session = new AgentSession({ model: fake, tools: [echo], hooks: [probe] });
+    await session.run("go");
     fake.teardown();
   });
 

--- a/packages/core/src/hook.ts
+++ b/packages/core/src/hook.ts
@@ -13,6 +13,7 @@
 import type {
   AssistantMessage,
   Message,
+  Tool,
   ToolCall,
 } from "@earendil-works/pi-ai";
 import type { HarnessTool } from "./types.js";
@@ -314,6 +315,16 @@ export interface SessionConfigView {
   readonly sessionId: string;
   readonly model: { id: string; provider: string };
   readonly toolNames: ReadonlyArray<string>;
+  /**
+   * 发给 LLM 的 tool schema（pi-ai `Tool` 形态 `{name, description, parameters}`，与每次请求随发的
+   * 完全一致）。token 估算插件（X1）需要它来把「每请求随发的 tool schema 体积」计进 context 估算——
+   * 只数 `toolNames` 会**严重低估**真实 usage（D0 实测低估 ~7x）。只读、构造期冻结。
+   */
+  readonly tools: ReadonlyArray<Tool>;
+  /**
+   * 当前 system prompt（与每次请求随发的一致；无则空串）。同样是 token 估算需计入的固定开销。只读。
+   */
+  readonly systemPrompt: string;
   readonly maxTurns: number;
   readonly maxContinuations: number;
 }

--- a/packages/core/src/hook.ts
+++ b/packages/core/src/hook.ts
@@ -317,12 +317,15 @@ export interface SessionConfigView {
   readonly toolNames: ReadonlyArray<string>;
   /**
    * 发给 LLM 的 tool schema（pi-ai `Tool` 形态 `{name, description, parameters}`，与每次请求随发的
-   * 完全一致）。token 估算插件（X1）需要它来把「每请求随发的 tool schema 体积」计进 context 估算——
-   * 只数 `toolNames` 会**严重低估**真实 usage（D0 实测低估 ~7x）。只读、构造期冻结。
+   * piTools 同形且内容一致——tools 不经 pipe 改写）。token 估算插件（X1）需要它把「每请求随发的 tool
+   * schema 体积」计进 context 估算——只数 `toolNames` 会**严重低估**真实 usage（D0 实测低估 ~7x）。
+   * 只读:数组与每个元素冻结;但 `parameters` 是 schema 对象引用、未深冻（估算只读不写）。
    */
   readonly tools: ReadonlyArray<Tool>;
   /**
-   * 当前 system prompt（与每次请求随发的一致；无则空串）。同样是 token 估算需计入的固定开销。只读。
+   * **base** system prompt（构造期传入的原值；无则空串）。token 估算据此计入「每请求随发的 system 开销」。
+   * 注意:若挂了 `transformSystemPromptBeforeLlm` pipe hook 改写 system prompt,实际随发的是 **pipe 后**的值,
+   * 本视图给的是 **pre-pipe base**——估算可能略低估被 hook 注入的增量（目前无 first-party hook 这么做）。只读。
    */
   readonly systemPrompt: string;
   readonly maxTurns: number;

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -327,6 +327,17 @@ export class AgentSession {
       sessionId: this.id,
       model: Object.freeze({ id: this.model.id, provider: this.model.provider }),
       toolNames: Object.freeze(this.tools.map((t) => t.name)),
+      // 只暴露 pi-ai Tool 三字段（与每请求随发的 piTools 同形），冻结每个元素防 plugin 改 schema。
+      tools: Object.freeze(
+        this.tools.map((t) =>
+          Object.freeze({
+            name: t.name,
+            description: t.description,
+            parameters: t.parameters,
+          }),
+        ),
+      ),
+      systemPrompt: this.systemPrompt,
       maxTurns: this.maxTurns,
       maxContinuations: this.maxContinuations,
     });

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -322,7 +322,9 @@ export class AgentSession {
 
     this._abortCtrl = new AbortController();
     // tools 是构造期固定（`use()` 只允许在 idle 加 hooks，不改 tools / model / maxTurns）。
-    // 整个 configView 包括 nested model 对象都 deep-freeze，runtime 拒绝任何 plugin 修改。
+    // Object.freeze 是**浅冻**：configView 顶层 + model + toolNames 数组 + tools 数组及其每个元素都冻结，
+    // plugin 不能替换字段/增删元素;但 tool.parameters 是 TypeBox schema 对象的**引用**(未深冻)——估算只读
+    // 不写,与 model 的扁平冻结粒度一致,不构成新风险面。
     const configView: SessionConfigView = Object.freeze({
       sessionId: this.id,
       model: Object.freeze({ id: this.model.id, provider: this.model.provider }),

--- a/packages/core/src/testing.ts
+++ b/packages/core/src/testing.ts
@@ -341,6 +341,8 @@ export function createTestContext(opts: TestContextOptions = {}): TestContextHan
     sessionId: opts.sessionId ?? "test-session",
     model: Object.freeze({ id: "test-model", provider: "test" }),
     toolNames: Object.freeze([]),
+    tools: Object.freeze([]),
+    systemPrompt: "",
     maxTurns: 200,
     maxContinuations: 5,
     ...(opts.config ?? {}),

--- a/packages/plugins/src/__tests__/auto-compaction.test.ts
+++ b/packages/plugins/src/__tests__/auto-compaction.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect } from "vitest";
 import { AgentSession, createUserMessage } from "@harness-pi/core";
 import { createTestContext, createFakeModel } from "@harness-pi/core/testing";
-import type { Message } from "@earendil-works/pi-ai";
-import { autoCompaction, estimateTokensByChars } from "../auto-compaction.js";
+import type { Message, Tool } from "@earendil-works/pi-ai";
+import {
+  autoCompaction,
+  estimateTokensByChars,
+  estimateRequestTokens,
+} from "../auto-compaction.js";
 
 function textOf(m: Message): string {
   return typeof m.content === "string"
@@ -19,7 +23,7 @@ describe("autoCompaction", () => {
       maxContextTokens: 100,
       triggerRatio: 0.5, // threshold = 50
       keepRecent: 2,
-      estimateTokens: (msgs) => msgs.length * 20, // 5 msgs => 100 > 50
+      tokenCounter: { estimate: ({ messages }) => messages.length * 20 }, // 5 msgs => 100 > 50
       summarize: (e) => {
         early = e;
         return `SUM:${e.length}`;
@@ -41,7 +45,7 @@ describe("autoCompaction", () => {
       maxContextTokens: 100,
       triggerRatio: 0.5, // threshold 50
       keepRecent: 2,
-      estimateTokens: () => 10, // < 50
+      tokenCounter: { estimate: () => 10 }, // < 50
       summarize: () => {
         calls++;
         return "S";
@@ -164,7 +168,7 @@ describe("autoCompaction", () => {
       maxContextTokens: 1,
       triggerRatio: 1,
       keepRecent: 3,
-      estimateTokens: () => 999, // over threshold → would compact if it could
+      tokenCounter: { estimate: () => 999 }, // over threshold → would compact if it could
       summarize: () => {
         calls++;
         return "S";
@@ -183,7 +187,7 @@ describe("autoCompaction", () => {
       triggerRatio: 1,
       keepRecent: 2,
       resummarizeEvery: 2,
-      estimateTokens: () => 999, // always over threshold -> always evaluate
+      tokenCounter: { estimate: () => 999 }, // always over threshold -> always evaluate
       summarize: (e) => {
         calls++;
         return `S${e.length}`;
@@ -236,7 +240,7 @@ describe("autoCompaction", () => {
           maxContextTokens: 100,
           triggerRatio: 0.8, // threshold 80
           keepRecent: 2,
-          estimateTokens: (msgs) => msgs.length * 50, // 7 msgs * 50 = 350 > 80
+          tokenCounter: { estimate: ({ messages }) => messages.length * 50 }, // 7 msgs * 50 = 350 > 80
           summarize: () => "RECAP",
         }),
       ],
@@ -266,7 +270,7 @@ describe("autoCompaction", () => {
           maxContextTokens: 100,
           triggerRatio: 0.8, // threshold 80
           keepRecent: 2,
-          estimateTokens: (msgs) => msgs.length * 50, // 7 msgs * 50 = 350 > 80 → 会尝试压缩
+          tokenCounter: { estimate: ({ messages }) => messages.length * 50 }, // 7 msgs * 50 = 350 > 80 → 会尝试压缩
           summarize: () => {
             throw new Error("summary backend down");
           },
@@ -282,5 +286,81 @@ describe("autoCompaction", () => {
     // 完整历史未被破坏：6 初始 + "go" + assistant = 8。
     expect(session.messages.length).toBe(8);
     fake.teardown();
+  });
+
+  it("X1: triggers earlier when tools are big (messages small but tool schema large)", async () => {
+    // 仅 2 条小消息：messages-only 估算远低于阈值、绝不触发；但带上大 tool schema 的请求级估算越过阈值 → 触发。
+    // 这正是 D0 53-vs-381 低估 7x 的修复方向：tool schema 每请求随发，必须计入。
+    const messages = [m("hi"), m("ok"), m("more"), m("again")]; // 小
+    const bigTool: Tool = {
+      name: "submit_evidence",
+      description: "Submit structured evidence. ".repeat(40),
+      parameters: {
+        type: "object",
+        properties: {
+          questionId: { type: "string", description: "the question id ".repeat(20) },
+          evidence: { type: "string", description: "the evidence body ".repeat(20) },
+        },
+        required: ["questionId", "evidence"],
+      },
+    } as Tool;
+
+    // 阈值卡在「messages-only 之上、含 tools 之下」之间。
+    const messagesOnly = estimateTokensByChars(messages);
+    const withTools = estimateRequestTokens({ messages, tools: [bigTool] });
+    expect(withTools).toBeGreaterThan(messagesOnly); // sanity：tools 确实抬高了估值
+    const threshold = (messagesOnly + withTools) / 2;
+
+    let summarized = false;
+    const compact = autoCompaction({
+      maxContextTokens: threshold,
+      triggerRatio: 1, // threshold = maxContextTokens
+      keepRecent: 1,
+      summarize: () => {
+        summarized = true;
+        return "RECAP";
+      },
+    });
+
+    // ctx 暴露 bigTool：autoCompaction 经 ctx.config.tools 把它计入 → 触发。
+    const { ctx } = createTestContext({ config: { tools: [bigTool] } });
+    const view = await compact.transformMessagesBeforeLlm!(messages, ctx);
+    expect(view).toBeDefined(); // 改进估算触发了
+    expect(summarized).toBe(true);
+
+    // 对照：同样 messages、同样阈值，但 ctx 没有 tools（messages-only 等价）→ 不触发。
+    let summarized2 = false;
+    const compact2 = autoCompaction({
+      maxContextTokens: threshold,
+      triggerRatio: 1,
+      keepRecent: 1,
+      summarize: () => {
+        summarized2 = true;
+        return "RECAP";
+      },
+    });
+    const { ctx: ctxNoTools } = createTestContext(); // config.tools = []
+    expect(await compact2.transformMessagesBeforeLlm!(messages, ctxNoTools)).toBeUndefined();
+    expect(summarized2).toBe(false);
+  });
+
+  it("X1: a custom tokenCounter overrides the default", async () => {
+    const calls: number[] = [];
+    const compact = autoCompaction({
+      maxContextTokens: 100,
+      triggerRatio: 1, // threshold 100
+      keepRecent: 1,
+      tokenCounter: {
+        estimate: ({ messages }) => {
+          calls.push(messages.length);
+          return 200; // 永远超阈值 → 触发
+        },
+      },
+      summarize: () => "RECAP",
+    });
+    const { ctx } = createTestContext();
+    const view = await compact.transformMessagesBeforeLlm!(grow(5), ctx);
+    expect(view).toBeDefined();
+    expect(calls.length).toBeGreaterThan(0); // 注入的 counter 真的被调用
   });
 });

--- a/packages/plugins/src/__tests__/estimate-request-tokens.test.ts
+++ b/packages/plugins/src/__tests__/estimate-request-tokens.test.ts
@@ -120,6 +120,26 @@ describe("estimateTokensByChars (regression — must stay unchanged by X1)", () 
   it("empty message is still 0 (no per-message overhead added)", () => {
     expect(estimateTokensByChars([m("")])).toBe(0);
   });
+
+  it("counts the tool parameters schema (the largest D0 blind spot), not just name+description", () => {
+    // 两个 tool 仅 parameters 不同:大 schema 必须让估值严格更高。
+    // 防回归:若只数 name+description 漏了 JSON.stringify(parameters),本测试会失败。
+    const messages = [m("hi")];
+    const small = [tool("t", "d", { type: "object", properties: {} })];
+    const bigSchema = {
+      type: "object",
+      properties: Object.fromEntries(
+        Array.from({ length: 30 }, (_, i) => [
+          `field_${i}`,
+          { type: "string", description: "a reasonably long field description ".repeat(3) },
+        ]),
+      ),
+    };
+    const big = [tool("t", "d", bigSchema)];
+    expect(estimateRequestTokens({ messages, tools: big })).toBeGreaterThan(
+      estimateRequestTokens({ messages, tools: small }),
+    );
+  });
 });
 
 describe("defaultTokenCounter", () => {

--- a/packages/plugins/src/__tests__/estimate-request-tokens.test.ts
+++ b/packages/plugins/src/__tests__/estimate-request-tokens.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import { createUserMessage } from "@harness-pi/core";
+import type { Message, Tool } from "@earendil-works/pi-ai";
+import {
+  estimateTokensByChars,
+  estimateRequestTokens,
+  defaultTokenCounter,
+} from "../auto-compaction.js";
+
+const m = (t: string): Message => createUserMessage(t);
+
+/** 造一个 pi-ai Tool（name + description + parameters）。 */
+function tool(name: string, description: string, parameters: unknown): Tool {
+  return { name, description, parameters } as Tool;
+}
+
+describe("estimateRequestTokens (X1, issue #55)", () => {
+  it("counts more than messages-only when tools are present (锁 D0 7x 低估方向)", () => {
+    const messages = [m("hi")];
+    const tools = [
+      tool("read", "Read a file from disk", {
+        type: "object",
+        properties: { path: { type: "string", description: "absolute path" } },
+        required: ["path"],
+      }),
+      tool("bash", "Run a shell command in the host shell", {
+        type: "object",
+        properties: { command: { type: "string", description: "the command" } },
+        required: ["command"],
+      }),
+    ];
+    const messagesOnly = estimateTokensByChars(messages);
+    const withTools = estimateRequestTokens({ messages, tools });
+    // 含 tool schema 的请求级估算 ≫ 仅数消息文本。
+    expect(withTools).toBeGreaterThan(messagesOnly);
+    // 而且差距显著（tools 的序列化体积远大于一条 "hi"）——不是只多一两个 token。
+    expect(withTools).toBeGreaterThan(messagesOnly * 5);
+  });
+
+  it("tools contribute additively: adding a tool strictly increases the estimate", () => {
+    const messages = [m("question")];
+    const t1 = tool("read", "read a file", { type: "object", properties: {} });
+    const t2 = tool(
+      "grep",
+      "search files by pattern with a long description here",
+      { type: "object", properties: { pattern: { type: "string" } } },
+    );
+    const one = estimateRequestTokens({ messages, tools: [t1] });
+    const two = estimateRequestTokens({ messages, tools: [t1, t2] });
+    expect(two).toBeGreaterThan(one);
+  });
+
+  it("systemPrompt contributes: a long system prompt raises the estimate", () => {
+    const messages = [m("q")];
+    const none = estimateRequestTokens({ messages });
+    const withSys = estimateRequestTokens({
+      messages,
+      systemPrompt: "You are a careful coding agent. ".repeat(50),
+    });
+    expect(withSys).toBeGreaterThan(none);
+  });
+
+  it("tools and systemPrompt contributions are separable (each adds on its own)", () => {
+    const messages = [m("q")];
+    const t = tool("read", "read a file from disk", { type: "object", properties: {} });
+    const sys = "system prompt body ".repeat(20);
+
+    const base = estimateRequestTokens({ messages });
+    const plusTool = estimateRequestTokens({ messages, tools: [t] });
+    const plusSys = estimateRequestTokens({ messages, systemPrompt: sys });
+    const plusBoth = estimateRequestTokens({ messages, tools: [t], systemPrompt: sys });
+
+    expect(plusTool).toBeGreaterThan(base);
+    expect(plusSys).toBeGreaterThan(base);
+    // 两者一起 = 各自增量之和（在 base 之上叠加），且严格大于任一单项。
+    expect(plusBoth).toBe(plusTool + plusSys - base);
+    expect(plusBoth).toBeGreaterThan(plusTool);
+    expect(plusBoth).toBeGreaterThan(plusSys);
+  });
+
+  it("adds a per-message format overhead (count grows with message count even for empty text)", () => {
+    const one = estimateRequestTokens({ messages: [m("")] });
+    const three = estimateRequestTokens({ messages: [m(""), m(""), m("")] });
+    // 空文本仍各计每消息格式开销，故条数多 = 估值高。
+    expect(three).toBeGreaterThan(one);
+    expect(three - one).toBe(8); // 2 条额外 × 4 tok/消息
+  });
+
+  it("reuses CJK / image rules from estimateTokensByChars", () => {
+    // CJK：每码点 ≈ 1 token，仍生效。
+    const cjk = "你好世界".repeat(10); // 40 码点
+    const cjkEst = estimateRequestTokens({ messages: [m(cjk)] });
+    // ≈ 40 (CJK) + 4 (每消息开销)。
+    expect(cjkEst).toBe(40 + 4);
+
+    // 图片：扁平 1000，不随 data 长度膨胀。
+    const imgMsg: Message = {
+      role: "user",
+      content: [{ type: "image", data: "A".repeat(50_000), mimeType: "image/png" }],
+      timestamp: 0,
+    };
+    const imgEst = estimateRequestTokens({ messages: [imgMsg] });
+    expect(imgEst).toBe(1000 + 4); // 1000 (image) + 每消息开销
+  });
+
+  it("equals messages-only + per-message overhead when tools/systemPrompt are omitted", () => {
+    const messages = [m("hello world"), m("second message")];
+    expect(estimateRequestTokens({ messages })).toBe(
+      estimateTokensByChars(messages) + messages.length * 4,
+    );
+  });
+});
+
+describe("estimateTokensByChars (regression — must stay unchanged by X1)", () => {
+  it("counts message text only, no tools/system/format overhead", () => {
+    // "hello" = 5 ASCII → ceil(5/4) = 2。绝不因 X1 多算每消息开销或 tool 体积。
+    expect(estimateTokensByChars([m("hello")])).toBe(2);
+  });
+
+  it("empty message is still 0 (no per-message overhead added)", () => {
+    expect(estimateTokensByChars([m("")])).toBe(0);
+  });
+});
+
+describe("defaultTokenCounter", () => {
+  it("estimate delegates to estimateRequestTokens", () => {
+    const input = {
+      messages: [m("hi")],
+      tools: [tool("read", "read a file", { type: "object", properties: {} })],
+      systemPrompt: "be careful",
+    };
+    expect(defaultTokenCounter.estimate(input)).toBe(estimateRequestTokens(input));
+  });
+
+  it("does not implement count (count? is a future opt-in seam)", () => {
+    expect(defaultTokenCounter.count).toBeUndefined();
+  });
+});

--- a/packages/plugins/src/__tests__/microcompact.test.ts
+++ b/packages/plugins/src/__tests__/microcompact.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { AgentSession, createUserMessage } from "@harness-pi/core";
 import { createTestContext, createFakeModel } from "@harness-pi/core/testing";
-import type { Message } from "@earendil-works/pi-ai";
+import type { Message, Tool } from "@earendil-works/pi-ai";
 import { microcompact } from "../microcompact.js";
+import { estimateRequestTokens } from "../auto-compaction.js";
 
 function textOf(m: Message): string {
   return typeof m.content === "string"
@@ -331,5 +332,115 @@ describe("microcompact", () => {
     expect(textOf(session.messages[0]!)).toContain("FILE_A");
     expect(textOf(session.messages[1]!)).toContain("FILE_B");
     fake.teardown();
+  });
+
+  it("X1: triggers earlier when tools are big (messages just under, tools push over)", () => {
+    // 3 条小 read（远低于 triggerTokens 的 messages-only 体积），加上大 tool schema 后请求级估算越过阈值。
+    const msgs: Message[] = [
+      tr("read", "small-1"),
+      tr("read", "small-2"),
+      tr("read", "recent"), // keepRecent=1 保护
+    ];
+    const bigTool: Tool = {
+      name: "submit_evidence",
+      description: "Submit structured evidence with a long description. ".repeat(40),
+      parameters: {
+        type: "object",
+        properties: { body: { type: "string", description: "the body ".repeat(30) } },
+      },
+    } as Tool;
+
+    // 阈值卡在「无 tools 估算之下、有 tools 估算之上」之间。
+    const noTools = estimateRequestTokens({ messages: msgs });
+    const withTools = estimateRequestTokens({ messages: msgs, tools: [bigTool] });
+    expect(withTools).toBeGreaterThan(noTools);
+    const trigger = Math.floor((noTools + withTools) / 2);
+
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: trigger,
+      targetTokens: 1,
+      keepRecent: 1,
+    });
+
+    // 有 tools（经 ctx.config）→ 触发清理。
+    const { ctx } = createTestContext({ config: { tools: [bigTool] } });
+    const view = compact.transformMessagesBeforeLlm!(msgs, ctx) as Message[];
+    expect(view).toBeDefined();
+    expect(textOf(view[0]!)).toContain("microcompact");
+
+    // 无 tools（messages-only 等价）→ 不触发。
+    const { ctx: ctxNoTools } = createTestContext();
+    expect(compact.transformMessagesBeforeLlm!(msgs, ctxNoTools)).toBeUndefined();
+  });
+
+  it("X1: incremental running-total equals a full re-estimate even with fixed tools/system constants", () => {
+    // 5 条大 read + 大 tools + system。增量 total（清一条减 estimateOne 差值）必须与「对清理后视图全量
+    // estimateRequestTokens」完全一致——固定常量（tools/system/每消息开销）在差值里抵消，数学等价。
+    const msgs: Message[] = Array.from({ length: 5 }, (_, i) =>
+      tr("read", `R${i}_` + "x".repeat(4000)),
+    );
+    const tools: Tool[] = [
+      {
+        name: "read",
+        description: "Read a file. ".repeat(30),
+        parameters: { type: "object", properties: { path: { type: "string" } } },
+      } as Tool,
+    ];
+    const systemPrompt = "You are a careful agent. ".repeat(50);
+
+    // triggerTokens = targetTokens = 2500：总体积 ~5000 > 2500 → 触发；清到 ≤2500 即停（中途早停、清部分），
+    // 考验早停判据用的增量 total 是否与全量重估一致。
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 2500,
+      targetTokens: 2500,
+      keepRecent: 0,
+    });
+    const { ctx } = createTestContext({ config: { tools, systemPrompt } });
+    const view = compact.transformMessagesBeforeLlm!(msgs, ctx) as Message[];
+    expect(view).toBeDefined();
+
+    // 部分被清（早停语义）：既有占位符也有原文留存。
+    const cleared = view.filter((mm) => textOf(mm).includes("microcompact")).length;
+    expect(cleared).toBeGreaterThan(0);
+    expect(cleared).toBeLessThan(5);
+
+    // 关键回归：对最终视图做全量请求级估算 ≤ targetTokens（增量 total 早停判据若与全量重估不一致，这里会破）。
+    const fullReEstimate = estimateRequestTokens({ messages: view, tools, systemPrompt });
+    expect(fullReEstimate).toBeLessThanOrEqual(2500);
+    // 且清掉最后一条之前的视图仍 > targetTokens（证明没有过度早停）——再恢复一条原文必然超标。
+    const idxsCleared: number[] = [];
+    view.forEach((mm, i) => {
+      if (textOf(mm).includes("microcompact")) idxsCleared.push(i);
+    });
+    const lastClearedIdx = idxsCleared[idxsCleared.length - 1]!;
+    const oneFewer = view.slice();
+    oneFewer[lastClearedIdx] = msgs[lastClearedIdx]!; // 把最后清的一条换回原文
+    const beforeLastClear = estimateRequestTokens({ messages: oneFewer, tools, systemPrompt });
+    expect(beforeLastClear).toBeGreaterThan(2500);
+  });
+
+  it("X1: a custom tokenCounter overrides the default", () => {
+    const calls: number[] = [];
+    const msgs: Message[] = [tr("read", "a"), tr("read", "b"), tr("read", "recent")];
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 100,
+      targetTokens: 1,
+      keepRecent: 1,
+      tokenCounter: {
+        estimate: ({ messages }) => {
+          calls.push(messages.length);
+          // 全量（>1 条）报超阈值以触发；单条 delta 用真实小值（这里给固定 50/条便于测调用）。
+          return messages.length === 1 ? 50 : 9999;
+        },
+      },
+    });
+    const { ctx } = createTestContext();
+    const view = compact.transformMessagesBeforeLlm!(msgs, ctx) as Message[];
+    expect(view).toBeDefined();
+    expect(textOf(view[0]!)).toContain("microcompact"); // 注入 counter 触发了清理
+    expect(calls.length).toBeGreaterThan(0); // counter 真被调用
   });
 });

--- a/packages/plugins/src/auto-compaction.ts
+++ b/packages/plugins/src/auto-compaction.ts
@@ -167,6 +167,13 @@ export function estimateRequestTokens(input: RequestTokenInput): number {
  *
  * **当前不实现 `count`**：pi-ai 0.74.2 无 `countTokens`（D0 已核），保留可选签名只为留一个不破坏 API 的接入口
  * （将来接真 tokenizer / provider count endpoint 时填它，消费方按需 `await counter.count?.(...)`）。
+ *
+ * **`estimate` 的 additivity 契约（自定义实现须遵守）**：`microcompact` 的增量 running-total
+ * （`total -= estimate({messages:[原]}) - estimate({messages:[占位]})`）只有在「`estimate` 对 messages 逐条可加、
+ * 且 tools/systemPrompt/每消息开销是**与单条消息无关的固定常量**」时才与全量重估逐 token 等价。默认
+ * {@link estimateRequestTokens} 满足。**非可加的真 BPE tokenizer 不满足**（token 跨消息边界、request framing 非线性）——
+ * 注入这类 counter 会让 microcompact 的体积早停漂移。届时应让 microcompact 改为每步全量 `estimate(整段)`，或只在
+ * autoCompaction（无增量假设）里用它。
  */
 export interface TokenCounter {
   estimate(input: RequestTokenInput): number;

--- a/packages/plugins/src/auto-compaction.ts
+++ b/packages/plugins/src/auto-compaction.ts
@@ -24,7 +24,7 @@
 
 import type { Hook, HookContext } from "@harness-pi/core";
 import { createUserMessage } from "@harness-pi/core";
-import type { Message } from "@earendil-works/pi-ai";
+import type { Message, Tool } from "@earendil-works/pi-ai";
 
 export interface AutoCompactionOptions {
   /** context token 预算（通常 = 模型上下文窗口，或你愿意用满的上限）。须 > 0。 */
@@ -39,10 +39,12 @@ export interface AutoCompactionOptions {
     ctx: HookContext,
   ) => string | Promise<string>;
   /**
-   * token 估算器。默认 {@link estimateTokensByChars}：CJK 感知（≈ 1 token/字）+ 图片感知（每图扁平估值），
-   * 整体偏**保守高估**（低估会漏触发压缩→窗口溢出，是安全 bug）；零依赖。接入真 tokenizer 可覆盖。
+   * Token 计数器（issue #55）。默认 {@link defaultTokenCounter}：`estimate` = {@link estimateRequestTokens}，
+   * 在 messages 字符估算之上**加回** tool schema + systemPrompt + 每消息格式开销（只数消息会低估真 usage ~7x）。
+   * 触发判据据此算，故有 tools 时**触发点比旧 messages-only 更早 = 更贴近真实窗口压力**（0.x 可接受的行为变更）。
+   * tools / systemPrompt 由内核经 `ctx.config` 提供，无需调用方传。接入真 tokenizer 时覆盖本选项即可。
    */
-  estimateTokens?: (messages: Message[]) => number;
+  tokenCounter?: TokenCounter;
   /**
    * 「想覆盖的前缀」比上次缓存增长达到这么多条才重算 summary；默认 = keepRecent。
    * 调大省 LLM 调用，调小更省 token。须 ≥ 1。
@@ -93,7 +95,9 @@ function estimateText(text: string): number {
  *   既不按短 ref 的字符数低估、也不按内联 base64 `data` 的字符数疯狂高估。
  * - **其余文本**（ASCII 等）：≈ 1/4 token/字符（向上取整），故纯英文仍 ≈ chars/4。
  *
- * 想接真 tokenizer：覆盖 `estimateTokens` 选项即可。
+ * **仅数消息文本**——不含每请求随发的 tool schema / systemPrompt / 格式开销（那些会**严重低估**真 usage，
+ * 见 {@link estimateRequestTokens}）。保留本函数原样是为向后兼容；消费插件默认走请求级的 {@link defaultTokenCounter}。
+ * 想接真 tokenizer：覆盖插件的 `tokenCounter` 选项即可。
  */
 export function estimateTokensByChars(messages: Message[]): number {
   let tokens = 0;
@@ -115,6 +119,64 @@ export function estimateTokensByChars(messages: Message[]): number {
   }
   return tokens;
 }
+
+/** 每条消息的固定格式开销（role / 分隔符 / 模板包装），主流 chat 模板约 3–4 tok/消息，取保守 4。 */
+const PER_MESSAGE_OVERHEAD = 4;
+
+/** {@link estimateRequestTokens} 的输入：一次 LLM 请求随发的三部分（tools / systemPrompt 每请求都发）。 */
+export interface RequestTokenInput {
+  messages: Message[];
+  /** 本次请求随发的 tool schema（pi-ai `Tool`：name + description + parameters）。 */
+  tools?: ReadonlyArray<Tool>;
+  /** 本次请求的 system prompt。 */
+  systemPrompt?: string;
+}
+
+/**
+ * 估算**整次 LLM 请求**的 token —— 在 {@link estimateTokensByChars}(messages) 之上，**加回**那些每请求随发、
+ * 却被「只数消息文本」漏掉的固定开销（issue #55 / D0 实测：只数消息低估真 usage ~7x，根因正是漏了下面三项）：
+ *
+ *   1. **tool schema**：每个 tool 的 `name` + `description` + `JSON.stringify(parameters)` 字符估算（走 1/4 规则）。
+ *      工具一多、parameters schema 一深，这块就是估算盲区里最大的一块。
+ *   2. **systemPrompt**：整段 system prompt 的字符估算（复用 CJK 感知的 {@link estimateTokensByChars}）。
+ *   3. **每消息格式开销**：每条消息一个小常量（{@link PER_MESSAGE_OVERHEAD}），覆盖 role / 分隔符 / 模板包装。
+ *
+ * CJK / image / chars-1/4 规则全部沿用 estimateTokensByChars，整体仍偏**保守高估**（压缩触发判据宁高勿低）。
+ * tools / systemPrompt **不传**时本函数退化为「estimateTokensByChars(messages) + 每消息常量」——比纯 messages-only
+ * 仍多算每消息常量，但语义一致。
+ */
+export function estimateRequestTokens(input: RequestTokenInput): number {
+  let tokens = estimateTokensByChars(input.messages);
+  tokens += input.messages.length * PER_MESSAGE_OVERHEAD;
+  if (input.systemPrompt) {
+    tokens += estimateText(input.systemPrompt);
+  }
+  if (input.tools) {
+    for (const t of input.tools) {
+      tokens += estimateText(t.name);
+      tokens += estimateText(t.description);
+      tokens += estimateText(JSON.stringify(t.parameters));
+    }
+  }
+  return tokens;
+}
+
+/**
+ * Token 计数 seam（issue #55）。`estimate` = 同步、零依赖的字符估算（默认 {@link estimateRequestTokens}）；
+ * `count` = 未来 opt-in 的**真** tokenizer（async）。
+ *
+ * **当前不实现 `count`**：pi-ai 0.74.2 无 `countTokens`（D0 已核），保留可选签名只为留一个不破坏 API 的接入口
+ * （将来接真 tokenizer / provider count endpoint 时填它，消费方按需 `await counter.count?.(...)`）。
+ */
+export interface TokenCounter {
+  estimate(input: RequestTokenInput): number;
+  count?(input: RequestTokenInput): Promise<number>;
+}
+
+/** 默认 TokenCounter：`estimate` = {@link estimateRequestTokens}；不提供 `count`。 */
+export const defaultTokenCounter: TokenCounter = {
+  estimate: estimateRequestTokens,
+};
 
 /**
  * 构造一个 autoCompaction hook。三条**使用须知**（issue #13，违反会得到悄无声息的错误压缩）：
@@ -146,7 +208,7 @@ export function autoCompaction(opts: AutoCompactionOptions): Hook {
   if (resummarizeEvery < 1) {
     throw new Error("autoCompaction: resummarizeEvery must be >= 1");
   }
-  const estimate = opts.estimateTokens ?? estimateTokensByChars;
+  const counter = opts.tokenCounter ?? defaultTokenCounter;
   const threshold = opts.maxContextTokens * triggerRatio;
   const wrap =
     opts.summaryText ??
@@ -159,8 +221,13 @@ export function autoCompaction(opts: AutoCompactionOptions): Hook {
     name: "autoCompaction",
 
     async transformMessagesBeforeLlm(messages, ctx) {
-      // 未到 token 阈值 → 原样。
-      if (estimate(messages) <= threshold) return undefined;
+      // 未到 token 阈值 → 原样。tools / systemPrompt 由 ctx.config 提供，计入每请求随发的固定开销（X1）。
+      const estimated = counter.estimate({
+        messages,
+        tools: ctx.config.tools,
+        systemPrompt: ctx.config.systemPrompt,
+      });
+      if (estimated <= threshold) return undefined;
       // 已经压无可压（tail 即全部）→ 总结救不了，交给 overflow 兜底，不在这里空转。
       if (messages.length <= keepRecent) return undefined;
 

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -44,8 +44,17 @@ export type { LeaseDecisionOptions } from "./lease-decision.js";
 export { compactSummarize } from "./compact-summarize.js";
 export type { CompactSummarizeOptions } from "./compact-summarize.js";
 
-export { autoCompaction, estimateTokensByChars } from "./auto-compaction.js";
-export type { AutoCompactionOptions } from "./auto-compaction.js";
+export {
+  autoCompaction,
+  estimateTokensByChars,
+  estimateRequestTokens,
+  defaultTokenCounter,
+} from "./auto-compaction.js";
+export type {
+  AutoCompactionOptions,
+  RequestTokenInput,
+  TokenCounter,
+} from "./auto-compaction.js";
 
 export { microcompact } from "./microcompact.js";
 export type { MicrocompactOptions } from "./microcompact.js";

--- a/packages/plugins/src/microcompact.ts
+++ b/packages/plugins/src/microcompact.ts
@@ -23,7 +23,7 @@
 
 import type { Hook } from "@harness-pi/core";
 import type { Message } from "@earendil-works/pi-ai";
-import { estimateTokensByChars } from "./auto-compaction.js";
+import { defaultTokenCounter, type TokenCounter } from "./auto-compaction.js";
 
 export interface MicrocompactOptions {
   /** 只清这些工具产生的 toolResult。**不 hardcode 工具名**——由调用方传（domain-free）。string[] 会归一成 Set。 */
@@ -44,8 +44,12 @@ export interface MicrocompactOptions {
   gapMinutes?: number;
   /** 当前时刻（ms）。默认 `Date.now`；测试可注入以走 `gapMinutes` 路径。 */
   now?: () => number;
-  /** token 估算器。默认 {@link estimateTokensByChars}（与 autoCompaction 同款、保守高估）。 */
-  estimateTokens?: (messages: Message[]) => number;
+  /**
+   * Token 计数器（issue #55）。默认 {@link defaultTokenCounter}（请求级估算：messages + tool schema +
+   * systemPrompt + 每消息开销）。触发判据与初始 running-total 据此算，故有 tools 时**触发点比旧 messages-only
+   * 更早**。tools / systemPrompt 由内核经 `ctx.config` 提供。接真 tokenizer 时覆盖即可。
+   */
+  tokenCounter?: TokenCounter;
   /** 占位符文案（默认带工具名 + 原内容字符数提示）。 */
   placeholderText?: (toolName: string, originalChars: number) => string;
 }
@@ -66,7 +70,8 @@ function contentChars(content: ToolResult["content"]): number {
  * 构造一个 microcompact hook。
  *
  * 触发判据（满足任一即动手）：
- *   1. **体积**：`estimateTokens(messages) > triggerTokens` → 从最旧白名单 toolResult 起清，降到 `targetTokens` 以下即停。
+ *   1. **体积**：`tokenCounter.estimate({messages, tools, systemPrompt}) > triggerTokens`（请求级估算，含每请求随发的
+ *      tool schema + systemPrompt）→ 从最旧白名单 toolResult 起清，降到 `targetTokens` 以下即停。
  *   2. **gap**（可选）：`now() - 最后一条消息的 timestamp > gapMinutes` 分钟（cache 已冷）→ 把**所有**可清的白名单
  *      toolResult 清掉（cache 反正要冷启重发，激进清以缩短下次冷启动 prompt，不受 targetTokens 早停约束）。
  *
@@ -89,7 +94,7 @@ export function microcompact(opts: MicrocompactOptions): Hook {
     throw new Error("microcompact: gapMinutes must be > 0");
   }
   const now = opts.now ?? Date.now;
-  const estimate = opts.estimateTokens ?? estimateTokensByChars;
+  const counter = opts.tokenCounter ?? defaultTokenCounter;
   const placeholderText =
     opts.placeholderText ??
     ((tool, chars) => `[microcompact: ${tool} output cleared, ~${chars} chars]`);
@@ -98,7 +103,16 @@ export function microcompact(opts: MicrocompactOptions): Hook {
     name: "microcompact",
     timeout: 50,
 
-    transformMessagesBeforeLlm(messages, _ctx) {
+    transformMessagesBeforeLlm(messages, ctx) {
+      // 请求级估算：messages 之外把每请求随发的 tool schema + systemPrompt 也计入（X1，issue #55）。
+      // 这两项是**固定常量**（清消息不改它），故下面增量 running-total 的 delta 里会自然抵消（见 142 行注释）。
+      const reqExtras = {
+        tools: ctx.config.tools,
+        systemPrompt: ctx.config.systemPrompt,
+      };
+      // 单消息估值（不含 tools/systemPrompt；其每消息开销常量在 delta 里抵消）——用于增量 running-total。
+      const estimateOne = (m: Message): number => counter.estimate({ messages: [m] });
+
       // gap 判据：最后一条消息的 timestamp 距 now 超过 gapMinutes（cache 已冷）。
       let coldCache = false;
       if (opts.gapMinutes !== undefined && messages.length > 0) {
@@ -108,7 +122,11 @@ export function microcompact(opts: MicrocompactOptions): Hook {
       }
 
       // 体积没超阈值、且 cache 不冷 → 原样返回。
-      if (estimate(messages) <= opts.triggerTokens && !coldCache) return undefined;
+      if (
+        counter.estimate({ messages, ...reqExtras }) <= opts.triggerTokens &&
+        !coldCache
+      )
+        return undefined;
 
       // 找出**可清**的白名单 toolResult 下标（排除最近 keepRecent 条 toolResult）。
       const toolResultIdxs: number[] = [];
@@ -129,13 +147,15 @@ export function microcompact(opts: MicrocompactOptions): Hook {
       // 体积触发：从最旧开始清，清到 ≤ targetTokens 即停（不必全清）。
       // gap 触发（coldCache）：不设早停，把所有可清的都清掉（cache 反正冷了）。
       //
-      // **增量 running total，不每轮全量重估。** estimateTokensByChars 是逐消息/逐块累加，故替换一条时
-      // `estimate([原]) - estimate([占位])` 正是整体估值的精确变化量——结果与全量重估完全一致，但复杂度从
-      // O(N·K) 降到 O(N+K)。这点很关键：本 transform 是**同步**的，`timeout:50` 拦不住同步循环（计时器在
-      // 同步阻塞期间根本没机会 fire），而本插件正是为大文件读取场景设计、harness 又是多 session 跑在单
-      // event loop（WorkPool/LeaseQueue）——全量重估的 O(N·K) 会让一个 session 的压缩同步冻住其余所有 session。
+      // **增量 running total，不每轮全量重估。** estimateRequestTokens 在 messages 字符估算之上只加**固定常量**
+      // （tool schema + systemPrompt + 每消息开销 ×N，N 不变）；其 messages 部分逐消息可加，故替换一条时
+      // `estimateOne(原) - estimateOne(占位)` 正是整体估值的精确变化量——固定常量在差值里抵消，结果与
+      // 全量 `counter.estimate({messages: out, ...reqExtras})` 重估**完全一致**，复杂度仍从 O(N·K) 降到 O(N+K)。
+      // 这点很关键：本 transform 是**同步**的，`timeout:50` 拦不住同步循环（计时器在同步阻塞期间根本没机会
+      // fire），而本插件正是为大文件读取场景设计、harness 又是多 session 跑在单 event loop（WorkPool/
+      // LeaseQueue）——全量重估的 O(N·K) 会让一个 session 的压缩同步冻住其余所有 session。
       const out = messages.slice(); // copy-on-write，绝不改原数组 / session.messages
-      let total = estimate(out); // 开头估一次
+      let total = counter.estimate({ messages: out, ...reqExtras }); // 开头估一次（含固定常量）
       for (const idx of clearable) {
         if (!coldCache && total <= targetTokens) break; // O(1) 比较；降到目标即停（gap 路径不早停）
         const msg = out[idx]! as ToolResult;
@@ -144,7 +164,7 @@ export function microcompact(opts: MicrocompactOptions): Hook {
           ...msg,
           content: [{ type: "text" as const, text: placeholderText(msg.toolName, chars) }],
         };
-        total -= estimate([msg]) - estimate([placeholder]); // 精确减去本条清理带来的体积下降
+        total -= estimateOne(msg) - estimateOne(placeholder); // 精确减去本条清理带来的体积下降（固定常量抵消）
         out[idx] = placeholder;
       }
 


### PR DESCRIPTION
**0.3.0 Wave B · X1**(epic #43,issue #55)。D0 实测 `estimateTokensByChars(messages)` 低估真 usage ~7x(忽略 tool schema/system/格式);容忍型 provider 又无反应式越界兜底 → 主动压缩防线建在低估上。X1 闭这个 gap。

## 改动
- **core**:`SessionConfigView` 加只读 `tools: ReadonlyArray<Tool>`(每元素冻结)+ `systemPrompt`(pre-pipe base);session.ts/testing.ts 构建处同步。纯加性、向后兼容。
- **plugins**:`estimateRequestTokens({messages,tools?,systemPrompt?})` = messages + 每 tool schema(name+desc+JSON.stringify(parameters))+ systemPrompt + 每消息格式常量;`TokenCounter` 接口(`count?` 留 future seam,pi-ai 0.74.2 无 countTokens 不实现)。autoCompaction/microcompact 默认走 `defaultTokenCounter`(经 ctx.config 取 tools/system),可注入 `tokenCounter`。`estimateTokensByChars(messages)` 原样保留。
- microcompact 增量 running-total:tools/system/每消息开销是固定常量、在 `estimateOne(原)-estimateOne(占位)` delta 里抵消 → 与全量重估逐 token 等价(数学等价回归含早停边界)。

## 验证
core 280 / plugins 281 / 全 6 包 test + `pnpm -r build/typecheck` 全绿。**review-gate 3/3 PASS**(实测 7 个 first-party tool 仅 schema 就 +~750tok,与 D0 的 53-vs-381 ~7x 吻合)。核心 wiring(真 session→ctx.config.tools/systemPrompt)+ tools freeze 有专测。

## ⚠️ 发布注意(CHANGELOG)
- **breaking(plugin option)**:autoCompaction/microcompact 的 `estimateTokens?:(messages)=>number` 选项重命名为 `tokenCounter?: TokenCounter`(仅这两插件消费,无 in-repo 外部调用方;新签名严格更强)。
- **行为变更**:有 tools 时压缩触发**更早=更准**;外部若 pin 了基于旧 messages-only 估算的 maxContextTokens/triggerRatio 会看到稍早压缩。

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)