### PR TITLE
feat(plugins): X2 — per-model 有效窗口阈值(替百分比)(#43 X2)

### DIFF
--- a/packages/core/src/__tests__/phase1-foundation.test.ts
+++ b/packages/core/src/__tests__/phase1-foundation.test.ts
@@ -229,6 +229,23 @@ describe("Phase 1: ctx.config", () => {
     fake.teardown();
   });
 
+  it("config.model 暴露 contextWindow / maxTokens(X2 #57)— autoCompaction 据此算绝对阈值", async () => {
+    let captured: HookContext["config"] | null = null;
+    const probe: Hook = {
+      name: "probe",
+      onSessionStart(_input, ctx) {
+        captured = ctx.config;
+      },
+    };
+    // createFakeModel 的 Model 携带 contextWindow=200_000 / maxTokens=4096(testing.ts 固定值)。
+    const fake = createFakeModel([{ content: [{ type: "text", text: "done" }] }]);
+    const session = new AgentSession({ model: fake, tools: [], hooks: [probe] });
+    await session.run("go");
+    expect(captured!.model.contextWindow).toBe(200_000);
+    expect(captured!.model.maxTokens).toBe(4096);
+    fake.teardown();
+  });
+
   it("config.systemPrompt 默认空串(未配置时)— 估算不应误把 undefined 当内容", async () => {
     let captured: HookContext["config"] | null = null;
     const probe: Hook = {

--- a/packages/core/src/hook.ts
+++ b/packages/core/src/hook.ts
@@ -313,7 +313,17 @@ export interface HookLogger {
  */
 export interface SessionConfigView {
   readonly sessionId: string;
-  readonly model: { id: string; provider: string };
+  /**
+   * 当前 model 的标识 + 有效窗口（X2 / #57）。`contextWindow` / `maxTokens` 取自 pi-ai `Model` 同名字段
+   * （`makeOpenAICompatibleModel` / registry 都填）——**值来自调用方 Model，内核不硬编 per-model 表、不解析 id**。
+   * autoCompaction 据此算「按有效窗口触发」的绝对阈值（`contextWindow − reserveForOutput − safetyBuffer`）。
+   */
+  readonly model: {
+    id: string;
+    provider: string;
+    contextWindow: number;
+    maxTokens: number;
+  };
   readonly toolNames: ReadonlyArray<string>;
   /**
    * 发给 LLM 的 tool schema（pi-ai `Tool` 形态 `{name, description, parameters}`，与每次请求随发的

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -327,7 +327,13 @@ export class AgentSession {
     // 不写,与 model 的扁平冻结粒度一致,不构成新风险面。
     const configView: SessionConfigView = Object.freeze({
       sessionId: this.id,
-      model: Object.freeze({ id: this.model.id, provider: this.model.provider }),
+      model: Object.freeze({
+        id: this.model.id,
+        provider: this.model.provider,
+        // X2(#57):暴露有效窗口给 autoCompaction 算绝对阈值。值取自 pi-ai Model 同名字段(调用方权威)。
+        contextWindow: this.model.contextWindow,
+        maxTokens: this.model.maxTokens,
+      }),
       toolNames: Object.freeze(this.tools.map((t) => t.name)),
       // 只暴露 pi-ai Tool 三字段（与每请求随发的 piTools 同形），冻结每个元素防 plugin 改 schema。
       tools: Object.freeze(

--- a/packages/core/src/testing.ts
+++ b/packages/core/src/testing.ts
@@ -339,7 +339,12 @@ export function createTestContext(opts: TestContextOptions = {}): TestContextHan
 
   const defaultConfig: SessionConfigView = Object.freeze({
     sessionId: opts.sessionId ?? "test-session",
-    model: Object.freeze({ id: "test-model", provider: "test" }),
+    model: Object.freeze({
+      id: "test-model",
+      provider: "test",
+      contextWindow: 200_000,
+      maxTokens: 4096,
+    }),
     toolNames: Object.freeze([]),
     tools: Object.freeze([]),
     systemPrompt: "",

--- a/packages/plugins/src/__tests__/auto-compaction.test.ts
+++ b/packages/plugins/src/__tests__/auto-compaction.test.ts
@@ -363,4 +363,179 @@ describe("autoCompaction", () => {
     expect(view).toBeDefined();
     expect(calls.length).toBeGreaterThan(0); // 注入的 counter 真的被调用
   });
+
+  // ───────────────── X2(#57): per-model 有效窗口 + 分层 buffer ─────────────────
+
+  const modelCfg = (contextWindow: number, maxTokens: number) => ({
+    model: { id: "m", provider: "p", contextWindow, maxTokens },
+  });
+
+  it("X2: window mode threshold = contextWindow − reserveForOutput − safetyBuffer", async () => {
+    // contextWindow=10000, reserveForOutput=4096(默认 min(maxTokens,4096)), safetyBuffer=500 → 阈值 5404。
+    let summarized = false;
+    const compact = autoCompaction({
+      // 不给 maxContextTokens → 走窗口路径
+      keepRecent: 1,
+      safetyBuffer: 500,
+      tokenCounter: { estimate: () => 5405 }, // 5404 < 5405 → 越界 → 触发
+      summarize: () => {
+        summarized = true;
+        return "RECAP";
+      },
+    });
+    const { ctx } = createTestContext({ config: modelCfg(10_000, 8000) }); // maxTokens=8000 → reserve=min(8000,4096)=4096
+    const view = await compact.transformMessagesBeforeLlm!(grow(3), ctx);
+    expect(view).toBeDefined();
+    expect(summarized).toBe(true);
+  });
+
+  it("X2: window mode does NOT trigger at or below the effective window", async () => {
+    // 阈值 = 10000 − 4096 − 0 = 5904。估算正好 = 5904（边界，<= 不触发）。
+    let calls = 0;
+    const compact = autoCompaction({
+      keepRecent: 1,
+      tokenCounter: { estimate: () => 5904 },
+      summarize: () => {
+        calls++;
+        return "S";
+      },
+    });
+    const { ctx } = createTestContext({ config: modelCfg(10_000, 4096) });
+    expect(await compact.transformMessagesBeforeLlm!(grow(5), ctx)).toBeUndefined();
+    expect(calls).toBe(0);
+
+    // 阈值 + 1 → 触发。
+    const compact2 = autoCompaction({
+      keepRecent: 1,
+      tokenCounter: { estimate: () => 5905 },
+      summarize: () => "S",
+    });
+    expect(await compact2.transformMessagesBeforeLlm!(grow(5), ctx)).toBeDefined();
+  });
+
+  it("X2: reserveForOutput / safetyBuffer overrides lower the effective window", async () => {
+    // 显式 reserveForOutput=1000, safetyBuffer=2000 → 阈值 = 10000 − 1000 − 2000 = 7000。
+    const compact = autoCompaction({
+      keepRecent: 1,
+      reserveForOutput: 1000,
+      safetyBuffer: 2000,
+      tokenCounter: { estimate: () => 7000 }, // == 阈值 → 不触发
+      summarize: () => "S",
+    });
+    const { ctx } = createTestContext({ config: modelCfg(10_000, 4096) });
+    expect(await compact.transformMessagesBeforeLlm!(grow(5), ctx)).toBeUndefined();
+
+    const compact2 = autoCompaction({
+      keepRecent: 1,
+      reserveForOutput: 1000,
+      safetyBuffer: 2000,
+      tokenCounter: { estimate: () => 7001 }, // 越界 1 → 触发
+      summarize: () => "S",
+    });
+    expect(await compact2.transformMessagesBeforeLlm!(grow(5), ctx)).toBeDefined();
+  });
+
+  it("X2: reserveForOutput defaults to min(model.maxTokens, 4096)", async () => {
+    // maxTokens=2000 < 4096 → reserve=2000 → 阈值 = 10000 − 2000 = 8000。
+    const compactSmall = autoCompaction({
+      keepRecent: 1,
+      tokenCounter: { estimate: () => 8001 },
+      summarize: () => "S",
+    });
+    const { ctx: ctxSmall } = createTestContext({ config: modelCfg(10_000, 2000) });
+    expect(await compactSmall.transformMessagesBeforeLlm!(grow(5), ctxSmall)).toBeDefined(); // 8001 > 8000
+
+    const compactSmall2 = autoCompaction({
+      keepRecent: 1,
+      tokenCounter: { estimate: () => 8000 },
+      summarize: () => "S",
+    });
+    expect(await compactSmall2.transformMessagesBeforeLlm!(grow(5), ctxSmall)).toBeUndefined(); // 8000 == 阈值
+
+    // maxTokens=100000 > 4096 → reserve 封顶 4096 → 阈值 = 10000 − 4096 = 5904。
+    const compactBig = autoCompaction({
+      keepRecent: 1,
+      tokenCounter: { estimate: () => 5905 },
+      summarize: () => "S",
+    });
+    const { ctx: ctxBig } = createTestContext({ config: modelCfg(10_000, 100_000) });
+    expect(await compactBig.transformMessagesBeforeLlm!(grow(5), ctxBig)).toBeDefined(); // 5905 > 5904
+  });
+
+  it("X2: explicit maxContextTokens takes priority over the window path (backward compat)", async () => {
+    // 即便 ctx 暴露了 contextWindow，给了 maxContextTokens 就走百分比路径，窗口路径被忽略。
+    // maxContextTokens=100, triggerRatio=1 → 阈值 100；窗口阈值会是 10000−4096=5904（若误用窗口路径则不触发）。
+    let summarized = false;
+    const compact = autoCompaction({
+      maxContextTokens: 100,
+      triggerRatio: 1,
+      keepRecent: 1,
+      tokenCounter: { estimate: () => 200 }, // > 100(百分比) 但 < 5904(窗口) → 只有走百分比才触发
+      summarize: () => {
+        summarized = true;
+        return "S";
+      },
+    });
+    const { ctx } = createTestContext({ config: modelCfg(10_000, 4096) });
+    const view = await compact.transformMessagesBeforeLlm!(grow(5), ctx);
+    expect(view).toBeDefined(); // 走了百分比路径
+    expect(summarized).toBe(true);
+  });
+
+  it("X2: contextWindow unavailable (0) and no maxContextTokens → no compaction (no threshold)", async () => {
+    let calls = 0;
+    const compact = autoCompaction({
+      keepRecent: 1,
+      tokenCounter: { estimate: () => 999_999 }, // 巨大，但算不出阈值
+      summarize: () => {
+        calls++;
+        return "S";
+      },
+    });
+    const { ctx } = createTestContext({ config: modelCfg(0, 0) }); // contextWindow=0
+    expect(await compact.transformMessagesBeforeLlm!(grow(5), ctx)).toBeUndefined();
+    expect(calls).toBe(0);
+  });
+
+  it("X2: rejects negative reserveForOutput / safetyBuffer; allows omitting maxContextTokens", () => {
+    expect(() =>
+      autoCompaction({ reserveForOutput: -1, summarize: () => "" }),
+    ).toThrow(/reserveForOutput/);
+    expect(() =>
+      autoCompaction({ safetyBuffer: -1, summarize: () => "" }),
+    ).toThrow(/safetyBuffer/);
+    // maxContextTokens 显式给 0 仍报错（区分「缺省」与「非法显式值」）。
+    expect(() => autoCompaction({ maxContextTokens: 0, summarize: () => "" })).toThrow(
+      /maxContextTokens/,
+    );
+    // 完全不给 maxContextTokens（窗口模式）→ 构造不报错。
+    expect(() => autoCompaction({ summarize: () => "" })).not.toThrow();
+  });
+
+  it("X2 end-to-end: window mode from a real session's model.contextWindow", async () => {
+    // fake model: contextWindow=200000, maxTokens=4096 → 阈值 = 200000 − 4096 = 195904。
+    // 注入一个超大 estimate(走 tokenCounter)，让请求体积越过窗口阈值 → 真 session 触发压缩。
+    const initial = [m("h1"), m("a1"), m("h2"), m("a2"), m("h3"), m("a3")]; // 6
+    const fake = createFakeModel([{ content: [{ type: "text", text: "ok" }], stopReason: "stop" }]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [],
+      initialMessages: initial,
+      hooks: [
+        autoCompaction({
+          // 不给 maxContextTokens → 用 model.contextWindow
+          keepRecent: 2,
+          tokenCounter: { estimate: () => 200_000 }, // > 195904 → 触发
+          summarize: () => "RECAP",
+        }),
+      ],
+    });
+    await session.run("go");
+
+    const view = fake.getCalls()[0]!.messages;
+    expect(view.length).toBe(3); // [summary, "a3", "go"]
+    expect(textOf(view[0]!)).toContain("RECAP");
+    expect(session.messages.length).toBe(8); // full history intact
+    fake.teardown();
+  });
 });

--- a/packages/plugins/src/__tests__/auto-compaction.test.ts
+++ b/packages/plugins/src/__tests__/auto-compaction.test.ts
@@ -497,6 +497,23 @@ describe("autoCompaction", () => {
     expect(calls).toBe(0);
   });
 
+  it("X2: reserveForOutput+safetyBuffer >= contextWindow → 阈值≤0 视为算不出 → no-op(不每 turn 空压)", async () => {
+    // footgun 防护:小窗口 + 大 reserve 让 effectiveWindow ≤ 0;若直接用,estimated(>=0) 永远 > 阈值 → 每 turn 压缩。
+    let calls = 0;
+    const compact = autoCompaction({
+      keepRecent: 1,
+      reserveForOutput: 200, // >= contextWindow(100) → w = 100 − 200 − 0 = −100 ≤ 0
+      tokenCounter: { estimate: () => 999_999 }, // 巨大,但阈值算不出 → 不应触发
+      summarize: () => {
+        calls++;
+        return "S";
+      },
+    });
+    const { ctx } = createTestContext({ config: modelCfg(100, 50) });
+    expect(await compact.transformMessagesBeforeLlm!(grow(5), ctx)).toBeUndefined();
+    expect(calls).toBe(0); // 不每 turn 空压
+  });
+
   it("X2: rejects negative reserveForOutput / safetyBuffer; allows omitting maxContextTokens", () => {
     expect(() =>
       autoCompaction({ reserveForOutput: -1, summarize: () => "" }),

--- a/packages/plugins/src/__tests__/estimate-request-tokens.test.ts
+++ b/packages/plugins/src/__tests__/estimate-request-tokens.test.ts
@@ -5,6 +5,7 @@ import {
   estimateTokensByChars,
   estimateRequestTokens,
   defaultTokenCounter,
+  PER_MESSAGE_OVERHEAD,
 } from "../auto-compaction.js";
 
 const m = (t: string): Message => createUserMessage(t);
@@ -90,8 +91,8 @@ describe("estimateRequestTokens (X1, issue #55)", () => {
     // CJK：每码点 ≈ 1 token，仍生效。
     const cjk = "你好世界".repeat(10); // 40 码点
     const cjkEst = estimateRequestTokens({ messages: [m(cjk)] });
-    // ≈ 40 (CJK) + 4 (每消息开销)。
-    expect(cjkEst).toBe(40 + 4);
+    // ≈ 40 (CJK) + 每消息开销。
+    expect(cjkEst).toBe(40 + PER_MESSAGE_OVERHEAD);
 
     // 图片：扁平 1000，不随 data 长度膨胀。
     const imgMsg: Message = {
@@ -100,13 +101,13 @@ describe("estimateRequestTokens (X1, issue #55)", () => {
       timestamp: 0,
     };
     const imgEst = estimateRequestTokens({ messages: [imgMsg] });
-    expect(imgEst).toBe(1000 + 4); // 1000 (image) + 每消息开销
+    expect(imgEst).toBe(1000 + PER_MESSAGE_OVERHEAD); // 1000 (image) + 每消息开销
   });
 
   it("equals messages-only + per-message overhead when tools/systemPrompt are omitted", () => {
     const messages = [m("hello world"), m("second message")];
     expect(estimateRequestTokens({ messages })).toBe(
-      estimateTokensByChars(messages) + messages.length * 4,
+      estimateTokensByChars(messages) + messages.length * PER_MESSAGE_OVERHEAD,
     );
   });
 });

--- a/packages/plugins/src/auto-compaction.ts
+++ b/packages/plugins/src/auto-compaction.ts
@@ -142,7 +142,7 @@ export function estimateTokensByChars(messages: Message[]): number {
 }
 
 /** 每条消息的固定格式开销（role / 分隔符 / 模板包装），主流 chat 模板约 3–4 tok/消息，取保守 4。 */
-const PER_MESSAGE_OVERHEAD = 4;
+export const PER_MESSAGE_OVERHEAD = 4;
 
 /** {@link estimateRequestTokens} 的输入：一次 LLM 请求随发的三部分（tools / systemPrompt 每请求都发）。 */
 export interface RequestTokenInput {
@@ -268,7 +268,11 @@ export function autoCompaction(opts: AutoCompactionOptions): Hook {
         const contextWindow = ctx.config.model.contextWindow;
         if (contextWindow > 0) {
           const reserveForOutput = opts.reserveForOutput ?? Math.min(ctx.config.model.maxTokens, 4096);
-          threshold = contextWindow - reserveForOutput - safetyBuffer;
+          const w = contextWindow - reserveForOutput - safetyBuffer;
+          // 防 footgun:reserve+safetyBuffer >= contextWindow 时 w<=0,直接用会让 estimated(>=0)永远 > 阈值
+          // → 每 turn 都压缩(过度激进)。视为「算不出有意义阈值」→ 本 turn no-op(下面 threshold===undefined 兜底)。
+          // 这种 misconfig 需 window < reserve(本就荒谬),no-op 比每 turn 空压更安全、更可诊断。
+          if (w > 0) threshold = w;
         }
       }
       if (threshold === undefined) return undefined;

--- a/packages/plugins/src/auto-compaction.ts
+++ b/packages/plugins/src/auto-compaction.ts
@@ -27,10 +27,31 @@ import { createUserMessage } from "@harness-pi/core";
 import type { Message, Tool } from "@earendil-works/pi-ai";
 
 export interface AutoCompactionOptions {
-  /** context token 预算（通常 = 模型上下文窗口，或你愿意用满的上限）。须 > 0。 */
-  maxContextTokens: number;
-  /** 触发比例：估算 tokens > `maxContextTokens * triggerRatio` 才压缩。默认 0.8，须 ∈ (0, 1]。 */
+  /**
+   * context token 预算（百分比触发路径）。须 > 0。
+   *
+   * **触发路径优先级（X2 / #57）**：
+   *   - 显式给了 `maxContextTokens` → 永远走百分比路径 `> maxContextTokens * triggerRatio`（尊重调用方的显式上限，
+   *     与旧行为一致；现有测试多走此路径）。
+   *   - 未给 `maxContextTokens`、但 `ctx.config.model.contextWindow > 0` → 走**绝对窗口路径**
+   *     `> contextWindow − reserveForOutput − safetyBuffer`（X2 的有效窗口阈值，更贴近真实窗口压力）。
+   *   - 两者都不可得（无 maxContextTokens 且 contextWindow 为 0/缺）→ 算不出阈值，本 turn 不压缩
+   *     （contextWindow 是运行时值、构造期无从校验，故退化为 no-op 而非构造期报错）。
+   *
+   * 即：**显式 maxContextTokens 压过窗口路径**；窗口路径是「没显式上限时用模型自带窗口」的兜底主路。
+   */
+  maxContextTokens?: number;
+  /** 触发比例（百分比路径）：估算 tokens > `maxContextTokens * triggerRatio` 才压缩。默认 0.8，须 ∈ (0, 1]。 */
   triggerRatio?: number;
+  /**
+   * 窗口路径（X2 / #57）给模型输出 + summary/续答预留的 token 数（从 contextWindow 里扣掉）。
+   * 默认 `Math.min(model.maxTokens, 4096)`——既不超模型实际能输出的上限、又给个合理保底。须 ≥ 0。
+   */
+  reserveForOutput?: number;
+  /**
+   * 窗口路径（X2 / #57）的绝对安全缓冲（再从 contextWindow 里多扣一截，吸收估算误差）。默认 0，须 ≥ 0。
+   */
+  safetyBuffer?: number;
   /** 压缩后原样保留的最近消息条数（recent tail）。默认 6，须 ≥ 1。 */
   keepRecent?: number;
   /** 把一批早期消息总结成文本（可 async / 调 LLM）——与 compactSummarize 同契约。 */
@@ -200,7 +221,8 @@ export const defaultTokenCounter: TokenCounter = {
  *    每个 session 各 `autoCompaction(...)` 一次。
  */
 export function autoCompaction(opts: AutoCompactionOptions): Hook {
-  if (!(opts.maxContextTokens > 0)) {
+  // maxContextTokens 可选（X2）：给了就走百分比路径(并须 > 0)；不给则走窗口路径(阈值来自 ctx.config.model)。
+  if (opts.maxContextTokens !== undefined && !(opts.maxContextTokens > 0)) {
     throw new Error("autoCompaction: maxContextTokens must be > 0");
   }
   const triggerRatio = opts.triggerRatio ?? 0.8;
@@ -215,8 +237,17 @@ export function autoCompaction(opts: AutoCompactionOptions): Hook {
   if (resummarizeEvery < 1) {
     throw new Error("autoCompaction: resummarizeEvery must be >= 1");
   }
+  if (opts.reserveForOutput !== undefined && opts.reserveForOutput < 0) {
+    throw new Error("autoCompaction: reserveForOutput must be >= 0");
+  }
+  if (opts.safetyBuffer !== undefined && opts.safetyBuffer < 0) {
+    throw new Error("autoCompaction: safetyBuffer must be >= 0");
+  }
   const counter = opts.tokenCounter ?? defaultTokenCounter;
-  const threshold = opts.maxContextTokens * triggerRatio;
+  const safetyBuffer = opts.safetyBuffer ?? 0;
+  // 百分比路径阈值是构造期常量；窗口路径阈值依赖 ctx.config.model.contextWindow，须每请求算。
+  const percentThreshold =
+    opts.maxContextTokens !== undefined ? opts.maxContextTokens * triggerRatio : undefined;
   const wrap =
     opts.summaryText ??
     ((summary, n) => `[auto-compacted summary of ${n} earlier messages]\n${summary}`);
@@ -228,6 +259,20 @@ export function autoCompaction(opts: AutoCompactionOptions): Hook {
     name: "autoCompaction",
 
     async transformMessagesBeforeLlm(messages, ctx) {
+      // 触发阈值（X2 #57，优先级：显式 maxContextTokens 压过窗口路径）：
+      //   - 给了 maxContextTokens → 百分比路径常量 percentThreshold（旧行为，尊重显式上限）。
+      //   - 否则用 model.contextWindow > 0 → 窗口路径 contextWindow − reserveForOutput − safetyBuffer。
+      //   - 两者都不可得 → 算不出阈值，本 turn 不压缩（return undefined）。
+      let threshold = percentThreshold;
+      if (threshold === undefined) {
+        const contextWindow = ctx.config.model.contextWindow;
+        if (contextWindow > 0) {
+          const reserveForOutput = opts.reserveForOutput ?? Math.min(ctx.config.model.maxTokens, 4096);
+          threshold = contextWindow - reserveForOutput - safetyBuffer;
+        }
+      }
+      if (threshold === undefined) return undefined;
+
       // 未到 token 阈值 → 原样。tools / systemPrompt 由 ctx.config 提供，计入每请求随发的固定开销（X1）。
       const estimated = counter.estimate({
         messages,


### PR DESCRIPTION
**0.3.0 Wave B · X2**(epic #43,issue #57,基于 X1)。autoCompaction 的「估算体积 80%」百分比阈值升级为 per-model「有效窗口 − buffer」绝对阈值。D0:容忍型 provider 反应式 overflow 恢复无效 → 主动压缩是唯一防线、阈值要准。

## 改动
- **core**:`SessionConfigView.model` 从 `{id,provider}` 扩为 `{id,provider,contextWindow,maxTokens}`(取自 pi-ai Model 同名字段,纯加性向后兼容)。不硬编 per-model 表、不解析 `[1m]` id。
- **plugins**:autoCompaction 三路优先级 —— 显式 `maxContextTokens`(改可选)走旧百分比(19 个老测试不变);否则 `contextWindow>0` 走窗口路径 `effectiveWindow = contextWindow − reserveForOutput − safetyBuffer`(reserve 默认 min(maxTokens,4096)、buffer 默认 0);都不可得 → no-op。**阈值≤0 守卫**(reserve+buffer >= window 的 misconfig → no-op,不每 turn 空压)。范围限 autoCompaction。

## 验证
core 281 / plugins 290(+9 X2)/ 全 6 包 test + `pnpm -r build/typecheck` 全绿、下游无破坏。**review-gate 3/3 PASS**(footgun-guard 修复后)。

## ⚠️ 发布注意(CHANGELOG,延续 X1)
- 默认 counter 改 estimateRequestTokens → 阈值更准但触发**更早**;`estimateTokens→tokenCounter` 选项 breaking。

## 非阻塞 follow-up(review 列,不阻塞)
- session.ts 的 tool.parameters 浅冻注释理由略不准(model 字段是基元、parameters 是可变对象;真实原因是深冻 TypeBox 有风险 + first-party 信任)——收紧注释。
- 补一个 window-path + 默认 counter + 大 tool 的 composition 测试(锁 X1×X2 接缝)。

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)