### PR TITLE
fix(core): 非越界 LLM 错误提级为 reason=error,不再静默成 done (#53)

### DIFF
--- a/packages/core/src/__tests__/event-bus.test.ts
+++ b/packages/core/src/__tests__/event-bus.test.ts
@@ -133,7 +133,8 @@ describe("Event Bus · live token deltas via on()", () => {
 
   it("on a runtime LLM error (error EVENT, not a sync throw) message_end still carries the error message", async () => {
     // Real providers surface runtime errors as an `error` stream event → result() RESOLVES to a
-    // stopReason="error" message (does NOT reject) → success path → message_end carries that message.
+    // stopReason="error" message (does NOT reject). The kernel emits message_end with that message
+    // BEFORE escalating the turn to reason="error" (#53), so message_end still carries it.
     // Downstream must judge failure by message.stopReason, not by message presence.
     const fake = createFakeModel([{ content: [], throwError: new Error("api 500") }]);
     const session = new AgentSession({ model: fake, tools: [], consoleSink: () => {} });

--- a/packages/core/src/__tests__/terminal-result.test.ts
+++ b/packages/core/src/__tests__/terminal-result.test.ts
@@ -116,20 +116,38 @@ describe("RunSummary as typed terminal result", () => {
     fake.teardown();
   });
 
-  it("provider-reported error (error EVENT, resolves) lands the error message as lastMessage, with reason='done'", async () => {
-    // distinct from streamThrows (sync throw -> catch -> reason='error', no lastMessage). Here
-    // result() RESOLVES a stopReason='error' assistant which IS pushed, so lastMessage is present.
-    // PINNED CONTRACT: this is complete()-equivalent — the loop only reports reason='error' on a
-    // genuine THROW; a provider error surfaced as a resolved message is a normal turn (stopReason
-    // != toolUse) => reason='done'. The failure on THIS path is signaled by lastMessage.stopReason,
-    // not by summary.reason (matches RunSummary.lastMessage doc).
+  it("escalates a resolved non-overflow error-stopReason to reason='error' and fires onError (#53)", async () => {
+    // Two LLM failure modes are now UNIFIED:
+    //   - streamThrows (sync throw) -> catch -> reason='error', no lastMessage.
+    //   - error EVENT: result() RESOLVES a stopReason='error' assistant (IS pushed, so lastMessage
+    //     is present). #53: this used to be silently treated as a normal turn => reason='done',
+    //     which let headless callers mistake auth/rate-limit failures for success. Now it escalates.
+    // (Overflow-classified errors still flow through onContextOverflow and keep reason='done' — see
+    // context-overflow.test.ts; THIS is the non-overflow error path.)
     const fake = createFakeModel([{ content: [], throwError: new Error("api 500") }]);
-    const session = new AgentSession({ model: fake, tools: [], consoleSink: () => {} });
+    const errs: Array<{ phase: string; message: string }> = [];
+    const session = new AgentSession({
+      model: fake,
+      tools: [],
+      consoleSink: () => {},
+      hooks: [
+        {
+          name: "err-watch",
+          onError: (i) => {
+            errs.push({ phase: i.phase, message: i.err.message });
+          },
+        },
+      ],
+    });
     const summary = await session.run("hi");
+    expect(summary.reason).toBe("error"); // #53: no longer silently 'done'
+    expect(summary.error?.message).toContain("api 500"); // errorMessage surfaced in RunSummary.error
+    // The error message still lands as lastMessage too (resolved + pushed before escalation).
     expect(summary.lastMessage).toBeDefined();
     expect(summary.lastMessage?.stopReason).toBe("error");
     expect(summary.stopReason).toBe("error");
-    expect(summary.reason).toBe("done"); // NOT 'error' — failure is in lastMessage.stopReason here
+    // onError fired exactly once with phase='llm' (observability; mirrors the sync-throw path).
+    expect(errs).toEqual([{ phase: "llm", message: "api 500" }]);
     fake.teardown();
   });
 

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -1326,7 +1326,9 @@ export class AgentSession {
     //     API error 报回，pi-ai 转成 error 流事件 → result() resolve 出 stopReason==="error"）。
     // 内核只「发事件」，不再当普通 done 静默吞掉；压缩/重启策略全在插件（ctx.abort("compaction:...")
     // → compactRestartFresh 重启 fresh，或 transformMessagesBeforeLlm 改写消息）。注意 fire 不改控制流：
-    // 没策略 abort 时这条 length/error assistant 仍以 reason:"done" 收尾。connection/config 类 sync-throw
+    // 没策略 abort 时这条 length / overflow-error assistant 仍以 reason:"done" 收尾（契约不变）。
+    // 但**非 overflow** 的 error-stopReason（坏 apiKey 401 / 限流 / 其它 provider 错误）会被下面的
+    // else-if 提级为 reason:"error"（#53），不再静默成 done。connection/config 类 sync-throw
     //（provider 未注册）走上面的 catch，不是 overflow，不在此分类。
     const overflow = this._detectOverflow(assistant);
     if (overflow) {
@@ -1336,6 +1338,17 @@ export class AgentSession {
         this._ctx,
       );
       this._flushSystemMessages(coOut.systemMessages);
+    } else if (assistant.stopReason === "error") {
+      // 非 overflow 的 resolved error-stopReason（#53）：此前因「无 tool call」被 turn loop 当正常完成
+      // → reason="done"，headless 调用方分不清硬错误与成功。修复：与同步抛路径（上面的 catch）一致——
+      // fire onError（可观测，插件可记录/决策；observe-only 不改控制流）后 throw，经 _runOneTurn 既有
+      // catch 提级 reason="error" + summary.error。两种 LLM 失败模式自此统一。assistant 已入 messages
+      //（lastMessage 仍带 errorMessage），message_end 也已发，故抛在此处不破坏 live 事件配对。
+      const err = new Error(
+        assistant.errorMessage ?? 'LLM call ended with stopReason="error"',
+      );
+      await this._dispatcher.fireError({ phase: "llm", err }, this._ctx);
+      throw err;
     }
 
     return assistant;


### PR DESCRIPTION
**D0 挖出的真 bug**(P1,issue #53)。pi-ai 把 provider runtime 错误(坏 apiKey 401 / 限流等)表达成「`result()` **resolve** 出一条 `stopReason="error"` 的 assistant」(非 reject/throw)。内核此前因该 assistant「无 tool call」被 turn loop 当正常完成 → `RunSummary.reason="done"`,headless 调用方(engram/bidding-agent)只看 reason **分不清硬错误与成功**。

## 修复(零新事件、零新字段)
`_phaseLlmCall` 尾部、overflow 检测的 **else 分支**,对**非 overflow** 的 `error-stopReason`:fire `onError({phase:"llm", err})`(observe-only,不改控制流,与同步抛路径一致的可观测性)→ `throw`。该 throw 经 `_runOneTurn` **既有 catch** 提级 `reason="error"` + `summary.error`。两种 LLM 失败模式(同步抛 vs resolved error)自此统一走同一条管道、`summary.error`/`onError` byte-for-byte 一致。

## 不变量保持(已逐条核验)
- **overflow 契约不变**:`length` 与「命中 overflow 文案的 error」仍走 `_detectOverflow→onContextOverflow`、**不进**新 else-if;无策略 abort 时仍 `reason="done"`。新 else-if 仅在 `_detectOverflow` 返回 null 时触发。
- **同步抛路径**(streamThrows / provider 未注册)仍走上面的 catch,不变。
- **live 事件配对**:assistant 已先 push(messages 末条带 errorMessage)、`message_end` 已发(携 error 消息),再抛——不破坏 message_start/end 配对。
- 空 errorMessage 也提级(`errorMessage ?? 兜底文案`)。

## 有意的契约翻转 + 全仓 throwError 审计
`terminal-result.test.ts` 原 PINNED CONTRACT「resolved error→reason=done」**正是 #53 的 bug**,翻转为新契约(reason=error + summary.error + onError fire phase=llm)。其余所有 resolved-error(`throwError`)用例已逐条复核**对翻转鲁棒**(只松断言、不断言 reason):
- `context-overflow.test.ts` 401 鉴权失败 / 空 errorMessage / 自定义谓词 → 只断言 overflow 是否 fire ✓
- `compact-restart-fresh.test.ts` → errorMessage 命中 overflow 文案,走 overflow 分支 ✓
- `event-bus.test.ts` message_end 带 error 消息(注释已订正)/ 无 message_update ✓
- `phase3-capabilities.test.ts` → 只断言 session-end 存在,不 pin reason ✓

## 验证
全仓 `pnpm -r build/typecheck/test` 全绿:core 281 / plugins 301 / tools 59 / adapters 61(+18 skip)/ coding-agent 240。**确定性 review-gate 3/3 PASS**(因 review-gate workflow 串台,改用 inline-diff 终审)。

## 非阻塞 follow-up(accepted,未阻塞)
- 极端 corner:hook 恰在 onLlmEnd 期间 ctx.abort() 且本 turn 是非 overflow error → 现得 reason="error" 而非 "aborted"。**有意不加 `!aborted` 守卫**:这种场景 hook 多半正因 error 才 abort,reason=error 更有信息;两者皆可辩。
- 若将来出现第三种 LLM 失败表达,可把「fire+throw」收成私有 helper(现在抽属过度设计)。

Closes #53