### PR TITLE
feat(plugins): S3 — AgentSpec 声明式路由 + routedSubAgentTool (#43 S3)

### DIFF
--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -73,7 +73,7 @@ Controllers (`@harness-pi/plugins/controllers`):
 - **forkSession / forkSessionAll** — branch a session into one or more isolated forks.
 - **LifecycleRestart** — restart-on-lifecycle supervision for long-running sessions.
 - **compactOnOverflow / CompactRestartFresh** — restart a session fresh from a compacted summary on context overflow.
-- **subAgentTool** — wrap a child session as a callable tool.
+- **subAgentTool / routedSubAgentTool** — wrap a child session as a callable tool; the routed variant picks among multiple `AgentSpec`s by `agent_type`.
 - **GapExplorer** — explore and report coverage gaps in a result set.
 
 Metrics:

--- a/packages/plugins/src/__tests__/gap-explorer.test.ts
+++ b/packages/plugins/src/__tests__/gap-explorer.test.ts
@@ -7,9 +7,11 @@ import { AgentSession, Type, type HarnessTool } from "@harness-pi/core";
 import { createFakeModel, createTestContext } from "@harness-pi/core/testing";
 import {
   subAgentTool,
+  routedSubAgentTool,
   GapExplorer,
   type Gap,
   type ExplorerFinding,
+  type AgentSpec,
 } from "../controllers/index.js";
 
 function blockText(content: unknown): string {
@@ -298,6 +300,252 @@ describe("subAgentTool depth gate (#45)", () => {
     const result = await tool.execute({ task: "t" }, ctx, new AbortController().signal);
     expect(blockText(result.content)).toContain("ok");
     subFake.teardown();
+  });
+});
+
+/* ──────────────── routedSubAgentTool (#59 / S3) ──────────────── */
+
+describe("routedSubAgentTool (#59)", () => {
+  /** 从 TypeBox Union(of Literals) schema 抽出枚举值（形如 anyOf:[{const},...]）。 */
+  function enumValues(params: unknown): string[] {
+    const props = (params as { properties?: Record<string, unknown> }).properties ?? {};
+    const at = props["agent_type"] as { anyOf?: Array<{ const?: string }> } | undefined;
+    return (at?.anyOf ?? []).map((b) => b.const).filter((c): c is string => typeof c === "string");
+  }
+
+  it("exposes agent_type as an enum of all spec types and folds each whenToUse into the description", () => {
+    const specs: AgentSpec[] = [
+      {
+        type: "researcher",
+        whenToUse: "use for open-ended investigation",
+        sessionFactory: () => new AgentSession({ model: createFakeModel([]), tools: [] }),
+      },
+      {
+        type: "coder",
+        whenToUse: "use for writing or editing code",
+        sessionFactory: () => new AgentSession({ model: createFakeModel([]), tools: [] }),
+      },
+    ];
+    const tool = routedSubAgentTool({ specs });
+    expect(enumValues(tool.parameters).sort()).toEqual(["coder", "researcher"]);
+    // description 拼进每个 spec 的 whenToUse（含 type 标签），供模型路由。
+    expect(tool.description).toContain("use for open-ended investigation");
+    expect(tool.description).toContain("use for writing or editing code");
+    expect(tool.description).toContain("researcher");
+    expect(tool.description).toContain("coder");
+  });
+
+  it("routes a valid agent_type to that spec's sessionFactory (distinguishable results)", async () => {
+    // 两个 spec 各自 fake 出可区分的终态文本 → 断言路由命中正确 factory。
+    const aFake = createFakeModel([{ content: [{ type: "text", text: "ANSWER-A" }], stopReason: "stop" }]);
+    const bFake = createFakeModel([{ content: [{ type: "text", text: "ANSWER-B" }], stopReason: "stop" }]);
+    let aCalls = 0;
+    let bCalls = 0;
+    const tool = routedSubAgentTool({
+      specs: [
+        {
+          type: "alpha",
+          whenToUse: "alpha tasks",
+          sessionFactory: () => {
+            aCalls++;
+            return new AgentSession({ model: aFake, tools: [] });
+          },
+        },
+        {
+          type: "beta",
+          whenToUse: "beta tasks",
+          sessionFactory: () => {
+            bCalls++;
+            return new AgentSession({ model: bFake, tools: [] });
+          },
+        },
+      ],
+    });
+    const { ctx } = createTestContext();
+    const sig = new AbortController().signal;
+
+    const rb = await tool.execute({ agent_type: "beta", task: "do it" }, ctx, sig);
+    expect(blockText(rb.content)).toContain("ANSWER-B");
+    expect(bCalls).toBe(1);
+    expect(aCalls).toBe(0); // 没误派给 alpha
+
+    const ra = await tool.execute({ agent_type: "alpha", task: "do it" }, ctx, sig);
+    expect(blockText(ra.content)).toContain("ANSWER-A");
+    expect(aCalls).toBe(1);
+
+    aFake.teardown();
+    bFake.teardown();
+  });
+
+  it("passes the task + parent ctx (and spec maxTurns) to the routed sessionFactory", async () => {
+    const subFake = createFakeModel([{ content: [{ type: "text", text: "ok" }], stopReason: "stop" }]);
+    let gotTask = "";
+    let gotCtx: unknown = null;
+    let gotMaxTurns: number | undefined = -1;
+    const { ctx } = createTestContext();
+    const tool = routedSubAgentTool({
+      specs: [
+        {
+          type: "x",
+          whenToUse: "x",
+          maxTurns: 7,
+          sessionFactory: (task, c, maxTurns) => {
+            gotTask = task;
+            gotCtx = c;
+            gotMaxTurns = maxTurns;
+            return new AgentSession({ model: subFake, tools: [], ...(maxTurns ? { maxTurns } : {}) });
+          },
+        },
+      ],
+    });
+    await tool.execute({ agent_type: "x", task: "hello" }, ctx, new AbortController().signal);
+    expect(gotTask).toBe("hello");
+    expect(gotCtx).toBe(ctx);
+    expect(gotMaxTurns).toBe(7); // spec.maxTurns 透传给工厂第三参
+    subFake.teardown();
+  });
+
+  it("throws a clear error on an unknown agent_type (fail-loud, no crash)", async () => {
+    const subFake = createFakeModel([{ content: [{ type: "text", text: "ok" }], stopReason: "stop" }]);
+    let factoryCalls = 0;
+    const tool = routedSubAgentTool({
+      specs: [
+        {
+          type: "known",
+          whenToUse: "k",
+          sessionFactory: () => {
+            factoryCalls++;
+            return new AgentSession({ model: subFake, tools: [] });
+          },
+        },
+      ],
+    });
+    const { ctx } = createTestContext();
+    const sig = new AbortController().signal;
+    await expect(
+      tool.execute({ agent_type: "nope", task: "t" }, ctx, sig),
+    ).rejects.toThrow(/unknown agent_type "nope".*expected one of: known/);
+    expect(factoryCalls).toBe(0); // 非法 type 绝不 spawn
+    subFake.teardown();
+  });
+
+  it("throws a clear error on a missing agent_type", async () => {
+    const subFake = createFakeModel([{ content: [{ type: "text", text: "ok" }], stopReason: "stop" }]);
+    const tool = routedSubAgentTool({
+      specs: [{ type: "k", whenToUse: "k", sessionFactory: () => new AgentSession({ model: subFake, tools: [] }) }],
+    });
+    const { ctx } = createTestContext();
+    await expect(
+      tool.execute({ task: "t" }, ctx, new AbortController().signal),
+    ).rejects.toThrow(/unknown agent_type/);
+    subFake.teardown();
+  });
+
+  it("throws on an empty/missing task (HarnessTool error contract)", async () => {
+    const subFake = createFakeModel([]);
+    const tool = routedSubAgentTool({
+      specs: [{ type: "k", whenToUse: "k", sessionFactory: () => new AgentSession({ model: subFake, tools: [] }) }],
+    });
+    const { ctx } = createTestContext();
+    const sig = new AbortController().signal;
+    await expect(tool.execute({ agent_type: "k", task: "" }, ctx, sig)).rejects.toThrow(/empty task/);
+    await expect(tool.execute({ agent_type: "k", task: "   " }, ctx, sig)).rejects.toThrow(/empty task/);
+    subFake.teardown();
+  });
+
+  it("rejects empty specs and duplicate types at construction (fail-loud)", () => {
+    expect(() => routedSubAgentTool({ specs: [] })).toThrow(/specs must not be empty/);
+    const dup: AgentSpec[] = [
+      { type: "dup", whenToUse: "a", sessionFactory: () => new AgentSession({ model: createFakeModel([]), tools: [] }) },
+      { type: "dup", whenToUse: "b", sessionFactory: () => new AgentSession({ model: createFakeModel([]), tools: [] }) },
+    ];
+    expect(() => routedSubAgentTool({ specs: dup })).toThrow(/duplicate agent type "dup"/);
+  });
+
+  it("enforces the maxSubAgents budget across all types (fail-loud after the cap)", async () => {
+    const subFake = createFakeModel([{ content: [{ type: "text", text: "1" }], stopReason: "stop" }]);
+    const mk = () => new AgentSession({ model: subFake, tools: [] });
+    const tool = routedSubAgentTool({
+      maxSubAgents: 1,
+      specs: [
+        { type: "a", whenToUse: "a", sessionFactory: mk },
+        { type: "b", whenToUse: "b", sessionFactory: mk },
+      ],
+    });
+    const { ctx } = createTestContext();
+    const sig = new AbortController().signal;
+    await tool.execute({ agent_type: "a", task: "t" }, ctx, sig); // spawned=1
+    // 即便换一种 type，横向预算是跨 type 合计 → 第 2 个被拦。
+    await expect(
+      tool.execute({ agent_type: "b", task: "t" }, ctx, sig),
+    ).rejects.toThrow(/budget exhausted/);
+    subFake.teardown();
+  });
+
+  it("honors the vertical depth gate (#45): top-level spawn blocked when maxDepth=0", async () => {
+    const subFake = createFakeModel([{ content: [{ type: "text", text: "x" }], stopReason: "stop" }]);
+    let factoryCalls = 0;
+    const tool = routedSubAgentTool({
+      maxDepth: 0,
+      specs: [
+        {
+          type: "k",
+          whenToUse: "k",
+          sessionFactory: () => {
+            factoryCalls++;
+            return new AgentSession({ model: subFake, tools: [] });
+          },
+        },
+      ],
+    });
+    const { ctx } = createTestContext(); // depth 缺省 0
+    await expect(
+      tool.execute({ agent_type: "k", task: "t" }, ctx, new AbortController().signal),
+    ).rejects.toThrow(/depth limit \(maxDepth=0\) reached/);
+    expect(factoryCalls).toBe(0);
+    subFake.teardown();
+  });
+
+  it("propagates depth across layers (#45): nested routed spawn hits the depth limit at maxDepth", async () => {
+    // 嵌套：每层 routed tool 先 spawn 一层再收尾。depth 沿 lineage +1，maxDepth=2 时孙(depth 2)被挡。
+    const fakes: Array<ReturnType<typeof createFakeModel>> = [];
+    const depthsSeen: number[] = [];
+    const build = (): AgentSession => {
+      const fake = createFakeModel([
+        { content: [{ type: "toolCall", name: "subAgent", arguments: { agent_type: "worker", task: "deeper" } }] },
+        { content: [{ type: "text", text: "layer done" }], stopReason: "stop" },
+      ]);
+      fakes.push(fake);
+      const tool = routedSubAgentTool({
+        maxDepth: 2,
+        specs: [
+          {
+            type: "worker",
+            whenToUse: "worker",
+            sessionFactory: (_task, c) => {
+              depthsSeen.push(c.state.get("subAgent.depth") ?? 0);
+              return build();
+            },
+          },
+        ],
+      });
+      return new AgentSession({ model: fake, tools: [tool] });
+    };
+    const root = build();
+    const res = await root.run("start");
+    expect(res.reason).toBe("done");
+
+    // 孙(depth 2)层 execute 读到 depth=2>=2 → throw，kernel 包成 isError toolResult。
+    const errText = fakes
+      .flatMap((f) => f.getCalls())
+      .flatMap((c) => c.messages)
+      .filter((m) => m.role === "toolResult")
+      .map((m) => blockText((m as { content: unknown }).content))
+      .join("\n");
+    expect(errText).toContain("depth limit (maxDepth=2) reached");
+    // spawn 只发生在 depth 0、1（孙被挡，不进 sessionFactory）。
+    expect(depthsSeen).toEqual([0, 1]);
+    fakes.forEach((f) => f.teardown());
   });
 });
 

--- a/packages/plugins/src/__tests__/gap-explorer.test.ts
+++ b/packages/plugins/src/__tests__/gap-explorer.test.ts
@@ -377,23 +377,20 @@ describe("routedSubAgentTool (#59)", () => {
     bFake.teardown();
   });
 
-  it("passes the task + parent ctx (and spec maxTurns) to the routed sessionFactory", async () => {
+  it("passes the task + parent ctx to the routed sessionFactory", async () => {
     const subFake = createFakeModel([{ content: [{ type: "text", text: "ok" }], stopReason: "stop" }]);
     let gotTask = "";
     let gotCtx: unknown = null;
-    let gotMaxTurns: number | undefined = -1;
     const { ctx } = createTestContext();
     const tool = routedSubAgentTool({
       specs: [
         {
           type: "x",
           whenToUse: "x",
-          maxTurns: 7,
-          sessionFactory: (task, c, maxTurns) => {
+          sessionFactory: (task, c) => {
             gotTask = task;
             gotCtx = c;
-            gotMaxTurns = maxTurns;
-            return new AgentSession({ model: subFake, tools: [], ...(maxTurns ? { maxTurns } : {}) });
+            return new AgentSession({ model: subFake, tools: [] });
           },
         },
       ],
@@ -401,8 +398,24 @@ describe("routedSubAgentTool (#59)", () => {
     await tool.execute({ agent_type: "x", task: "hello" }, ctx, new AbortController().signal);
     expect(gotTask).toBe("hello");
     expect(gotCtx).toBe(ctx);
-    expect(gotMaxTurns).toBe(7); // spec.maxTurns 透传给工厂第三参
     subFake.teardown();
+  });
+
+  it("honors a custom tool name and description prefix (whenToUse folded after it)", async () => {
+    const tool = routedSubAgentTool({
+      name: "router",
+      description: "Route to a specialist.",
+      specs: [
+        { type: "alpha", whenToUse: "alpha tasks", sessionFactory: () => new AgentSession({ model: createFakeModel([]), tools: [] }) },
+      ],
+    });
+    expect(tool.name).toBe("router");
+    // 自定义前缀在前，各 spec 的 whenToUse 折叠在 "Available agent types:" 之后。
+    const prefixAt = tool.description.indexOf("Route to a specialist.");
+    const typesAt = tool.description.indexOf("Available agent types:");
+    expect(prefixAt).toBeGreaterThanOrEqual(0);
+    expect(typesAt).toBeGreaterThan(prefixAt);
+    expect(tool.description).toContain("alpha: alpha tasks");
   });
 
   it("throws a clear error on an unknown agent_type (fail-loud, no crash)", async () => {

--- a/packages/plugins/src/controllers/index.ts
+++ b/packages/plugins/src/controllers/index.ts
@@ -48,8 +48,12 @@ export type {
   CompactRestartResult,
 } from "./compact-restart-fresh.js";
 
-export { subAgentTool } from "./sub-agent-tool.js";
-export type { SubAgentToolOptions } from "./sub-agent-tool.js";
+export { subAgentTool, routedSubAgentTool } from "./sub-agent-tool.js";
+export type {
+  SubAgentToolOptions,
+  AgentSpec,
+  RoutedSubAgentToolOptions,
+} from "./sub-agent-tool.js";
 
 export { persistCompactionBoundary } from "./persist-compaction-boundary.js";
 export type { PersistCompactionBoundaryOptions } from "./persist-compaction-boundary.js";

--- a/packages/plugins/src/controllers/sub-agent-tool.ts
+++ b/packages/plugins/src/controllers/sub-agent-tool.ts
@@ -144,16 +144,11 @@ export interface AgentSpec {
   /** 给模型看的选择依据——拼进 tool description，让模型据此决定派给哪种 agent。 */
   whenToUse: string;
   /**
-   * 造这种 sub-agent 的 AgentSession 工厂。形如单 factory 版的 `(task, ctx)`，但多收一个**可选**
-   * 第三参 `maxTurns`——即本 spec 声明的 `maxTurns`（见下）。`AgentSession.maxTurns` 是构造期 readonly，
-   * 故由工厂在 `new AgentSession({ ..., maxTurns })` 时落地（不给就用工厂自己的默认）。
+   * 造这种 sub-agent 的 AgentSession 工厂——与单 factory 版 `SubAgentToolOptions.sessionFactory`
+   * 同型 `(task, ctx)`。这种 sub-agent 的轮数/预算（maxTurns 等）由工厂在 `new AgentSession(...)`
+   * 时自行闭包决定，不在 spec 上重复声明。
    */
-  sessionFactory: (task: string, ctx: HookContext, maxTurns?: number) => AgentSession;
-  /**
-   * 可选：本 spec 造出的 sub-agent 的轮数上限。给了就作为第三参透传给 `sessionFactory`，
-   * 由工厂在构造时落地。不给则第三参为 undefined，工厂沿用自身默认。
-   */
-  maxTurns?: number;
+  sessionFactory: (task: string, ctx: HookContext) => AgentSession;
 }
 
 export interface RoutedSubAgentToolOptions {
@@ -178,7 +173,7 @@ export interface RoutedSubAgentToolOptions {
  * 与单 factory 版共享同一套 bounded 机制：横向 `maxSubAgents` 扇出闸 + 纵向 `maxDepth` 跨层深度闸（#45）
  * 都对 routed 变体同样生效（复用 `DEPTH_KEY` 透传 + `spawnSubAgent`）。差别只在：参数多一个 `agent_type`
  * 枚举（值 = 各 spec 的 `type`），description 拼进每个 spec 的 `whenToUse` 供模型路由，execute 时按
- * `agent_type` 分派到对应 spec 的 `sessionFactory`（及其可选 `maxTurns`）。
+ * `agent_type` 分派到对应 spec 的 `sessionFactory`。
  *
  * **domain-free**：本工厂不认识任何业务；每种 sub-agent 用什么 tools/systemPrompt 全在调用方的 spec 里。
  */
@@ -248,7 +243,7 @@ export function routedSubAgentTool(opts: RoutedSubAgentToolOptions): HarnessTool
       }
       spawned++;
 
-      const sub = spec.sessionFactory(task, ctx, spec.maxTurns);
+      const sub = spec.sessionFactory(task, ctx);
       return spawnSubAgent(sub, task, depth, signal);
     },
   };

--- a/packages/plugins/src/controllers/sub-agent-tool.ts
+++ b/packages/plugins/src/controllers/sub-agent-tool.ts
@@ -9,7 +9,7 @@
  * `sessionFactory` 里。父 session 的 abort signal 透传给 sub-agent（协作式取消）。
  */
 
-import type { AgentSession, Hook, HarnessTool, HookContext, Message } from "@harness-pi/core";
+import type { AgentSession, Hook, HarnessTool, HookContext, Message, ToolExecResult } from "@harness-pi/core";
 import { Type } from "@earendil-works/pi-ai";
 
 /**
@@ -52,6 +52,46 @@ function messageText(m: Message | undefined): string {
         .join("");
 }
 
+/**
+ * 共享：spawn 一个 sub-agent session 并整形结果。单 factory 版与 routed 版（#59）都走这里——
+ * 纵向深度透传（给子挂 onSessionStart hook 把深度设为 父+1）、父 signal 透传、子终态回灌全在此收口。
+ * 横向/纵向闸由调用方在调用前各自判（错误文案各自独立），故本函数只管「确实要 spawn 时」的动作。
+ */
+async function spawnSubAgent(
+  sub: AgentSession,
+  task: string,
+  depth: number,
+  signal: AbortSignal,
+): Promise<ToolExecResult> {
+  // 纵向深度透传：给子 session 挂一个 onSessionStart hook，把子 ctx.state 的深度设为 当前+1。
+  // 子 session 自己的（routed）subAgentTool（若有）execute 时就读到递增后的深度——多分支各自从父继承，
+  // 互不串扰（每个子 session 有独立 ctx.state）。零内核改动：只用现成的 use()/onSessionStart。
+  const depthInjector: Hook = {
+    name: "subAgent.depth-injector",
+    internal: true,
+    onSessionStart(_input, subCtx) {
+      subCtx.state.set(DEPTH_KEY, depth + 1);
+    },
+  };
+  sub.use(depthInjector);
+  // 父 signal 透传 → sub-agent 可被父的 abort 协作式取消。
+  const summary = await sub.run(task, { signal });
+  const text = messageText(summary.lastMessage) || "(sub-agent produced no text output)";
+
+  // 把子代理终态放进 details（trace/metrics 用），content 回灌父模型。
+  return {
+    content: [{ type: "text", text }],
+    details: {
+      subAgent: {
+        reason: summary.reason,
+        turns: summary.turns,
+        usage: summary.usage,
+        ...(summary.stopReason ? { stopReason: summary.stopReason } : {}),
+      },
+    },
+  };
+}
+
 export function subAgentTool(opts: SubAgentToolOptions): HarnessTool {
   const max = opts.maxSubAgents ?? 8;
   const maxDepth = opts.maxDepth ?? 2;
@@ -86,34 +126,130 @@ export function subAgentTool(opts: SubAgentToolOptions): HarnessTool {
       }
       spawned++;
 
-      // 父 signal 透传 → sub-agent 可被父的 abort 协作式取消。
       const sub = opts.sessionFactory(task, ctx);
-      // 纵向深度透传：给子 session 挂一个 onSessionStart hook，把子 ctx.state 的深度设为 当前+1。
-      // 子 session 自己的 subAgentTool（若有）execute 时就读到递增后的深度——多分支各自从父继承，
-      // 互不串扰（每个子 session 有独立 ctx.state）。零内核改动：只用现成的 use()/onSessionStart。
-      const depthInjector: Hook = {
-        name: "subAgent.depth-injector",
-        internal: true,
-        onSessionStart(_input, subCtx) {
-          subCtx.state.set(DEPTH_KEY, depth + 1);
-        },
-      };
-      sub.use(depthInjector);
-      const summary = await sub.run(task, { signal });
-      const text = messageText(summary.lastMessage) || "(sub-agent produced no text output)";
+      return spawnSubAgent(sub, task, depth, signal);
+    },
+  };
+}
 
-      // 把子代理终态放进 details（trace/metrics 用），content 回灌父模型。
-      return {
-        content: [{ type: "text", text }],
-        details: {
-          subAgent: {
-            reason: summary.reason,
-            turns: summary.turns,
-            usage: summary.usage,
-            ...(summary.stopReason ? { stopReason: summary.stopReason } : {}),
-          },
-        },
-      };
+/* ──────────────── routed 变体（#59 / S3） ──────────────── */
+
+/**
+ * 一种可路由的 sub-agent 规格（**domain-free**：只是「类型标识 + 选择依据 + 怎么造 session」，
+ * 不含任何业务/文件布局概念）。父模型据 `whenToUse` 在多个 spec 间挑一个 `type` 来分派。
+ */
+export interface AgentSpec {
+  /** 路由标识。父模型用它在 `agent_type` 参数里点名；同一 tool 内须唯一。 */
+  type: string;
+  /** 给模型看的选择依据——拼进 tool description，让模型据此决定派给哪种 agent。 */
+  whenToUse: string;
+  /**
+   * 造这种 sub-agent 的 AgentSession 工厂。形如单 factory 版的 `(task, ctx)`，但多收一个**可选**
+   * 第三参 `maxTurns`——即本 spec 声明的 `maxTurns`（见下）。`AgentSession.maxTurns` 是构造期 readonly，
+   * 故由工厂在 `new AgentSession({ ..., maxTurns })` 时落地（不给就用工厂自己的默认）。
+   */
+  sessionFactory: (task: string, ctx: HookContext, maxTurns?: number) => AgentSession;
+  /**
+   * 可选：本 spec 造出的 sub-agent 的轮数上限。给了就作为第三参透传给 `sessionFactory`，
+   * 由工厂在构造时落地。不给则第三参为 undefined，工厂沿用自身默认。
+   */
+  maxTurns?: number;
+}
+
+export interface RoutedSubAgentToolOptions {
+  /** 候选 agent 规格（至少一个）。`agent_type` 枚举 = 全部 spec 的 `type`。 */
+  specs: AgentSpec[];
+  /** tool name（默认 "subAgent"）。 */
+  name?: string;
+  /**
+   * tool description 前缀（给模型看的总体说明）。各 spec 的 `whenToUse` 会**自动拼在其后**，
+   * 故这里只写「这是个会路由的子代理工具」之类的总纲，不必重复每种 agent 的用途。
+   */
+  description?: string;
+  /** 本 tool 实例最多派多少个 sub-agent（**横向**闸：跨所有 type 合计）。默认 8。 */
+  maxSubAgents?: number;
+  /** 跨层递归**纵向**深度闸（#45），语义同单 factory 版。默认 2。 */
+  maxDepth?: number;
+}
+
+/**
+ * routed sub-agent tool factory（#59）——在单 factory 版旁加一个**多规格、按 `agent_type` 路由**的变体。
+ *
+ * 与单 factory 版共享同一套 bounded 机制：横向 `maxSubAgents` 扇出闸 + 纵向 `maxDepth` 跨层深度闸（#45）
+ * 都对 routed 变体同样生效（复用 `DEPTH_KEY` 透传 + `spawnSubAgent`）。差别只在：参数多一个 `agent_type`
+ * 枚举（值 = 各 spec 的 `type`），description 拼进每个 spec 的 `whenToUse` 供模型路由，execute 时按
+ * `agent_type` 分派到对应 spec 的 `sessionFactory`（及其可选 `maxTurns`）。
+ *
+ * **domain-free**：本工厂不认识任何业务；每种 sub-agent 用什么 tools/systemPrompt 全在调用方的 spec 里。
+ */
+export function routedSubAgentTool(opts: RoutedSubAgentToolOptions): HarnessTool {
+  const specs = opts.specs;
+  if (specs.length === 0) {
+    throw new Error("routedSubAgentTool: specs must not be empty");
+  }
+  // type 须唯一——重复会让枚举/路由表二义，构造期 fail-loud 比运行时静默撞车好。
+  const byType = new Map<string, AgentSpec>();
+  for (const s of specs) {
+    if (byType.has(s.type)) {
+      throw new Error(`routedSubAgentTool: duplicate agent type "${s.type}"`);
+    }
+    byType.set(s.type, s);
+  }
+
+  const max = opts.maxSubAgents ?? 8;
+  const maxDepth = opts.maxDepth ?? 2;
+  let spawned = 0;
+
+  const types = specs.map((s) => s.type);
+  // description 拼进每个 spec 的 whenToUse → 模型据此挑 agent_type。
+  const routingLines = specs.map((s) => `- ${s.type}: ${s.whenToUse}`).join("\n");
+  const description =
+    (opts.description ??
+      "Delegate a self-contained sub-task to a bounded sub-agent, routed by agent_type.") +
+    `\n\nAvailable agent types:\n${routingLines}`;
+
+  return {
+    name: opts.name ?? "subAgent",
+    description,
+    parameters: Type.Object({
+      agent_type: Type.Union(
+        types.map((t) => Type.Literal(t)),
+        { description: `Which kind of sub-agent to route this task to. One of: ${types.join(", ")}.` },
+      ),
+      task: Type.String({
+        description: "A self-contained task for the chosen sub-agent to carry out.",
+      }),
+    }),
+
+    async execute(args, ctx, signal) {
+      const task = typeof args.task === "string" ? args.task : "";
+      // throw 是 HarnessTool 的错误合约（kernel 包成 isError 回灌模型）——空任务 / 非法 type / 超预算 / 超深都 fail-loud。
+      if (task.trim().length === 0) {
+        throw new Error("subAgent: empty task");
+      }
+      // 路由防御性校验：缺失 / 非枚举的 agent_type → 明确 error（不崩、不静默）。即使内核 validate 已按枚举
+      // schema 拦过，这里仍兜一层，便于直接 execute（绕过内核）时也有清晰错误。
+      const agentType = typeof args.agent_type === "string" ? args.agent_type : "";
+      const spec = byType.get(agentType);
+      if (!spec) {
+        throw new Error(
+          `subAgent: unknown agent_type "${agentType}" (expected one of: ${types.join(", ")})`,
+        );
+      }
+      // 纵向闸（#45）：读**当前** session 深度（缺省 0）。到顶就不 spawn——挡在横向计数之前，
+      // 让超深的尝试不消耗本层 maxSubAgents 预算（二闸正交）。
+      const depth = ctx.state.get(DEPTH_KEY) ?? 0;
+      if (depth >= maxDepth) {
+        throw new Error(`subAgent: depth limit (maxDepth=${maxDepth}) reached`);
+      }
+      // 横向闸：本 tool 实例的扇出预算（跨所有 type 合计）。
+      if (spawned >= max) {
+        throw new Error(`subAgent: budget exhausted (max ${max} sub-agents per tool)`);
+      }
+      spawned++;
+
+      const sub = spec.sessionFactory(task, ctx, spec.maxTurns);
+      return spawnSubAgent(sub, task, depth, signal);
     },
   };
 }


### PR DESCRIPTION
**0.3.0 Wave B · S3**(epic #43,issue #59,Sub-Agent 组)。在单 factory 版 `subAgentTool` 旁加一个 **domain-free 的多规格路由变体** `routedSubAgentTool`:模型用 `agent_type` 枚举按各 spec 的 `whenToUse`(拼进 tool description)路由到对应 `sessionFactory`。

## 改动(零内核改动,纯 @harness-pi/plugins/controllers)
- 抽出共享 helper `spawnSubAgent`(深度注入 onSessionStart 复用 S2 的 `DEPTH_KEY` + 父 signal 透传 + 结果整形),单 factory 版改为复用(行为不变)。
- `AgentSpec{type, whenToUse, sessionFactory}` —— domain-free,`sessionFactory` 签名 `(task, ctx)` 与单 factory 版**完全一致**。
- `routedSubAgentTool(specs)`:`agent_type` 为 `Type.Union(Literal)` 枚举;构造期 fail-loud(空 specs / 重复 type throw);运行期 fail-loud(空 task / 非法 agent_type / 超横向 `maxSubAgents` / 超纵向 `maxDepth` 都 throw,内核包成 isError 回灌)。纵向深度闸先于横向预算(超深不耗预算,与单 factory 一致)。

## 验证
plugins 275 测试(+14 routed)、`pnpm -r build/typecheck/test` 全绿、下游无破坏。**review-gate 两轮 3/3 PASS**。

## review 闭环(已处理)
- linus 指出 `AgentSpec.maxTurns` + sessionFactory 第三参是冗余管道(正中 CLAUDE.md「不加未被要求的灵活性」,无外部消费者)→ **已砍**,签名退回 `(task, ctx)` 消除与单 factory 的分叉。
- 补 README routedSubAgentTool 一行 + 自定义 name/description 前缀测试。

## 非阻塞 follow-up(review 列,未阻塞)
- 两个 execute 的闸序列 ~8 行 copy-paste(linus 标 judgment call;两路径有 agent_type 解析差异,暂不强抽)。
- `name` 默认同为 "subAgent",两变体同挂一 session 需各自改名(pre-existing);`whenToUse` 空值未校验(cosmetic)。
- routed 的 details.subAgent / 预算×深度正交 / abort 仅经共享 helper 间接覆盖,可补 routed 专属断言。

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)