### PR TITLE
feat(tools): X3 — read 大输出 token 维度封顶(maxTokens)(#43 X3)

### DIFF
--- a/packages/tools/src/__tests__/pi-compat.test.ts
+++ b/packages/tools/src/__tests__/pi-compat.test.ts
@@ -39,7 +39,8 @@ const PI_053_CODING_DEFAULTS = ["read", "bash", "edit", "write"] as const;
 const PI_053_READ_ONLY_DEFAULTS = ["read", "grep", "find", "ls"] as const;
 
 const PI_053_SCHEMA_KEYS = {
-  read: ["path", "offset", "limit"],
+  // maxTokens 是 X3(#60)的第一方扩展,有意超出上游 0.53 的 read schema。
+  read: ["path", "offset", "limit", "maxTokens"],
   bash: ["command", "timeout"],
   edit: ["path", "oldText", "newText"],
   write: ["path", "content"],

--- a/packages/tools/src/__tests__/tools.test.ts
+++ b/packages/tools/src/__tests__/tools.test.ts
@@ -187,7 +187,43 @@ describe("read tool", () => {
       limit: 5,
       maxTokens: 100,
     });
-    expect(text(sliced)).toContain("xxxx");
+    // 切片成功路径要精确钉住窗口大小:以 5 行原文开头、且不含第 6 行
+    // (read 对部分读会追加续读页脚,故不能整串相等;但"恰好 5 行"必须钉死)。
+    const fiveLines = Array.from({ length: 5 }, () => "x".repeat(40)).join("\n");
+    const sixLines = Array.from({ length: 6 }, () => "x".repeat(40)).join("\n");
+    expect(text(sliced).startsWith(fiveLines)).toBe(true);
+    expect(text(sliced).startsWith(sixLines)).toBe(false);
+  });
+
+  it("treats an estimate exactly equal to maxTokens as within the cap (boundary, not off-by-one)", async () => {
+    // 整个特性就是一个阈值判定 `estimated > maxTokens`——把临界点两侧都钉死,
+    // 防 `>` 被改成 `>=` 这类回归在边界静默改变行为。
+    await writeFile(path.join(dir, "exact.txt"), "x".repeat(40)); // 40B / 4 = 10 === cap
+    const atCap = await runTool(createReadTool(dir), { path: "exact.txt", maxTokens: 10 });
+    expect(text(atCap)).toBe("x".repeat(40)); // 恰好等于 → 返回完整内容,不 throw
+
+    await writeFile(path.join(dir, "over.txt"), "x".repeat(41)); // 41B / 4 → ceil = 11 > cap
+    await expect(
+      runTool(createReadTool(dir), { path: "over.txt", maxTokens: 10 }),
+    ).rejects.toThrow(/exceeds maxTokens=10/); // 超 1 token → throw
+  });
+
+  it("rejects a negative maxTokens via the shared positive-integer validator", async () => {
+    await writeFile(path.join(dir, "notes.txt"), "hi");
+    await expect(
+      runTool(createReadTool(dir), { path: "notes.txt", maxTokens: -1 }),
+    ).rejects.toThrow(/must be a non-negative number/);
+  });
+
+  it("still applies normal byte truncation when content is within maxTokens", async () => {
+    // token 检查跑在 truncateHead 之前的 selected 上;未超 cap 时不该干扰既有 lines/bytes 截断。
+    await writeFile(path.join(dir, "big.txt"), "x".repeat(400)); // 400B / 4 = 100 估算
+    const result = await runTool(createReadTool(dir, { maxBytes: 100 }), {
+      path: "big.txt",
+      maxTokens: 200, // 100 <= 200 → 不 throw,落到字节截断
+    });
+    expect(result.details).toBeDefined(); // 发生了截断(details 带 truncation 元数据)
+    expect(Buffer.byteLength(text(result), "utf8")).toBeLessThan(400); // 返回的是截断后内容
   });
 
   it("rejects symlink escapes and bounded default exports reject outside cwd", async () => {

--- a/packages/tools/src/__tests__/tools.test.ts
+++ b/packages/tools/src/__tests__/tools.test.ts
@@ -123,6 +123,73 @@ describe("read tool", () => {
     expect(text(result)).toBe("outside");
   });
 
+  it("behaves identically to default truncation when maxTokens is unset", async () => {
+    await writeFile(path.join(dir, "notes.txt"), ["one", "two", "three"].join("\n"));
+    const withoutCap = await runTool(createReadTool(dir), { path: "notes.txt" });
+    expect(text(withoutCap)).toBe("one\ntwo\nthree");
+    expect(withoutCap.details).toBeUndefined();
+  });
+
+  it("returns content when estimated tokens are within maxTokens", async () => {
+    await writeFile(path.join(dir, "notes.txt"), "x".repeat(40));
+    // 40 bytes / 4 = 10 estimated tokens, under the cap.
+    const result = await runTool(createReadTool(dir), {
+      path: "notes.txt",
+      maxTokens: 100,
+    });
+    expect(text(result)).toBe("x".repeat(40));
+  });
+
+  it("returns a short error guiding offset+limit when maxTokens is exceeded", async () => {
+    await writeFile(path.join(dir, "big.txt"), "x".repeat(4_000));
+    // 4000 bytes / 4 = 1000 estimated tokens, over the cap of 100.
+    const promise = runTool(createReadTool(dir), {
+      path: "big.txt",
+      maxTokens: 100,
+    });
+    await expect(promise).rejects.toThrow(/exceeds maxTokens=100/);
+    await expect(promise).rejects.toThrow(/~1000 tokens/);
+    await expect(promise).rejects.toThrow(/offset\+limit/i);
+    const err = await promise.catch((e: Error) => e);
+    expect(Buffer.byteLength((err as Error).message, "utf8")).toBeLessThan(200);
+    // Does not leak truncated file content into the error message.
+    expect((err as Error).message).not.toContain("xxxx");
+  });
+
+  it("estimates denser bytesPerToken for json/jsonl than other extensions", async () => {
+    const payload = "x".repeat(300);
+    await writeFile(path.join(dir, "data.json"), payload);
+    await writeFile(path.join(dir, "data.txt"), payload);
+    // 300 bytes: json -> ceil(300/2)=150 tokens, txt -> ceil(300/4)=75 tokens.
+    // A cap of 100 trips the .json file but not the .txt file.
+    await expect(
+      runTool(createReadTool(dir), { path: "data.json", maxTokens: 100 }),
+    ).rejects.toThrow(/~150 tokens/);
+    const txtResult = await runTool(createReadTool(dir), {
+      path: "data.txt",
+      maxTokens: 100,
+    });
+    expect(text(txtResult)).toBe(payload);
+  });
+
+  it("estimates tokens on the offset+limit slice so a smaller range succeeds", async () => {
+    await writeFile(
+      path.join(dir, "lines.txt"),
+      Array.from({ length: 20 }, () => "x".repeat(40)).join("\n"),
+    );
+    // Whole file ~20*41/4 ≈ 205 tokens > 100, but a 5-line slice is well under.
+    await expect(
+      runTool(createReadTool(dir), { path: "lines.txt", maxTokens: 100 }),
+    ).rejects.toThrow(/exceeds maxTokens=100/);
+    const sliced = await runTool(createReadTool(dir), {
+      path: "lines.txt",
+      offset: 1,
+      limit: 5,
+      maxTokens: 100,
+    });
+    expect(text(sliced)).toContain("xxxx");
+  });
+
   it("rejects symlink escapes and bounded default exports reject outside cwd", async () => {
     const outside = path.join(path.dirname(dir), `${path.basename(dir)}-secret.txt`);
     await writeFile(outside, "secret");

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -24,6 +24,7 @@ import {
   DEFAULT_MAX_BYTES,
   DEFAULT_MAX_LINES,
   GREP_MAX_LINE_LENGTH,
+  estimateReadTokens,
   formatSize,
   truncateHead,
   truncateLine,
@@ -225,6 +226,7 @@ export function createReadTool(
       path: Type.String({ description: "Path to the file to read (relative or absolute)" }),
       offset: Type.Optional(Type.Number({ description: "Line number to start reading from (1-indexed)" })),
       limit: Type.Optional(Type.Number({ description: "Maximum number of lines to read" })),
+      maxTokens: Type.Optional(Type.Number({ description: "If the estimated token count of the content exceeds this, return a short error instead of content. Re-read a smaller range with offset+limit." })),
     }),
     isConcurrencySafe: () => true,
     async execute(args, _ctx, signal) {
@@ -256,6 +258,7 @@ export function createReadTool(
         requestedPath,
         offset: asOptionalPositiveInteger(args["offset"], "offset"),
         limit: asOptionalPositiveInteger(args["limit"], "limit"),
+        maxTokens: asOptionalPositiveInteger(args["maxTokens"], "maxTokens"),
         maxLines: options.maxLines,
         maxBytes: options.maxBytes,
       });
@@ -715,6 +718,7 @@ function buildReadTextOutput(opts: {
   requestedPath: string;
   offset?: number | undefined;
   limit?: number | undefined;
+  maxTokens?: number | undefined;
   maxLines?: number | undefined;
   maxBytes?: number | undefined;
 }): ReadTextOutput {
@@ -733,6 +737,15 @@ function buildReadTextOutput(opts: {
     userLimitedLines = endLine - startLine;
   } else {
     selected = allLines.slice(startLine).join("\n");
+  }
+
+  if (opts.maxTokens !== undefined) {
+    const estimated = estimateReadTokens(selected, opts.requestedPath);
+    if (estimated > opts.maxTokens) {
+      throw new Error(
+        `Content ~${estimated} tokens exceeds maxTokens=${opts.maxTokens}. Retry with offset+limit to read in smaller chunks.`,
+      );
+    }
   }
 
   const truncation = truncateHead(selected, {

--- a/packages/tools/src/truncate.ts
+++ b/packages/tools/src/truncate.ts
@@ -27,6 +27,17 @@ export function formatSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
 }
 
+/**
+ * Self-contained char-based token estimate for read output. Denser formats
+ * (json/jsonl) pack fewer chars per token, so use 2 bytes/token there and
+ * 4 bytes/token elsewhere. Estimate = ceil(utf8 bytes / bytesPerToken).
+ */
+export function estimateReadTokens(content: string, filePath: string): number {
+  const ext = filePath.slice(filePath.lastIndexOf(".") + 1).toLowerCase();
+  const bytesPerToken = ext === "json" || ext === "jsonl" ? 2 : 4;
+  return Math.ceil(Buffer.byteLength(content, "utf8") / bytesPerToken);
+}
+
 export function truncateHead(
   content: string,
   options: TruncationOptions = {},


### PR DESCRIPTION
**0.3.0 Wave C · X3**(epic #43,issue #60,Context 组,软依赖已完成的 X1)。给 `@harness-pi/tools` 的 read 加可选 `maxTokens`,补上 cc Read 有而我们缺的 token 维度封顶(此前 `truncate.ts` 仅 lines/bytes)。

## 改动(零内核改动、不依赖 @harness-pi/plugins)
- `truncate.ts`:自包含 `estimateReadTokens(content, filePath)` = `ceil(utf8字节 / bytesPerToken)`,`bytesPerToken` 按扩展名(json/jsonl=2,其余=4)。
- `read` schema 加可选 `maxTokens`;在选出 offset/limit 片段后、`truncateHead` 前估算,**超限 throw 一条 <200B 引导 error**(含估算 token 数/上限/用 offset+limit 重试),不返回截断内容、不泄漏文件内容。
- 估算针对 **offset/limit 选定片段**(故缩小 limit 能落回 cap 下,重试引导才真有效);token 检查与既有 byte/line 截断互不干扰。

## 默认 opt-in / 兼容
未设 `maxTokens` 时行为与 0.2.x **完全一致**(仅 lines/bytes 截断)。`pi-compat.test.ts` 的 read schema 对齐表有意更新为含 maxTokens(第一方扩展,已加注释)。

## 验证
tools **59 测试**(+8 X3 行为:未设一致 / 未超限返回 / 超限 <200B error 不泄漏 / json·jsonl 更密 / 切片估算 / **阈值临界点两侧** / 负数校验 / 与字节截断互不干扰)、`pnpm -r build/typecheck` 干净、下游无破坏。

## review 闭环
首轮 FAIL(2/3):test-review 阻塞=缺阈值临界点测试(防 `>`→`>=` 静默回归)。已补边界两侧(40B/cap10 估=10 返完整内容;41B→ceil11>10 抛)+ 负数校验 + 截断交互 + 切片精确钉窗口。**确定性重审 3/3 PASS**(因 review-gate workflow 串台,改用 inline-diff 终审,见下)。

## 非阻塞 follow-up(review 列,未阻塞)
- `asOptionalPositiveInteger` 误名:放行 `maxTokens:0`(合法但对非空文件永远 throw 的废值)——复用既有校验器是对的,收紧到 `>0` 是全局 follow-up。
- 估算全用 ASCII 测;可补一条 CJK/emoji(utf8 字节≠字符)锁「按字节估」语义。
- token 检查在 byte 截断之前可加一行注释点明设计意图。

Closes #60