### PR TITLE
release: v0.2.3 — Context/估算正确性 + Sub-Agent 路由 + 错误提级 + D0 真机验证

### DIFF
--- a/apps/coding-agent/package.json
+++ b/apps/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-pi/coding-agent",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Dogfood coding agent built on harness-pi — usable pi-tui CLI showcasing the harness-pi kernel",
   "license": "MIT",
   "repository": {

--- a/apps/coding-agent/scripts/d0-smoke.ts
+++ b/apps/coding-agent/scripts/d0-smoke.ts
@@ -1,0 +1,208 @@
+/**
+ * D0 (#44): 真 DashScope provider smoke —— 把成熟度从「机制已实现」推到「provider 已验证」。
+ *
+ * 不进 `pnpm test`(真 API 外呼 + 花费)。手动跑(key 经 env 注入,不硬编码、不落盘):
+ *   DASHSCOPE_API_KEY=$(security find-generic-password -a "$USER" -s DASHSCOPE_API_KEY -w) \
+ *     pnpm --filter @harness-pi/coding-agent exec tsx scripts/d0-smoke.ts
+ *   # 可选:D0_MODEL=qwen-turbo(更便宜)覆盖默认 qwen-plus
+ *
+ * 验证目标(本仓刚发的修复在真 provider 下成立):
+ *   A. streaming + tool call 端到端:reason=done、真 streaming delta、tool 往返。
+ *   A'. X1/X2 估算校准:estimateRequestTokens(turn-0 含 tool schema) vs 真 usage.input 偏差。
+ *   B. provider error(坏 apiKey):#53 —— 真 401 → reason=error(不再静默 done)、不误判 overflow。
+ *   C. 容忍型 provider 探针:大(但 < 窗口)prompt 正常完成、不误 fire overflow(记录为何真 overflow 不便宜)。
+ */
+import { AgentSession, type HarnessTool } from "@harness-pi/core";
+import { estimateRequestTokens } from "@harness-pi/plugins";
+import { Type } from "@earendil-works/pi-ai";
+import { resolveDashScopeModel } from "../src/providers/dashscope.js";
+
+const MODEL_ID = process.env.D0_MODEL ?? "qwen-plus";
+const key = process.env.DASHSCOPE_API_KEY;
+if (!key) {
+  console.error(
+    "[D0] 缺 DASHSCOPE_API_KEY。跑法:DASHSCOPE_API_KEY=$(security find-generic-password -a \"$USER\" -s DASHSCOPE_API_KEY -w) pnpm --filter @harness-pi/coding-agent exec tsx scripts/d0-smoke.ts",
+  );
+  process.exit(2);
+}
+
+let failures = 0;
+function check(name: string, cond: boolean, detail = ""): void {
+  console.log(`  ${cond ? "✓" : "✗"} ${name}${detail ? ` — ${detail}` : ""}`);
+  if (!cond) failures++;
+}
+
+const addTool: HarnessTool = {
+  name: "add",
+  description: "Add two integers and return the sum.",
+  parameters: Type.Object({
+    a: Type.Number({ description: "first integer" }),
+    b: Type.Number({ description: "second integer" }),
+  }),
+  isConcurrencySafe: () => true,
+  async execute(args) {
+    const a = Number((args as { a: number }).a);
+    const b = Number((args as { b: number }).b);
+    return { content: [{ type: "text", text: String(a + b) }] };
+  },
+};
+
+async function testA(): Promise<void> {
+  console.log(`\n[A] streaming + tool call + 估算校准 (model=${MODEL_ID})`);
+  const { model, llmOptions } = resolveDashScopeModel(MODEL_ID, {
+    DASHSCOPE_API_KEY: key,
+  });
+  const systemPrompt =
+    "You are a calculator. When asked to add numbers, you MUST call the add tool, then reply with only the resulting number.";
+  const userPrompt = "What is 2 + 3? Use the add tool, then give me just the number.";
+
+  let deltaCount = 0;
+  let toolCalled = false;
+  let firstRealInput: number | undefined;
+
+  const session = new AgentSession({
+    model,
+    tools: [addTool],
+    systemPrompt,
+    llmOptions,
+    maxTurns: 6,
+    consoleSink: () => {},
+    hooks: [
+      {
+        name: "d0-probe",
+        // 记 turn-0 真实 prompt token(第一次 LLM 调用的 usage.input)。
+        onLlmEnd: (input) => {
+          if (firstRealInput === undefined) {
+            firstRealInput = input.msg.usage?.input;
+          }
+        },
+      },
+    ],
+  });
+  session.on("text_delta", () => deltaCount++);
+  session.on("message_end", (e) => {
+    const msg = e.message as { content?: Array<{ type: string }> } | undefined;
+    if (msg?.content?.some((b) => b.type === "toolCall")) toolCalled = true;
+  });
+
+  const summary = await session.run(userPrompt);
+  const finalText = ((summary.lastMessage?.content ?? []) as Array<{ type: string; text?: string }>)
+    .filter((b) => b.type === "text")
+    .map((b) => b.text ?? "")
+    .join("");
+
+  check("reason === 'done'", summary.reason === "done", `reason=${summary.reason}`);
+  check("tool 'add' 被调用", toolCalled);
+  check("streaming delta > 0(真流式)", deltaCount > 0, `deltas=${deltaCount}`);
+  check("最终回答含 '5'", finalText.includes("5"), `final="${finalText.slice(0, 60)}"`);
+
+  // X1/X2 校准:turn-0 请求级估算(含 tool schema)vs 真 usage.input。
+  const est = estimateRequestTokens({
+    messages: [{ role: "user", content: [{ type: "text", text: userPrompt }], timestamp: 0 }],
+    tools: [addTool],
+    systemPrompt,
+  });
+  if (firstRealInput && firstRealInput > 0) {
+    const ratio = firstRealInput / est;
+    console.log(
+      `  · 估算校准:estimateRequestTokens(turn-0)=${est}  vs  真 usage.input=${firstRealInput}  → 真/估=${ratio.toFixed(2)}x`,
+    );
+    // X1 修复前是纯 char 估算、~7x 低估(真/估 ≫ 1)。修复后应锁进一个合理带:
+    // 上界 3x 防低估(危险侧:阈值触发偏晚),下界 0.5x 防 estimator 朝过高方向漂移。
+    check(
+      "估算锁进合理区间(0.5x ≤ 真/估 ≤ 3x)",
+      ratio >= 0.5 && ratio <= 3,
+      `真/估=${ratio.toFixed(2)}x(X1 修复前约 7x)`,
+    );
+  } else {
+    // 校准是本 smoke 的头条卖点;provider 不回 usage.input = 校准根本没跑,
+    // 计为失败,别让 exit0「全部 ✓」假绿。
+    check("provider 回传 usage.input(估算校准前提)", false, "未回传 usage.input,校准未执行");
+  }
+  console.log(`  · 真 usage: input=${summary.usage.input} output=${summary.usage.output} total=${summary.usage.totalTokens}`);
+}
+
+async function testB(): Promise<void> {
+  console.log(`\n[B] provider error(坏 apiKey)→ #53 提级 reason=error`);
+  // 坏 key 经 resolveDashScopeModel 透传进返回的 llmOptions —— 直接用它,不再手写重复魔法字符串。
+  const { model, llmOptions } = resolveDashScopeModel(MODEL_ID, {
+    DASHSCOPE_API_KEY: "sk-deliberately-invalid-key-for-d0",
+  });
+  let overflowFired = false;
+  let onErrorFired = false;
+  const session = new AgentSession({
+    model,
+    tools: [],
+    llmOptions,
+    consoleSink: () => {},
+    hooks: [
+      { name: "ovf-watch", onContextOverflow: () => { overflowFired = true; } },
+      { name: "err-watch", onError: () => { onErrorFired = true; } },
+    ],
+  });
+  const summary = await session.run("hello");
+  check(
+    "reason === 'error'(#53:不再静默 done)",
+    summary.reason === "error",
+    `reason=${summary.reason}`,
+  );
+  check("summary.error 有错误信息", !!summary.error, summary.error?.message?.slice(0, 80) ?? "");
+  check("未误判为 overflow(onContextOverflow 不 fire)", !overflowFired);
+  check("onError 已 fire(可观测)", onErrorFired);
+}
+
+async function testC(): Promise<void> {
+  console.log(`\n[C] 容忍型 provider 探针(大 prompt 正常完成、不误 fire overflow)`);
+  const { model, llmOptions } = resolveDashScopeModel(MODEL_ID, {
+    DASHSCOPE_API_KEY: key,
+  });
+  // ~几千 token 的填充(远低于 Qwen 1M 窗口)——证明大输入正常完成、不会误触发 overflow。
+  const filler = "The quick brown fox jumps over the lazy dog. ".repeat(400);
+  let overflowFired = false;
+  const session = new AgentSession({
+    model,
+    tools: [],
+    llmOptions,
+    maxTurns: 2,
+    consoleSink: () => {},
+    hooks: [{ name: "ovf-watch", onContextOverflow: () => { overflowFired = true; } }],
+  });
+  const summary = await session.run(
+    `Here is some text:\n${filler}\nReply with exactly the word: ok`,
+  );
+  check("reason === 'done'(大 prompt 正常完成)", summary.reason === "done", `reason=${summary.reason}`);
+  check("未误 fire overflow", !overflowFired);
+  console.log(`  · 真 usage.input=${summary.usage.input}(远低于 1M 窗口)`);
+  console.log(
+    "  · 说明:Qwen 是容忍型 provider + 1M 窗口,真正 >1M 的 reactive overflow 强行触发成本过高;",
+  );
+  console.log(
+    "    overflow 机制本身由确定性测试(context-overflow.test.ts)覆盖;此发现正是 C3 走主动压缩(X1/X2)的依据。",
+  );
+}
+
+async function main(): Promise<void> {
+  console.log(`=== D0 真 provider smoke (DashScope ${MODEL_ID}) ===`);
+  try {
+    await testA();
+  } catch (err) {
+    failures++;
+    console.error("  ✗ [A] 抛异常:", err instanceof Error ? err.message : err);
+  }
+  try {
+    await testB();
+  } catch (err) {
+    failures++;
+    console.error("  ✗ [B] 抛异常:", err instanceof Error ? err.message : err);
+  }
+  try {
+    await testC();
+  } catch (err) {
+    failures++;
+    console.error("  ✗ [C] 抛异常:", err instanceof Error ? err.message : err);
+  }
+  console.log(`\n=== D0 smoke 结束:${failures === 0 ? "全部 ✓" : `${failures} 项 ✗`} ===`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+void main();

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-pi/adapters",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "SessionStore adapters for harness-pi (JSONL file + Postgres). Concrete I/O behind the kernel SessionStore protocol.",
   "license": "MIT",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-pi/core",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Agent kernel — pi-ai loop + first-class hook system",
   "license": "MIT",
   "repository": {

--- a/packages/core/src/__tests__/event-bus.test.ts
+++ b/packages/core/src/__tests__/event-bus.test.ts
@@ -133,7 +133,8 @@ describe("Event Bus · live token deltas via on()", () => {
 
   it("on a runtime LLM error (error EVENT, not a sync throw) message_end still carries the error message", async () => {
     // Real providers surface runtime errors as an `error` stream event → result() RESOLVES to a
-    // stopReason="error" message (does NOT reject) → success path → message_end carries that message.
+    // stopReason="error" message (does NOT reject). The kernel emits message_end with that message
+    // BEFORE escalating the turn to reason="error" (#53), so message_end still carries it.
     // Downstream must judge failure by message.stopReason, not by message presence.
     const fake = createFakeModel([{ content: [], throwError: new Error("api 500") }]);
     const session = new AgentSession({ model: fake, tools: [], consoleSink: () => {} });

--- a/packages/core/src/__tests__/phase1-foundation.test.ts
+++ b/packages/core/src/__tests__/phase1-foundation.test.ts
@@ -229,6 +229,23 @@ describe("Phase 1: ctx.config", () => {
     fake.teardown();
   });
 
+  it("config.model 暴露 contextWindow / maxTokens(X2 #57)— autoCompaction 据此算绝对阈值", async () => {
+    let captured: HookContext["config"] | null = null;
+    const probe: Hook = {
+      name: "probe",
+      onSessionStart(_input, ctx) {
+        captured = ctx.config;
+      },
+    };
+    // createFakeModel 的 Model 携带 contextWindow=200_000 / maxTokens=4096(testing.ts 固定值)。
+    const fake = createFakeModel([{ content: [{ type: "text", text: "done" }] }]);
+    const session = new AgentSession({ model: fake, tools: [], hooks: [probe] });
+    await session.run("go");
+    expect(captured!.model.contextWindow).toBe(200_000);
+    expect(captured!.model.maxTokens).toBe(4096);
+    fake.teardown();
+  });
+
   it("config.systemPrompt 默认空串(未配置时)— 估算不应误把 undefined 当内容", async () => {
     let captured: HookContext["config"] | null = null;
     const probe: Hook = {

--- a/packages/core/src/__tests__/phase1-foundation.test.ts
+++ b/packages/core/src/__tests__/phase1-foundation.test.ts
@@ -208,6 +208,7 @@ describe("Phase 1: ctx.config", () => {
       model: fake,
       tools: [echo],
       hooks: [probe],
+      systemPrompt: "You are a test agent.",
       maxTurns: 12,
       maxContinuations: 3,
     });
@@ -219,6 +220,56 @@ describe("Phase 1: ctx.config", () => {
     expect(captured!.maxContinuations).toBe(3);
     expect(Array.from(captured!.toolNames)).toEqual(["echo"]);
     expect(captured!.model.id).toMatch(/^fake-model-/);
+    // X1(#55):真 session 把完整 tool schema + systemPrompt 灌进 ctx.config —— 这是请求级估算修 7x 低估的本体。
+    expect(captured!.tools).toHaveLength(1);
+    expect(captured!.tools[0]!.name).toBe("echo");
+    expect(captured!.tools[0]!.description).toBe("echo");
+    expect(captured!.tools[0]!.parameters).toBe(echo.parameters); // schema 原样透传(引用)
+    expect(captured!.systemPrompt).toBe("You are a test agent.");
+    fake.teardown();
+  });
+
+  it("config.systemPrompt 默认空串(未配置时)— 估算不应误把 undefined 当内容", async () => {
+    let captured: HookContext["config"] | null = null;
+    const probe: Hook = {
+      name: "probe",
+      onSessionStart(_input, ctx) {
+        captured = ctx.config;
+      },
+    };
+    const fake = createFakeModel([{ content: [{ type: "text", text: "done" }] }]);
+    const session = new AgentSession({ model: fake, tools: [], hooks: [probe] });
+    await session.run("go");
+    expect(captured!.systemPrompt).toBe("");
+    expect(captured!.tools).toEqual([]);
+    fake.teardown();
+  });
+
+  it("config.tools 逐元素冻结 — plugin 不能增删元素或改 tool 字段", async () => {
+    const echo: HarnessTool = {
+      name: "echo",
+      description: "echo",
+      parameters: Type.Object({}),
+      async execute() {
+        return { content: [{ type: "text", text: "hi" }] };
+      },
+    };
+    const probe: Hook = {
+      name: "probe",
+      onSessionStart(_input, ctx) {
+        // 数组冻结:不能 push
+        expect(() => {
+          (ctx.config.tools as unknown as unknown[]).push({});
+        }).toThrow();
+        // 元素冻结:不能改 name/description
+        expect(() => {
+          (ctx.config.tools[0] as unknown as { name: string }).name = "hack";
+        }).toThrow();
+      },
+    };
+    const fake = createFakeModel([{ content: [{ type: "text", text: "done" }] }]);
+    const session = new AgentSession({ model: fake, tools: [echo], hooks: [probe] });
+    await session.run("go");
     fake.teardown();
   });
 

--- a/packages/core/src/__tests__/terminal-result.test.ts
+++ b/packages/core/src/__tests__/terminal-result.test.ts
@@ -116,20 +116,38 @@ describe("RunSummary as typed terminal result", () => {
     fake.teardown();
   });
 
-  it("provider-reported error (error EVENT, resolves) lands the error message as lastMessage, with reason='done'", async () => {
-    // distinct from streamThrows (sync throw -> catch -> reason='error', no lastMessage). Here
-    // result() RESOLVES a stopReason='error' assistant which IS pushed, so lastMessage is present.
-    // PINNED CONTRACT: this is complete()-equivalent — the loop only reports reason='error' on a
-    // genuine THROW; a provider error surfaced as a resolved message is a normal turn (stopReason
-    // != toolUse) => reason='done'. The failure on THIS path is signaled by lastMessage.stopReason,
-    // not by summary.reason (matches RunSummary.lastMessage doc).
+  it("escalates a resolved non-overflow error-stopReason to reason='error' and fires onError (#53)", async () => {
+    // Two LLM failure modes are now UNIFIED:
+    //   - streamThrows (sync throw) -> catch -> reason='error', no lastMessage.
+    //   - error EVENT: result() RESOLVES a stopReason='error' assistant (IS pushed, so lastMessage
+    //     is present). #53: this used to be silently treated as a normal turn => reason='done',
+    //     which let headless callers mistake auth/rate-limit failures for success. Now it escalates.
+    // (Overflow-classified errors still flow through onContextOverflow and keep reason='done' — see
+    // context-overflow.test.ts; THIS is the non-overflow error path.)
     const fake = createFakeModel([{ content: [], throwError: new Error("api 500") }]);
-    const session = new AgentSession({ model: fake, tools: [], consoleSink: () => {} });
+    const errs: Array<{ phase: string; message: string }> = [];
+    const session = new AgentSession({
+      model: fake,
+      tools: [],
+      consoleSink: () => {},
+      hooks: [
+        {
+          name: "err-watch",
+          onError: (i) => {
+            errs.push({ phase: i.phase, message: i.err.message });
+          },
+        },
+      ],
+    });
     const summary = await session.run("hi");
+    expect(summary.reason).toBe("error"); // #53: no longer silently 'done'
+    expect(summary.error?.message).toContain("api 500"); // errorMessage surfaced in RunSummary.error
+    // The error message still lands as lastMessage too (resolved + pushed before escalation).
     expect(summary.lastMessage).toBeDefined();
     expect(summary.lastMessage?.stopReason).toBe("error");
     expect(summary.stopReason).toBe("error");
-    expect(summary.reason).toBe("done"); // NOT 'error' — failure is in lastMessage.stopReason here
+    // onError fired exactly once with phase='llm' (observability; mirrors the sync-throw path).
+    expect(errs).toEqual([{ phase: "llm", message: "api 500" }]);
     fake.teardown();
   });
 

--- a/packages/core/src/hook.ts
+++ b/packages/core/src/hook.ts
@@ -313,7 +313,17 @@ export interface HookLogger {
  */
 export interface SessionConfigView {
   readonly sessionId: string;
-  readonly model: { id: string; provider: string };
+  /**
+   * 当前 model 的标识 + 有效窗口（X2 / #57）。`contextWindow` / `maxTokens` 取自 pi-ai `Model` 同名字段
+   * （`makeOpenAICompatibleModel` / registry 都填）——**值来自调用方 Model，内核不硬编 per-model 表、不解析 id**。
+   * autoCompaction 据此算「按有效窗口触发」的绝对阈值（`contextWindow − reserveForOutput − safetyBuffer`）。
+   */
+  readonly model: {
+    id: string;
+    provider: string;
+    contextWindow: number;
+    maxTokens: number;
+  };
   readonly toolNames: ReadonlyArray<string>;
   /**
    * 发给 LLM 的 tool schema（pi-ai `Tool` 形态 `{name, description, parameters}`，与每次请求随发的

--- a/packages/core/src/hook.ts
+++ b/packages/core/src/hook.ts
@@ -13,6 +13,7 @@
 import type {
   AssistantMessage,
   Message,
+  Tool,
   ToolCall,
 } from "@earendil-works/pi-ai";
 import type { HarnessTool } from "./types.js";
@@ -314,6 +315,16 @@ export interface SessionConfigView {
   readonly sessionId: string;
   readonly model: { id: string; provider: string };
   readonly toolNames: ReadonlyArray<string>;
+  /**
+   * 发给 LLM 的 tool schema（pi-ai `Tool` 形态 `{name, description, parameters}`，与每次请求随发的
+   * 完全一致）。token 估算插件（X1）需要它来把「每请求随发的 tool schema 体积」计进 context 估算——
+   * 只数 `toolNames` 会**严重低估**真实 usage（D0 实测低估 ~7x）。只读、构造期冻结。
+   */
+  readonly tools: ReadonlyArray<Tool>;
+  /**
+   * 当前 system prompt（与每次请求随发的一致；无则空串）。同样是 token 估算需计入的固定开销。只读。
+   */
+  readonly systemPrompt: string;
   readonly maxTurns: number;
   readonly maxContinuations: number;
 }

--- a/packages/core/src/hook.ts
+++ b/packages/core/src/hook.ts
@@ -317,12 +317,15 @@ export interface SessionConfigView {
   readonly toolNames: ReadonlyArray<string>;
   /**
    * 发给 LLM 的 tool schema（pi-ai `Tool` 形态 `{name, description, parameters}`，与每次请求随发的
-   * 完全一致）。token 估算插件（X1）需要它来把「每请求随发的 tool schema 体积」计进 context 估算——
-   * 只数 `toolNames` 会**严重低估**真实 usage（D0 实测低估 ~7x）。只读、构造期冻结。
+   * piTools 同形且内容一致——tools 不经 pipe 改写）。token 估算插件（X1）需要它把「每请求随发的 tool
+   * schema 体积」计进 context 估算——只数 `toolNames` 会**严重低估**真实 usage（D0 实测低估 ~7x）。
+   * 只读:数组与每个元素冻结;但 `parameters` 是 schema 对象引用、未深冻（估算只读不写）。
    */
   readonly tools: ReadonlyArray<Tool>;
   /**
-   * 当前 system prompt（与每次请求随发的一致；无则空串）。同样是 token 估算需计入的固定开销。只读。
+   * **base** system prompt（构造期传入的原值；无则空串）。token 估算据此计入「每请求随发的 system 开销」。
+   * 注意:若挂了 `transformSystemPromptBeforeLlm` pipe hook 改写 system prompt,实际随发的是 **pipe 后**的值,
+   * 本视图给的是 **pre-pipe base**——估算可能略低估被 hook 注入的增量（目前无 first-party hook 这么做）。只读。
    */
   readonly systemPrompt: string;
   readonly maxTurns: number;

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -327,6 +327,17 @@ export class AgentSession {
       sessionId: this.id,
       model: Object.freeze({ id: this.model.id, provider: this.model.provider }),
       toolNames: Object.freeze(this.tools.map((t) => t.name)),
+      // 只暴露 pi-ai Tool 三字段（与每请求随发的 piTools 同形），冻结每个元素防 plugin 改 schema。
+      tools: Object.freeze(
+        this.tools.map((t) =>
+          Object.freeze({
+            name: t.name,
+            description: t.description,
+            parameters: t.parameters,
+          }),
+        ),
+      ),
+      systemPrompt: this.systemPrompt,
       maxTurns: this.maxTurns,
       maxContinuations: this.maxContinuations,
     });

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -1326,7 +1326,9 @@ export class AgentSession {
     //     API error 报回，pi-ai 转成 error 流事件 → result() resolve 出 stopReason==="error"）。
     // 内核只「发事件」，不再当普通 done 静默吞掉；压缩/重启策略全在插件（ctx.abort("compaction:...")
     // → compactRestartFresh 重启 fresh，或 transformMessagesBeforeLlm 改写消息）。注意 fire 不改控制流：
-    // 没策略 abort 时这条 length/error assistant 仍以 reason:"done" 收尾。connection/config 类 sync-throw
+    // 没策略 abort 时这条 length / overflow-error assistant 仍以 reason:"done" 收尾（契约不变）。
+    // 但**非 overflow** 的 error-stopReason（坏 apiKey 401 / 限流 / 其它 provider 错误）会被下面的
+    // else-if 提级为 reason:"error"（#53），不再静默成 done。connection/config 类 sync-throw
     //（provider 未注册）走上面的 catch，不是 overflow，不在此分类。
     const overflow = this._detectOverflow(assistant);
     if (overflow) {
@@ -1336,6 +1338,17 @@ export class AgentSession {
         this._ctx,
       );
       this._flushSystemMessages(coOut.systemMessages);
+    } else if (assistant.stopReason === "error") {
+      // 非 overflow 的 resolved error-stopReason（#53）：此前因「无 tool call」被 turn loop 当正常完成
+      // → reason="done"，headless 调用方分不清硬错误与成功。修复：与同步抛路径（上面的 catch）一致——
+      // fire onError（可观测，插件可记录/决策；observe-only 不改控制流）后 throw，经 _runOneTurn 既有
+      // catch 提级 reason="error" + summary.error。两种 LLM 失败模式自此统一。assistant 已入 messages
+      //（lastMessage 仍带 errorMessage），message_end 也已发，故抛在此处不破坏 live 事件配对。
+      const err = new Error(
+        assistant.errorMessage ?? 'LLM call ended with stopReason="error"',
+      );
+      await this._dispatcher.fireError({ phase: "llm", err }, this._ctx);
+      throw err;
     }
 
     return assistant;

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -327,7 +327,13 @@ export class AgentSession {
     // 不写,与 model 的扁平冻结粒度一致,不构成新风险面。
     const configView: SessionConfigView = Object.freeze({
       sessionId: this.id,
-      model: Object.freeze({ id: this.model.id, provider: this.model.provider }),
+      model: Object.freeze({
+        id: this.model.id,
+        provider: this.model.provider,
+        // X2(#57):暴露有效窗口给 autoCompaction 算绝对阈值。值取自 pi-ai Model 同名字段(调用方权威)。
+        contextWindow: this.model.contextWindow,
+        maxTokens: this.model.maxTokens,
+      }),
       toolNames: Object.freeze(this.tools.map((t) => t.name)),
       // 只暴露 pi-ai Tool 三字段（与每请求随发的 piTools 同形），冻结每个元素防 plugin 改 schema。
       tools: Object.freeze(

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -322,7 +322,9 @@ export class AgentSession {
 
     this._abortCtrl = new AbortController();
     // tools 是构造期固定（`use()` 只允许在 idle 加 hooks，不改 tools / model / maxTurns）。
-    // 整个 configView 包括 nested model 对象都 deep-freeze，runtime 拒绝任何 plugin 修改。
+    // Object.freeze 是**浅冻**：configView 顶层 + model + toolNames 数组 + tools 数组及其每个元素都冻结，
+    // plugin 不能替换字段/增删元素;但 tool.parameters 是 TypeBox schema 对象的**引用**(未深冻)——估算只读
+    // 不写,与 model 的扁平冻结粒度一致,不构成新风险面。
     const configView: SessionConfigView = Object.freeze({
       sessionId: this.id,
       model: Object.freeze({ id: this.model.id, provider: this.model.provider }),

--- a/packages/core/src/testing.ts
+++ b/packages/core/src/testing.ts
@@ -341,6 +341,8 @@ export function createTestContext(opts: TestContextOptions = {}): TestContextHan
     sessionId: opts.sessionId ?? "test-session",
     model: Object.freeze({ id: "test-model", provider: "test" }),
     toolNames: Object.freeze([]),
+    tools: Object.freeze([]),
+    systemPrompt: "",
     maxTurns: 200,
     maxContinuations: 5,
     ...(opts.config ?? {}),

--- a/packages/core/src/testing.ts
+++ b/packages/core/src/testing.ts
@@ -339,7 +339,12 @@ export function createTestContext(opts: TestContextOptions = {}): TestContextHan
 
   const defaultConfig: SessionConfigView = Object.freeze({
     sessionId: opts.sessionId ?? "test-session",
-    model: Object.freeze({ id: "test-model", provider: "test" }),
+    model: Object.freeze({
+      id: "test-model",
+      provider: "test",
+      contextWindow: 200_000,
+      maxTokens: 4096,
+    }),
     toolNames: Object.freeze([]),
     tools: Object.freeze([]),
     systemPrompt: "",

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -73,7 +73,7 @@ Controllers (`@harness-pi/plugins/controllers`):
 - **forkSession / forkSessionAll** — branch a session into one or more isolated forks.
 - **LifecycleRestart** — restart-on-lifecycle supervision for long-running sessions.
 - **compactOnOverflow / CompactRestartFresh** — restart a session fresh from a compacted summary on context overflow.
-- **subAgentTool** — wrap a child session as a callable tool.
+- **subAgentTool / routedSubAgentTool** — wrap a child session as a callable tool; the routed variant picks among multiple `AgentSpec`s by `agent_type`.
 - **GapExplorer** — explore and report coverage gaps in a result set.
 
 Metrics:

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-pi/plugins",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Standard library of harness-pi plugins + controllers + sinks",
   "license": "MIT",
   "repository": {

--- a/packages/plugins/src/__tests__/auto-compaction.test.ts
+++ b/packages/plugins/src/__tests__/auto-compaction.test.ts
@@ -363,4 +363,179 @@ describe("autoCompaction", () => {
     expect(view).toBeDefined();
     expect(calls.length).toBeGreaterThan(0); // 注入的 counter 真的被调用
   });
+
+  // ───────────────── X2(#57): per-model 有效窗口 + 分层 buffer ─────────────────
+
+  const modelCfg = (contextWindow: number, maxTokens: number) => ({
+    model: { id: "m", provider: "p", contextWindow, maxTokens },
+  });
+
+  it("X2: window mode threshold = contextWindow − reserveForOutput − safetyBuffer", async () => {
+    // contextWindow=10000, reserveForOutput=4096(默认 min(maxTokens,4096)), safetyBuffer=500 → 阈值 5404。
+    let summarized = false;
+    const compact = autoCompaction({
+      // 不给 maxContextTokens → 走窗口路径
+      keepRecent: 1,
+      safetyBuffer: 500,
+      tokenCounter: { estimate: () => 5405 }, // 5404 < 5405 → 越界 → 触发
+      summarize: () => {
+        summarized = true;
+        return "RECAP";
+      },
+    });
+    const { ctx } = createTestContext({ config: modelCfg(10_000, 8000) }); // maxTokens=8000 → reserve=min(8000,4096)=4096
+    const view = await compact.transformMessagesBeforeLlm!(grow(3), ctx);
+    expect(view).toBeDefined();
+    expect(summarized).toBe(true);
+  });
+
+  it("X2: window mode does NOT trigger at or below the effective window", async () => {
+    // 阈值 = 10000 − 4096 − 0 = 5904。估算正好 = 5904（边界，<= 不触发）。
+    let calls = 0;
+    const compact = autoCompaction({
+      keepRecent: 1,
+      tokenCounter: { estimate: () => 5904 },
+      summarize: () => {
+        calls++;
+        return "S";
+      },
+    });
+    const { ctx } = createTestContext({ config: modelCfg(10_000, 4096) });
+    expect(await compact.transformMessagesBeforeLlm!(grow(5), ctx)).toBeUndefined();
+    expect(calls).toBe(0);
+
+    // 阈值 + 1 → 触发。
+    const compact2 = autoCompaction({
+      keepRecent: 1,
+      tokenCounter: { estimate: () => 5905 },
+      summarize: () => "S",
+    });
+    expect(await compact2.transformMessagesBeforeLlm!(grow(5), ctx)).toBeDefined();
+  });
+
+  it("X2: reserveForOutput / safetyBuffer overrides lower the effective window", async () => {
+    // 显式 reserveForOutput=1000, safetyBuffer=2000 → 阈值 = 10000 − 1000 − 2000 = 7000。
+    const compact = autoCompaction({
+      keepRecent: 1,
+      reserveForOutput: 1000,
+      safetyBuffer: 2000,
+      tokenCounter: { estimate: () => 7000 }, // == 阈值 → 不触发
+      summarize: () => "S",
+    });
+    const { ctx } = createTestContext({ config: modelCfg(10_000, 4096) });
+    expect(await compact.transformMessagesBeforeLlm!(grow(5), ctx)).toBeUndefined();
+
+    const compact2 = autoCompaction({
+      keepRecent: 1,
+      reserveForOutput: 1000,
+      safetyBuffer: 2000,
+      tokenCounter: { estimate: () => 7001 }, // 越界 1 → 触发
+      summarize: () => "S",
+    });
+    expect(await compact2.transformMessagesBeforeLlm!(grow(5), ctx)).toBeDefined();
+  });
+
+  it("X2: reserveForOutput defaults to min(model.maxTokens, 4096)", async () => {
+    // maxTokens=2000 < 4096 → reserve=2000 → 阈值 = 10000 − 2000 = 8000。
+    const compactSmall = autoCompaction({
+      keepRecent: 1,
+      tokenCounter: { estimate: () => 8001 },
+      summarize: () => "S",
+    });
+    const { ctx: ctxSmall } = createTestContext({ config: modelCfg(10_000, 2000) });
+    expect(await compactSmall.transformMessagesBeforeLlm!(grow(5), ctxSmall)).toBeDefined(); // 8001 > 8000
+
+    const compactSmall2 = autoCompaction({
+      keepRecent: 1,
+      tokenCounter: { estimate: () => 8000 },
+      summarize: () => "S",
+    });
+    expect(await compactSmall2.transformMessagesBeforeLlm!(grow(5), ctxSmall)).toBeUndefined(); // 8000 == 阈值
+
+    // maxTokens=100000 > 4096 → reserve 封顶 4096 → 阈值 = 10000 − 4096 = 5904。
+    const compactBig = autoCompaction({
+      keepRecent: 1,
+      tokenCounter: { estimate: () => 5905 },
+      summarize: () => "S",
+    });
+    const { ctx: ctxBig } = createTestContext({ config: modelCfg(10_000, 100_000) });
+    expect(await compactBig.transformMessagesBeforeLlm!(grow(5), ctxBig)).toBeDefined(); // 5905 > 5904
+  });
+
+  it("X2: explicit maxContextTokens takes priority over the window path (backward compat)", async () => {
+    // 即便 ctx 暴露了 contextWindow，给了 maxContextTokens 就走百分比路径，窗口路径被忽略。
+    // maxContextTokens=100, triggerRatio=1 → 阈值 100；窗口阈值会是 10000−4096=5904（若误用窗口路径则不触发）。
+    let summarized = false;
+    const compact = autoCompaction({
+      maxContextTokens: 100,
+      triggerRatio: 1,
+      keepRecent: 1,
+      tokenCounter: { estimate: () => 200 }, // > 100(百分比) 但 < 5904(窗口) → 只有走百分比才触发
+      summarize: () => {
+        summarized = true;
+        return "S";
+      },
+    });
+    const { ctx } = createTestContext({ config: modelCfg(10_000, 4096) });
+    const view = await compact.transformMessagesBeforeLlm!(grow(5), ctx);
+    expect(view).toBeDefined(); // 走了百分比路径
+    expect(summarized).toBe(true);
+  });
+
+  it("X2: contextWindow unavailable (0) and no maxContextTokens → no compaction (no threshold)", async () => {
+    let calls = 0;
+    const compact = autoCompaction({
+      keepRecent: 1,
+      tokenCounter: { estimate: () => 999_999 }, // 巨大，但算不出阈值
+      summarize: () => {
+        calls++;
+        return "S";
+      },
+    });
+    const { ctx } = createTestContext({ config: modelCfg(0, 0) }); // contextWindow=0
+    expect(await compact.transformMessagesBeforeLlm!(grow(5), ctx)).toBeUndefined();
+    expect(calls).toBe(0);
+  });
+
+  it("X2: rejects negative reserveForOutput / safetyBuffer; allows omitting maxContextTokens", () => {
+    expect(() =>
+      autoCompaction({ reserveForOutput: -1, summarize: () => "" }),
+    ).toThrow(/reserveForOutput/);
+    expect(() =>
+      autoCompaction({ safetyBuffer: -1, summarize: () => "" }),
+    ).toThrow(/safetyBuffer/);
+    // maxContextTokens 显式给 0 仍报错（区分「缺省」与「非法显式值」）。
+    expect(() => autoCompaction({ maxContextTokens: 0, summarize: () => "" })).toThrow(
+      /maxContextTokens/,
+    );
+    // 完全不给 maxContextTokens（窗口模式）→ 构造不报错。
+    expect(() => autoCompaction({ summarize: () => "" })).not.toThrow();
+  });
+
+  it("X2 end-to-end: window mode from a real session's model.contextWindow", async () => {
+    // fake model: contextWindow=200000, maxTokens=4096 → 阈值 = 200000 − 4096 = 195904。
+    // 注入一个超大 estimate(走 tokenCounter)，让请求体积越过窗口阈值 → 真 session 触发压缩。
+    const initial = [m("h1"), m("a1"), m("h2"), m("a2"), m("h3"), m("a3")]; // 6
+    const fake = createFakeModel([{ content: [{ type: "text", text: "ok" }], stopReason: "stop" }]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [],
+      initialMessages: initial,
+      hooks: [
+        autoCompaction({
+          // 不给 maxContextTokens → 用 model.contextWindow
+          keepRecent: 2,
+          tokenCounter: { estimate: () => 200_000 }, // > 195904 → 触发
+          summarize: () => "RECAP",
+        }),
+      ],
+    });
+    await session.run("go");
+
+    const view = fake.getCalls()[0]!.messages;
+    expect(view.length).toBe(3); // [summary, "a3", "go"]
+    expect(textOf(view[0]!)).toContain("RECAP");
+    expect(session.messages.length).toBe(8); // full history intact
+    fake.teardown();
+  });
 });

--- a/packages/plugins/src/__tests__/auto-compaction.test.ts
+++ b/packages/plugins/src/__tests__/auto-compaction.test.ts
@@ -497,6 +497,23 @@ describe("autoCompaction", () => {
     expect(calls).toBe(0);
   });
 
+  it("X2: reserveForOutput+safetyBuffer >= contextWindow → 阈值≤0 视为算不出 → no-op(不每 turn 空压)", async () => {
+    // footgun 防护:小窗口 + 大 reserve 让 effectiveWindow ≤ 0;若直接用,estimated(>=0) 永远 > 阈值 → 每 turn 压缩。
+    let calls = 0;
+    const compact = autoCompaction({
+      keepRecent: 1,
+      reserveForOutput: 200, // >= contextWindow(100) → w = 100 − 200 − 0 = −100 ≤ 0
+      tokenCounter: { estimate: () => 999_999 }, // 巨大,但阈值算不出 → 不应触发
+      summarize: () => {
+        calls++;
+        return "S";
+      },
+    });
+    const { ctx } = createTestContext({ config: modelCfg(100, 50) });
+    expect(await compact.transformMessagesBeforeLlm!(grow(5), ctx)).toBeUndefined();
+    expect(calls).toBe(0); // 不每 turn 空压
+  });
+
   it("X2: rejects negative reserveForOutput / safetyBuffer; allows omitting maxContextTokens", () => {
     expect(() =>
       autoCompaction({ reserveForOutput: -1, summarize: () => "" }),

--- a/packages/plugins/src/__tests__/auto-compaction.test.ts
+++ b/packages/plugins/src/__tests__/auto-compaction.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect } from "vitest";
 import { AgentSession, createUserMessage } from "@harness-pi/core";
 import { createTestContext, createFakeModel } from "@harness-pi/core/testing";
-import type { Message } from "@earendil-works/pi-ai";
-import { autoCompaction, estimateTokensByChars } from "../auto-compaction.js";
+import type { Message, Tool } from "@earendil-works/pi-ai";
+import {
+  autoCompaction,
+  estimateTokensByChars,
+  estimateRequestTokens,
+} from "../auto-compaction.js";
 
 function textOf(m: Message): string {
   return typeof m.content === "string"
@@ -19,7 +23,7 @@ describe("autoCompaction", () => {
       maxContextTokens: 100,
       triggerRatio: 0.5, // threshold = 50
       keepRecent: 2,
-      estimateTokens: (msgs) => msgs.length * 20, // 5 msgs => 100 > 50
+      tokenCounter: { estimate: ({ messages }) => messages.length * 20 }, // 5 msgs => 100 > 50
       summarize: (e) => {
         early = e;
         return `SUM:${e.length}`;
@@ -41,7 +45,7 @@ describe("autoCompaction", () => {
       maxContextTokens: 100,
       triggerRatio: 0.5, // threshold 50
       keepRecent: 2,
-      estimateTokens: () => 10, // < 50
+      tokenCounter: { estimate: () => 10 }, // < 50
       summarize: () => {
         calls++;
         return "S";
@@ -164,7 +168,7 @@ describe("autoCompaction", () => {
       maxContextTokens: 1,
       triggerRatio: 1,
       keepRecent: 3,
-      estimateTokens: () => 999, // over threshold → would compact if it could
+      tokenCounter: { estimate: () => 999 }, // over threshold → would compact if it could
       summarize: () => {
         calls++;
         return "S";
@@ -183,7 +187,7 @@ describe("autoCompaction", () => {
       triggerRatio: 1,
       keepRecent: 2,
       resummarizeEvery: 2,
-      estimateTokens: () => 999, // always over threshold -> always evaluate
+      tokenCounter: { estimate: () => 999 }, // always over threshold -> always evaluate
       summarize: (e) => {
         calls++;
         return `S${e.length}`;
@@ -236,7 +240,7 @@ describe("autoCompaction", () => {
           maxContextTokens: 100,
           triggerRatio: 0.8, // threshold 80
           keepRecent: 2,
-          estimateTokens: (msgs) => msgs.length * 50, // 7 msgs * 50 = 350 > 80
+          tokenCounter: { estimate: ({ messages }) => messages.length * 50 }, // 7 msgs * 50 = 350 > 80
           summarize: () => "RECAP",
         }),
       ],
@@ -266,7 +270,7 @@ describe("autoCompaction", () => {
           maxContextTokens: 100,
           triggerRatio: 0.8, // threshold 80
           keepRecent: 2,
-          estimateTokens: (msgs) => msgs.length * 50, // 7 msgs * 50 = 350 > 80 → 会尝试压缩
+          tokenCounter: { estimate: ({ messages }) => messages.length * 50 }, // 7 msgs * 50 = 350 > 80 → 会尝试压缩
           summarize: () => {
             throw new Error("summary backend down");
           },
@@ -282,5 +286,81 @@ describe("autoCompaction", () => {
     // 完整历史未被破坏：6 初始 + "go" + assistant = 8。
     expect(session.messages.length).toBe(8);
     fake.teardown();
+  });
+
+  it("X1: triggers earlier when tools are big (messages small but tool schema large)", async () => {
+    // 仅 2 条小消息：messages-only 估算远低于阈值、绝不触发；但带上大 tool schema 的请求级估算越过阈值 → 触发。
+    // 这正是 D0 53-vs-381 低估 7x 的修复方向：tool schema 每请求随发，必须计入。
+    const messages = [m("hi"), m("ok"), m("more"), m("again")]; // 小
+    const bigTool: Tool = {
+      name: "submit_evidence",
+      description: "Submit structured evidence. ".repeat(40),
+      parameters: {
+        type: "object",
+        properties: {
+          questionId: { type: "string", description: "the question id ".repeat(20) },
+          evidence: { type: "string", description: "the evidence body ".repeat(20) },
+        },
+        required: ["questionId", "evidence"],
+      },
+    } as Tool;
+
+    // 阈值卡在「messages-only 之上、含 tools 之下」之间。
+    const messagesOnly = estimateTokensByChars(messages);
+    const withTools = estimateRequestTokens({ messages, tools: [bigTool] });
+    expect(withTools).toBeGreaterThan(messagesOnly); // sanity：tools 确实抬高了估值
+    const threshold = (messagesOnly + withTools) / 2;
+
+    let summarized = false;
+    const compact = autoCompaction({
+      maxContextTokens: threshold,
+      triggerRatio: 1, // threshold = maxContextTokens
+      keepRecent: 1,
+      summarize: () => {
+        summarized = true;
+        return "RECAP";
+      },
+    });
+
+    // ctx 暴露 bigTool：autoCompaction 经 ctx.config.tools 把它计入 → 触发。
+    const { ctx } = createTestContext({ config: { tools: [bigTool] } });
+    const view = await compact.transformMessagesBeforeLlm!(messages, ctx);
+    expect(view).toBeDefined(); // 改进估算触发了
+    expect(summarized).toBe(true);
+
+    // 对照：同样 messages、同样阈值，但 ctx 没有 tools（messages-only 等价）→ 不触发。
+    let summarized2 = false;
+    const compact2 = autoCompaction({
+      maxContextTokens: threshold,
+      triggerRatio: 1,
+      keepRecent: 1,
+      summarize: () => {
+        summarized2 = true;
+        return "RECAP";
+      },
+    });
+    const { ctx: ctxNoTools } = createTestContext(); // config.tools = []
+    expect(await compact2.transformMessagesBeforeLlm!(messages, ctxNoTools)).toBeUndefined();
+    expect(summarized2).toBe(false);
+  });
+
+  it("X1: a custom tokenCounter overrides the default", async () => {
+    const calls: number[] = [];
+    const compact = autoCompaction({
+      maxContextTokens: 100,
+      triggerRatio: 1, // threshold 100
+      keepRecent: 1,
+      tokenCounter: {
+        estimate: ({ messages }) => {
+          calls.push(messages.length);
+          return 200; // 永远超阈值 → 触发
+        },
+      },
+      summarize: () => "RECAP",
+    });
+    const { ctx } = createTestContext();
+    const view = await compact.transformMessagesBeforeLlm!(grow(5), ctx);
+    expect(view).toBeDefined();
+    expect(calls.length).toBeGreaterThan(0); // 注入的 counter 真的被调用
   });
 });

--- a/packages/plugins/src/__tests__/estimate-request-tokens.test.ts
+++ b/packages/plugins/src/__tests__/estimate-request-tokens.test.ts
@@ -120,6 +120,26 @@ describe("estimateTokensByChars (regression — must stay unchanged by X1)", () 
   it("empty message is still 0 (no per-message overhead added)", () => {
     expect(estimateTokensByChars([m("")])).toBe(0);
   });
+
+  it("counts the tool parameters schema (the largest D0 blind spot), not just name+description", () => {
+    // 两个 tool 仅 parameters 不同:大 schema 必须让估值严格更高。
+    // 防回归:若只数 name+description 漏了 JSON.stringify(parameters),本测试会失败。
+    const messages = [m("hi")];
+    const small = [tool("t", "d", { type: "object", properties: {} })];
+    const bigSchema = {
+      type: "object",
+      properties: Object.fromEntries(
+        Array.from({ length: 30 }, (_, i) => [
+          `field_${i}`,
+          { type: "string", description: "a reasonably long field description ".repeat(3) },
+        ]),
+      ),
+    };
+    const big = [tool("t", "d", bigSchema)];
+    expect(estimateRequestTokens({ messages, tools: big })).toBeGreaterThan(
+      estimateRequestTokens({ messages, tools: small }),
+    );
+  });
 });
 
 describe("defaultTokenCounter", () => {

--- a/packages/plugins/src/__tests__/estimate-request-tokens.test.ts
+++ b/packages/plugins/src/__tests__/estimate-request-tokens.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import { createUserMessage } from "@harness-pi/core";
+import type { Message, Tool } from "@earendil-works/pi-ai";
+import {
+  estimateTokensByChars,
+  estimateRequestTokens,
+  defaultTokenCounter,
+} from "../auto-compaction.js";
+
+const m = (t: string): Message => createUserMessage(t);
+
+/** 造一个 pi-ai Tool（name + description + parameters）。 */
+function tool(name: string, description: string, parameters: unknown): Tool {
+  return { name, description, parameters } as Tool;
+}
+
+describe("estimateRequestTokens (X1, issue #55)", () => {
+  it("counts more than messages-only when tools are present (锁 D0 7x 低估方向)", () => {
+    const messages = [m("hi")];
+    const tools = [
+      tool("read", "Read a file from disk", {
+        type: "object",
+        properties: { path: { type: "string", description: "absolute path" } },
+        required: ["path"],
+      }),
+      tool("bash", "Run a shell command in the host shell", {
+        type: "object",
+        properties: { command: { type: "string", description: "the command" } },
+        required: ["command"],
+      }),
+    ];
+    const messagesOnly = estimateTokensByChars(messages);
+    const withTools = estimateRequestTokens({ messages, tools });
+    // 含 tool schema 的请求级估算 ≫ 仅数消息文本。
+    expect(withTools).toBeGreaterThan(messagesOnly);
+    // 而且差距显著（tools 的序列化体积远大于一条 "hi"）——不是只多一两个 token。
+    expect(withTools).toBeGreaterThan(messagesOnly * 5);
+  });
+
+  it("tools contribute additively: adding a tool strictly increases the estimate", () => {
+    const messages = [m("question")];
+    const t1 = tool("read", "read a file", { type: "object", properties: {} });
+    const t2 = tool(
+      "grep",
+      "search files by pattern with a long description here",
+      { type: "object", properties: { pattern: { type: "string" } } },
+    );
+    const one = estimateRequestTokens({ messages, tools: [t1] });
+    const two = estimateRequestTokens({ messages, tools: [t1, t2] });
+    expect(two).toBeGreaterThan(one);
+  });
+
+  it("systemPrompt contributes: a long system prompt raises the estimate", () => {
+    const messages = [m("q")];
+    const none = estimateRequestTokens({ messages });
+    const withSys = estimateRequestTokens({
+      messages,
+      systemPrompt: "You are a careful coding agent. ".repeat(50),
+    });
+    expect(withSys).toBeGreaterThan(none);
+  });
+
+  it("tools and systemPrompt contributions are separable (each adds on its own)", () => {
+    const messages = [m("q")];
+    const t = tool("read", "read a file from disk", { type: "object", properties: {} });
+    const sys = "system prompt body ".repeat(20);
+
+    const base = estimateRequestTokens({ messages });
+    const plusTool = estimateRequestTokens({ messages, tools: [t] });
+    const plusSys = estimateRequestTokens({ messages, systemPrompt: sys });
+    const plusBoth = estimateRequestTokens({ messages, tools: [t], systemPrompt: sys });
+
+    expect(plusTool).toBeGreaterThan(base);
+    expect(plusSys).toBeGreaterThan(base);
+    // 两者一起 = 各自增量之和（在 base 之上叠加），且严格大于任一单项。
+    expect(plusBoth).toBe(plusTool + plusSys - base);
+    expect(plusBoth).toBeGreaterThan(plusTool);
+    expect(plusBoth).toBeGreaterThan(plusSys);
+  });
+
+  it("adds a per-message format overhead (count grows with message count even for empty text)", () => {
+    const one = estimateRequestTokens({ messages: [m("")] });
+    const three = estimateRequestTokens({ messages: [m(""), m(""), m("")] });
+    // 空文本仍各计每消息格式开销，故条数多 = 估值高。
+    expect(three).toBeGreaterThan(one);
+    expect(three - one).toBe(8); // 2 条额外 × 4 tok/消息
+  });
+
+  it("reuses CJK / image rules from estimateTokensByChars", () => {
+    // CJK：每码点 ≈ 1 token，仍生效。
+    const cjk = "你好世界".repeat(10); // 40 码点
+    const cjkEst = estimateRequestTokens({ messages: [m(cjk)] });
+    // ≈ 40 (CJK) + 4 (每消息开销)。
+    expect(cjkEst).toBe(40 + 4);
+
+    // 图片：扁平 1000，不随 data 长度膨胀。
+    const imgMsg: Message = {
+      role: "user",
+      content: [{ type: "image", data: "A".repeat(50_000), mimeType: "image/png" }],
+      timestamp: 0,
+    };
+    const imgEst = estimateRequestTokens({ messages: [imgMsg] });
+    expect(imgEst).toBe(1000 + 4); // 1000 (image) + 每消息开销
+  });
+
+  it("equals messages-only + per-message overhead when tools/systemPrompt are omitted", () => {
+    const messages = [m("hello world"), m("second message")];
+    expect(estimateRequestTokens({ messages })).toBe(
+      estimateTokensByChars(messages) + messages.length * 4,
+    );
+  });
+});
+
+describe("estimateTokensByChars (regression — must stay unchanged by X1)", () => {
+  it("counts message text only, no tools/system/format overhead", () => {
+    // "hello" = 5 ASCII → ceil(5/4) = 2。绝不因 X1 多算每消息开销或 tool 体积。
+    expect(estimateTokensByChars([m("hello")])).toBe(2);
+  });
+
+  it("empty message is still 0 (no per-message overhead added)", () => {
+    expect(estimateTokensByChars([m("")])).toBe(0);
+  });
+});
+
+describe("defaultTokenCounter", () => {
+  it("estimate delegates to estimateRequestTokens", () => {
+    const input = {
+      messages: [m("hi")],
+      tools: [tool("read", "read a file", { type: "object", properties: {} })],
+      systemPrompt: "be careful",
+    };
+    expect(defaultTokenCounter.estimate(input)).toBe(estimateRequestTokens(input));
+  });
+
+  it("does not implement count (count? is a future opt-in seam)", () => {
+    expect(defaultTokenCounter.count).toBeUndefined();
+  });
+});

--- a/packages/plugins/src/__tests__/estimate-request-tokens.test.ts
+++ b/packages/plugins/src/__tests__/estimate-request-tokens.test.ts
@@ -5,6 +5,7 @@ import {
   estimateTokensByChars,
   estimateRequestTokens,
   defaultTokenCounter,
+  PER_MESSAGE_OVERHEAD,
 } from "../auto-compaction.js";
 
 const m = (t: string): Message => createUserMessage(t);
@@ -90,8 +91,8 @@ describe("estimateRequestTokens (X1, issue #55)", () => {
     // CJK：每码点 ≈ 1 token，仍生效。
     const cjk = "你好世界".repeat(10); // 40 码点
     const cjkEst = estimateRequestTokens({ messages: [m(cjk)] });
-    // ≈ 40 (CJK) + 4 (每消息开销)。
-    expect(cjkEst).toBe(40 + 4);
+    // ≈ 40 (CJK) + 每消息开销。
+    expect(cjkEst).toBe(40 + PER_MESSAGE_OVERHEAD);
 
     // 图片：扁平 1000，不随 data 长度膨胀。
     const imgMsg: Message = {
@@ -100,13 +101,13 @@ describe("estimateRequestTokens (X1, issue #55)", () => {
       timestamp: 0,
     };
     const imgEst = estimateRequestTokens({ messages: [imgMsg] });
-    expect(imgEst).toBe(1000 + 4); // 1000 (image) + 每消息开销
+    expect(imgEst).toBe(1000 + PER_MESSAGE_OVERHEAD); // 1000 (image) + 每消息开销
   });
 
   it("equals messages-only + per-message overhead when tools/systemPrompt are omitted", () => {
     const messages = [m("hello world"), m("second message")];
     expect(estimateRequestTokens({ messages })).toBe(
-      estimateTokensByChars(messages) + messages.length * 4,
+      estimateTokensByChars(messages) + messages.length * PER_MESSAGE_OVERHEAD,
     );
   });
 });

--- a/packages/plugins/src/__tests__/gap-explorer.test.ts
+++ b/packages/plugins/src/__tests__/gap-explorer.test.ts
@@ -7,9 +7,11 @@ import { AgentSession, Type, type HarnessTool } from "@harness-pi/core";
 import { createFakeModel, createTestContext } from "@harness-pi/core/testing";
 import {
   subAgentTool,
+  routedSubAgentTool,
   GapExplorer,
   type Gap,
   type ExplorerFinding,
+  type AgentSpec,
 } from "../controllers/index.js";
 
 function blockText(content: unknown): string {
@@ -298,6 +300,252 @@ describe("subAgentTool depth gate (#45)", () => {
     const result = await tool.execute({ task: "t" }, ctx, new AbortController().signal);
     expect(blockText(result.content)).toContain("ok");
     subFake.teardown();
+  });
+});
+
+/* ──────────────── routedSubAgentTool (#59 / S3) ──────────────── */
+
+describe("routedSubAgentTool (#59)", () => {
+  /** 从 TypeBox Union(of Literals) schema 抽出枚举值（形如 anyOf:[{const},...]）。 */
+  function enumValues(params: unknown): string[] {
+    const props = (params as { properties?: Record<string, unknown> }).properties ?? {};
+    const at = props["agent_type"] as { anyOf?: Array<{ const?: string }> } | undefined;
+    return (at?.anyOf ?? []).map((b) => b.const).filter((c): c is string => typeof c === "string");
+  }
+
+  it("exposes agent_type as an enum of all spec types and folds each whenToUse into the description", () => {
+    const specs: AgentSpec[] = [
+      {
+        type: "researcher",
+        whenToUse: "use for open-ended investigation",
+        sessionFactory: () => new AgentSession({ model: createFakeModel([]), tools: [] }),
+      },
+      {
+        type: "coder",
+        whenToUse: "use for writing or editing code",
+        sessionFactory: () => new AgentSession({ model: createFakeModel([]), tools: [] }),
+      },
+    ];
+    const tool = routedSubAgentTool({ specs });
+    expect(enumValues(tool.parameters).sort()).toEqual(["coder", "researcher"]);
+    // description 拼进每个 spec 的 whenToUse（含 type 标签），供模型路由。
+    expect(tool.description).toContain("use for open-ended investigation");
+    expect(tool.description).toContain("use for writing or editing code");
+    expect(tool.description).toContain("researcher");
+    expect(tool.description).toContain("coder");
+  });
+
+  it("routes a valid agent_type to that spec's sessionFactory (distinguishable results)", async () => {
+    // 两个 spec 各自 fake 出可区分的终态文本 → 断言路由命中正确 factory。
+    const aFake = createFakeModel([{ content: [{ type: "text", text: "ANSWER-A" }], stopReason: "stop" }]);
+    const bFake = createFakeModel([{ content: [{ type: "text", text: "ANSWER-B" }], stopReason: "stop" }]);
+    let aCalls = 0;
+    let bCalls = 0;
+    const tool = routedSubAgentTool({
+      specs: [
+        {
+          type: "alpha",
+          whenToUse: "alpha tasks",
+          sessionFactory: () => {
+            aCalls++;
+            return new AgentSession({ model: aFake, tools: [] });
+          },
+        },
+        {
+          type: "beta",
+          whenToUse: "beta tasks",
+          sessionFactory: () => {
+            bCalls++;
+            return new AgentSession({ model: bFake, tools: [] });
+          },
+        },
+      ],
+    });
+    const { ctx } = createTestContext();
+    const sig = new AbortController().signal;
+
+    const rb = await tool.execute({ agent_type: "beta", task: "do it" }, ctx, sig);
+    expect(blockText(rb.content)).toContain("ANSWER-B");
+    expect(bCalls).toBe(1);
+    expect(aCalls).toBe(0); // 没误派给 alpha
+
+    const ra = await tool.execute({ agent_type: "alpha", task: "do it" }, ctx, sig);
+    expect(blockText(ra.content)).toContain("ANSWER-A");
+    expect(aCalls).toBe(1);
+
+    aFake.teardown();
+    bFake.teardown();
+  });
+
+  it("passes the task + parent ctx (and spec maxTurns) to the routed sessionFactory", async () => {
+    const subFake = createFakeModel([{ content: [{ type: "text", text: "ok" }], stopReason: "stop" }]);
+    let gotTask = "";
+    let gotCtx: unknown = null;
+    let gotMaxTurns: number | undefined = -1;
+    const { ctx } = createTestContext();
+    const tool = routedSubAgentTool({
+      specs: [
+        {
+          type: "x",
+          whenToUse: "x",
+          maxTurns: 7,
+          sessionFactory: (task, c, maxTurns) => {
+            gotTask = task;
+            gotCtx = c;
+            gotMaxTurns = maxTurns;
+            return new AgentSession({ model: subFake, tools: [], ...(maxTurns ? { maxTurns } : {}) });
+          },
+        },
+      ],
+    });
+    await tool.execute({ agent_type: "x", task: "hello" }, ctx, new AbortController().signal);
+    expect(gotTask).toBe("hello");
+    expect(gotCtx).toBe(ctx);
+    expect(gotMaxTurns).toBe(7); // spec.maxTurns 透传给工厂第三参
+    subFake.teardown();
+  });
+
+  it("throws a clear error on an unknown agent_type (fail-loud, no crash)", async () => {
+    const subFake = createFakeModel([{ content: [{ type: "text", text: "ok" }], stopReason: "stop" }]);
+    let factoryCalls = 0;
+    const tool = routedSubAgentTool({
+      specs: [
+        {
+          type: "known",
+          whenToUse: "k",
+          sessionFactory: () => {
+            factoryCalls++;
+            return new AgentSession({ model: subFake, tools: [] });
+          },
+        },
+      ],
+    });
+    const { ctx } = createTestContext();
+    const sig = new AbortController().signal;
+    await expect(
+      tool.execute({ agent_type: "nope", task: "t" }, ctx, sig),
+    ).rejects.toThrow(/unknown agent_type "nope".*expected one of: known/);
+    expect(factoryCalls).toBe(0); // 非法 type 绝不 spawn
+    subFake.teardown();
+  });
+
+  it("throws a clear error on a missing agent_type", async () => {
+    const subFake = createFakeModel([{ content: [{ type: "text", text: "ok" }], stopReason: "stop" }]);
+    const tool = routedSubAgentTool({
+      specs: [{ type: "k", whenToUse: "k", sessionFactory: () => new AgentSession({ model: subFake, tools: [] }) }],
+    });
+    const { ctx } = createTestContext();
+    await expect(
+      tool.execute({ task: "t" }, ctx, new AbortController().signal),
+    ).rejects.toThrow(/unknown agent_type/);
+    subFake.teardown();
+  });
+
+  it("throws on an empty/missing task (HarnessTool error contract)", async () => {
+    const subFake = createFakeModel([]);
+    const tool = routedSubAgentTool({
+      specs: [{ type: "k", whenToUse: "k", sessionFactory: () => new AgentSession({ model: subFake, tools: [] }) }],
+    });
+    const { ctx } = createTestContext();
+    const sig = new AbortController().signal;
+    await expect(tool.execute({ agent_type: "k", task: "" }, ctx, sig)).rejects.toThrow(/empty task/);
+    await expect(tool.execute({ agent_type: "k", task: "   " }, ctx, sig)).rejects.toThrow(/empty task/);
+    subFake.teardown();
+  });
+
+  it("rejects empty specs and duplicate types at construction (fail-loud)", () => {
+    expect(() => routedSubAgentTool({ specs: [] })).toThrow(/specs must not be empty/);
+    const dup: AgentSpec[] = [
+      { type: "dup", whenToUse: "a", sessionFactory: () => new AgentSession({ model: createFakeModel([]), tools: [] }) },
+      { type: "dup", whenToUse: "b", sessionFactory: () => new AgentSession({ model: createFakeModel([]), tools: [] }) },
+    ];
+    expect(() => routedSubAgentTool({ specs: dup })).toThrow(/duplicate agent type "dup"/);
+  });
+
+  it("enforces the maxSubAgents budget across all types (fail-loud after the cap)", async () => {
+    const subFake = createFakeModel([{ content: [{ type: "text", text: "1" }], stopReason: "stop" }]);
+    const mk = () => new AgentSession({ model: subFake, tools: [] });
+    const tool = routedSubAgentTool({
+      maxSubAgents: 1,
+      specs: [
+        { type: "a", whenToUse: "a", sessionFactory: mk },
+        { type: "b", whenToUse: "b", sessionFactory: mk },
+      ],
+    });
+    const { ctx } = createTestContext();
+    const sig = new AbortController().signal;
+    await tool.execute({ agent_type: "a", task: "t" }, ctx, sig); // spawned=1
+    // 即便换一种 type，横向预算是跨 type 合计 → 第 2 个被拦。
+    await expect(
+      tool.execute({ agent_type: "b", task: "t" }, ctx, sig),
+    ).rejects.toThrow(/budget exhausted/);
+    subFake.teardown();
+  });
+
+  it("honors the vertical depth gate (#45): top-level spawn blocked when maxDepth=0", async () => {
+    const subFake = createFakeModel([{ content: [{ type: "text", text: "x" }], stopReason: "stop" }]);
+    let factoryCalls = 0;
+    const tool = routedSubAgentTool({
+      maxDepth: 0,
+      specs: [
+        {
+          type: "k",
+          whenToUse: "k",
+          sessionFactory: () => {
+            factoryCalls++;
+            return new AgentSession({ model: subFake, tools: [] });
+          },
+        },
+      ],
+    });
+    const { ctx } = createTestContext(); // depth 缺省 0
+    await expect(
+      tool.execute({ agent_type: "k", task: "t" }, ctx, new AbortController().signal),
+    ).rejects.toThrow(/depth limit \(maxDepth=0\) reached/);
+    expect(factoryCalls).toBe(0);
+    subFake.teardown();
+  });
+
+  it("propagates depth across layers (#45): nested routed spawn hits the depth limit at maxDepth", async () => {
+    // 嵌套：每层 routed tool 先 spawn 一层再收尾。depth 沿 lineage +1，maxDepth=2 时孙(depth 2)被挡。
+    const fakes: Array<ReturnType<typeof createFakeModel>> = [];
+    const depthsSeen: number[] = [];
+    const build = (): AgentSession => {
+      const fake = createFakeModel([
+        { content: [{ type: "toolCall", name: "subAgent", arguments: { agent_type: "worker", task: "deeper" } }] },
+        { content: [{ type: "text", text: "layer done" }], stopReason: "stop" },
+      ]);
+      fakes.push(fake);
+      const tool = routedSubAgentTool({
+        maxDepth: 2,
+        specs: [
+          {
+            type: "worker",
+            whenToUse: "worker",
+            sessionFactory: (_task, c) => {
+              depthsSeen.push(c.state.get("subAgent.depth") ?? 0);
+              return build();
+            },
+          },
+        ],
+      });
+      return new AgentSession({ model: fake, tools: [tool] });
+    };
+    const root = build();
+    const res = await root.run("start");
+    expect(res.reason).toBe("done");
+
+    // 孙(depth 2)层 execute 读到 depth=2>=2 → throw，kernel 包成 isError toolResult。
+    const errText = fakes
+      .flatMap((f) => f.getCalls())
+      .flatMap((c) => c.messages)
+      .filter((m) => m.role === "toolResult")
+      .map((m) => blockText((m as { content: unknown }).content))
+      .join("\n");
+    expect(errText).toContain("depth limit (maxDepth=2) reached");
+    // spawn 只发生在 depth 0、1（孙被挡，不进 sessionFactory）。
+    expect(depthsSeen).toEqual([0, 1]);
+    fakes.forEach((f) => f.teardown());
   });
 });
 

--- a/packages/plugins/src/__tests__/gap-explorer.test.ts
+++ b/packages/plugins/src/__tests__/gap-explorer.test.ts
@@ -377,23 +377,20 @@ describe("routedSubAgentTool (#59)", () => {
     bFake.teardown();
   });
 
-  it("passes the task + parent ctx (and spec maxTurns) to the routed sessionFactory", async () => {
+  it("passes the task + parent ctx to the routed sessionFactory", async () => {
     const subFake = createFakeModel([{ content: [{ type: "text", text: "ok" }], stopReason: "stop" }]);
     let gotTask = "";
     let gotCtx: unknown = null;
-    let gotMaxTurns: number | undefined = -1;
     const { ctx } = createTestContext();
     const tool = routedSubAgentTool({
       specs: [
         {
           type: "x",
           whenToUse: "x",
-          maxTurns: 7,
-          sessionFactory: (task, c, maxTurns) => {
+          sessionFactory: (task, c) => {
             gotTask = task;
             gotCtx = c;
-            gotMaxTurns = maxTurns;
-            return new AgentSession({ model: subFake, tools: [], ...(maxTurns ? { maxTurns } : {}) });
+            return new AgentSession({ model: subFake, tools: [] });
           },
         },
       ],
@@ -401,8 +398,24 @@ describe("routedSubAgentTool (#59)", () => {
     await tool.execute({ agent_type: "x", task: "hello" }, ctx, new AbortController().signal);
     expect(gotTask).toBe("hello");
     expect(gotCtx).toBe(ctx);
-    expect(gotMaxTurns).toBe(7); // spec.maxTurns 透传给工厂第三参
     subFake.teardown();
+  });
+
+  it("honors a custom tool name and description prefix (whenToUse folded after it)", async () => {
+    const tool = routedSubAgentTool({
+      name: "router",
+      description: "Route to a specialist.",
+      specs: [
+        { type: "alpha", whenToUse: "alpha tasks", sessionFactory: () => new AgentSession({ model: createFakeModel([]), tools: [] }) },
+      ],
+    });
+    expect(tool.name).toBe("router");
+    // 自定义前缀在前，各 spec 的 whenToUse 折叠在 "Available agent types:" 之后。
+    const prefixAt = tool.description.indexOf("Route to a specialist.");
+    const typesAt = tool.description.indexOf("Available agent types:");
+    expect(prefixAt).toBeGreaterThanOrEqual(0);
+    expect(typesAt).toBeGreaterThan(prefixAt);
+    expect(tool.description).toContain("alpha: alpha tasks");
   });
 
   it("throws a clear error on an unknown agent_type (fail-loud, no crash)", async () => {

--- a/packages/plugins/src/__tests__/microcompact.test.ts
+++ b/packages/plugins/src/__tests__/microcompact.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { AgentSession, createUserMessage } from "@harness-pi/core";
 import { createTestContext, createFakeModel } from "@harness-pi/core/testing";
-import type { Message } from "@earendil-works/pi-ai";
+import type { Message, Tool } from "@earendil-works/pi-ai";
 import { microcompact } from "../microcompact.js";
+import { estimateRequestTokens } from "../auto-compaction.js";
 
 function textOf(m: Message): string {
   return typeof m.content === "string"
@@ -331,5 +332,115 @@ describe("microcompact", () => {
     expect(textOf(session.messages[0]!)).toContain("FILE_A");
     expect(textOf(session.messages[1]!)).toContain("FILE_B");
     fake.teardown();
+  });
+
+  it("X1: triggers earlier when tools are big (messages just under, tools push over)", () => {
+    // 3 条小 read（远低于 triggerTokens 的 messages-only 体积），加上大 tool schema 后请求级估算越过阈值。
+    const msgs: Message[] = [
+      tr("read", "small-1"),
+      tr("read", "small-2"),
+      tr("read", "recent"), // keepRecent=1 保护
+    ];
+    const bigTool: Tool = {
+      name: "submit_evidence",
+      description: "Submit structured evidence with a long description. ".repeat(40),
+      parameters: {
+        type: "object",
+        properties: { body: { type: "string", description: "the body ".repeat(30) } },
+      },
+    } as Tool;
+
+    // 阈值卡在「无 tools 估算之下、有 tools 估算之上」之间。
+    const noTools = estimateRequestTokens({ messages: msgs });
+    const withTools = estimateRequestTokens({ messages: msgs, tools: [bigTool] });
+    expect(withTools).toBeGreaterThan(noTools);
+    const trigger = Math.floor((noTools + withTools) / 2);
+
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: trigger,
+      targetTokens: 1,
+      keepRecent: 1,
+    });
+
+    // 有 tools（经 ctx.config）→ 触发清理。
+    const { ctx } = createTestContext({ config: { tools: [bigTool] } });
+    const view = compact.transformMessagesBeforeLlm!(msgs, ctx) as Message[];
+    expect(view).toBeDefined();
+    expect(textOf(view[0]!)).toContain("microcompact");
+
+    // 无 tools（messages-only 等价）→ 不触发。
+    const { ctx: ctxNoTools } = createTestContext();
+    expect(compact.transformMessagesBeforeLlm!(msgs, ctxNoTools)).toBeUndefined();
+  });
+
+  it("X1: incremental running-total equals a full re-estimate even with fixed tools/system constants", () => {
+    // 5 条大 read + 大 tools + system。增量 total（清一条减 estimateOne 差值）必须与「对清理后视图全量
+    // estimateRequestTokens」完全一致——固定常量（tools/system/每消息开销）在差值里抵消，数学等价。
+    const msgs: Message[] = Array.from({ length: 5 }, (_, i) =>
+      tr("read", `R${i}_` + "x".repeat(4000)),
+    );
+    const tools: Tool[] = [
+      {
+        name: "read",
+        description: "Read a file. ".repeat(30),
+        parameters: { type: "object", properties: { path: { type: "string" } } },
+      } as Tool,
+    ];
+    const systemPrompt = "You are a careful agent. ".repeat(50);
+
+    // triggerTokens = targetTokens = 2500：总体积 ~5000 > 2500 → 触发；清到 ≤2500 即停（中途早停、清部分），
+    // 考验早停判据用的增量 total 是否与全量重估一致。
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 2500,
+      targetTokens: 2500,
+      keepRecent: 0,
+    });
+    const { ctx } = createTestContext({ config: { tools, systemPrompt } });
+    const view = compact.transformMessagesBeforeLlm!(msgs, ctx) as Message[];
+    expect(view).toBeDefined();
+
+    // 部分被清（早停语义）：既有占位符也有原文留存。
+    const cleared = view.filter((mm) => textOf(mm).includes("microcompact")).length;
+    expect(cleared).toBeGreaterThan(0);
+    expect(cleared).toBeLessThan(5);
+
+    // 关键回归：对最终视图做全量请求级估算 ≤ targetTokens（增量 total 早停判据若与全量重估不一致，这里会破）。
+    const fullReEstimate = estimateRequestTokens({ messages: view, tools, systemPrompt });
+    expect(fullReEstimate).toBeLessThanOrEqual(2500);
+    // 且清掉最后一条之前的视图仍 > targetTokens（证明没有过度早停）——再恢复一条原文必然超标。
+    const idxsCleared: number[] = [];
+    view.forEach((mm, i) => {
+      if (textOf(mm).includes("microcompact")) idxsCleared.push(i);
+    });
+    const lastClearedIdx = idxsCleared[idxsCleared.length - 1]!;
+    const oneFewer = view.slice();
+    oneFewer[lastClearedIdx] = msgs[lastClearedIdx]!; // 把最后清的一条换回原文
+    const beforeLastClear = estimateRequestTokens({ messages: oneFewer, tools, systemPrompt });
+    expect(beforeLastClear).toBeGreaterThan(2500);
+  });
+
+  it("X1: a custom tokenCounter overrides the default", () => {
+    const calls: number[] = [];
+    const msgs: Message[] = [tr("read", "a"), tr("read", "b"), tr("read", "recent")];
+    const compact = microcompact({
+      compactableTools: ["read"],
+      triggerTokens: 100,
+      targetTokens: 1,
+      keepRecent: 1,
+      tokenCounter: {
+        estimate: ({ messages }) => {
+          calls.push(messages.length);
+          // 全量（>1 条）报超阈值以触发；单条 delta 用真实小值（这里给固定 50/条便于测调用）。
+          return messages.length === 1 ? 50 : 9999;
+        },
+      },
+    });
+    const { ctx } = createTestContext();
+    const view = compact.transformMessagesBeforeLlm!(msgs, ctx) as Message[];
+    expect(view).toBeDefined();
+    expect(textOf(view[0]!)).toContain("microcompact"); // 注入 counter 触发了清理
+    expect(calls.length).toBeGreaterThan(0); // counter 真被调用
   });
 });

--- a/packages/plugins/src/auto-compaction.ts
+++ b/packages/plugins/src/auto-compaction.ts
@@ -167,6 +167,13 @@ export function estimateRequestTokens(input: RequestTokenInput): number {
  *
  * **当前不实现 `count`**：pi-ai 0.74.2 无 `countTokens`（D0 已核），保留可选签名只为留一个不破坏 API 的接入口
  * （将来接真 tokenizer / provider count endpoint 时填它，消费方按需 `await counter.count?.(...)`）。
+ *
+ * **`estimate` 的 additivity 契约（自定义实现须遵守）**：`microcompact` 的增量 running-total
+ * （`total -= estimate({messages:[原]}) - estimate({messages:[占位]})`）只有在「`estimate` 对 messages 逐条可加、
+ * 且 tools/systemPrompt/每消息开销是**与单条消息无关的固定常量**」时才与全量重估逐 token 等价。默认
+ * {@link estimateRequestTokens} 满足。**非可加的真 BPE tokenizer 不满足**（token 跨消息边界、request framing 非线性）——
+ * 注入这类 counter 会让 microcompact 的体积早停漂移。届时应让 microcompact 改为每步全量 `estimate(整段)`，或只在
+ * autoCompaction（无增量假设）里用它。
  */
 export interface TokenCounter {
   estimate(input: RequestTokenInput): number;

--- a/packages/plugins/src/auto-compaction.ts
+++ b/packages/plugins/src/auto-compaction.ts
@@ -142,7 +142,7 @@ export function estimateTokensByChars(messages: Message[]): number {
 }
 
 /** 每条消息的固定格式开销（role / 分隔符 / 模板包装），主流 chat 模板约 3–4 tok/消息，取保守 4。 */
-const PER_MESSAGE_OVERHEAD = 4;
+export const PER_MESSAGE_OVERHEAD = 4;
 
 /** {@link estimateRequestTokens} 的输入：一次 LLM 请求随发的三部分（tools / systemPrompt 每请求都发）。 */
 export interface RequestTokenInput {
@@ -268,7 +268,11 @@ export function autoCompaction(opts: AutoCompactionOptions): Hook {
         const contextWindow = ctx.config.model.contextWindow;
         if (contextWindow > 0) {
           const reserveForOutput = opts.reserveForOutput ?? Math.min(ctx.config.model.maxTokens, 4096);
-          threshold = contextWindow - reserveForOutput - safetyBuffer;
+          const w = contextWindow - reserveForOutput - safetyBuffer;
+          // 防 footgun:reserve+safetyBuffer >= contextWindow 时 w<=0,直接用会让 estimated(>=0)永远 > 阈值
+          // → 每 turn 都压缩(过度激进)。视为「算不出有意义阈值」→ 本 turn no-op(下面 threshold===undefined 兜底)。
+          // 这种 misconfig 需 window < reserve(本就荒谬),no-op 比每 turn 空压更安全、更可诊断。
+          if (w > 0) threshold = w;
         }
       }
       if (threshold === undefined) return undefined;

--- a/packages/plugins/src/auto-compaction.ts
+++ b/packages/plugins/src/auto-compaction.ts
@@ -24,7 +24,7 @@
 
 import type { Hook, HookContext } from "@harness-pi/core";
 import { createUserMessage } from "@harness-pi/core";
-import type { Message } from "@earendil-works/pi-ai";
+import type { Message, Tool } from "@earendil-works/pi-ai";
 
 export interface AutoCompactionOptions {
   /** context token 预算（通常 = 模型上下文窗口，或你愿意用满的上限）。须 > 0。 */
@@ -39,10 +39,12 @@ export interface AutoCompactionOptions {
     ctx: HookContext,
   ) => string | Promise<string>;
   /**
-   * token 估算器。默认 {@link estimateTokensByChars}：CJK 感知（≈ 1 token/字）+ 图片感知（每图扁平估值），
-   * 整体偏**保守高估**（低估会漏触发压缩→窗口溢出，是安全 bug）；零依赖。接入真 tokenizer 可覆盖。
+   * Token 计数器（issue #55）。默认 {@link defaultTokenCounter}：`estimate` = {@link estimateRequestTokens}，
+   * 在 messages 字符估算之上**加回** tool schema + systemPrompt + 每消息格式开销（只数消息会低估真 usage ~7x）。
+   * 触发判据据此算，故有 tools 时**触发点比旧 messages-only 更早 = 更贴近真实窗口压力**（0.x 可接受的行为变更）。
+   * tools / systemPrompt 由内核经 `ctx.config` 提供，无需调用方传。接入真 tokenizer 时覆盖本选项即可。
    */
-  estimateTokens?: (messages: Message[]) => number;
+  tokenCounter?: TokenCounter;
   /**
    * 「想覆盖的前缀」比上次缓存增长达到这么多条才重算 summary；默认 = keepRecent。
    * 调大省 LLM 调用，调小更省 token。须 ≥ 1。
@@ -93,7 +95,9 @@ function estimateText(text: string): number {
  *   既不按短 ref 的字符数低估、也不按内联 base64 `data` 的字符数疯狂高估。
  * - **其余文本**（ASCII 等）：≈ 1/4 token/字符（向上取整），故纯英文仍 ≈ chars/4。
  *
- * 想接真 tokenizer：覆盖 `estimateTokens` 选项即可。
+ * **仅数消息文本**——不含每请求随发的 tool schema / systemPrompt / 格式开销（那些会**严重低估**真 usage，
+ * 见 {@link estimateRequestTokens}）。保留本函数原样是为向后兼容；消费插件默认走请求级的 {@link defaultTokenCounter}。
+ * 想接真 tokenizer：覆盖插件的 `tokenCounter` 选项即可。
  */
 export function estimateTokensByChars(messages: Message[]): number {
   let tokens = 0;
@@ -115,6 +119,64 @@ export function estimateTokensByChars(messages: Message[]): number {
   }
   return tokens;
 }
+
+/** 每条消息的固定格式开销（role / 分隔符 / 模板包装），主流 chat 模板约 3–4 tok/消息，取保守 4。 */
+const PER_MESSAGE_OVERHEAD = 4;
+
+/** {@link estimateRequestTokens} 的输入：一次 LLM 请求随发的三部分（tools / systemPrompt 每请求都发）。 */
+export interface RequestTokenInput {
+  messages: Message[];
+  /** 本次请求随发的 tool schema（pi-ai `Tool`：name + description + parameters）。 */
+  tools?: ReadonlyArray<Tool>;
+  /** 本次请求的 system prompt。 */
+  systemPrompt?: string;
+}
+
+/**
+ * 估算**整次 LLM 请求**的 token —— 在 {@link estimateTokensByChars}(messages) 之上，**加回**那些每请求随发、
+ * 却被「只数消息文本」漏掉的固定开销（issue #55 / D0 实测：只数消息低估真 usage ~7x，根因正是漏了下面三项）：
+ *
+ *   1. **tool schema**：每个 tool 的 `name` + `description` + `JSON.stringify(parameters)` 字符估算（走 1/4 规则）。
+ *      工具一多、parameters schema 一深，这块就是估算盲区里最大的一块。
+ *   2. **systemPrompt**：整段 system prompt 的字符估算（复用 CJK 感知的 {@link estimateTokensByChars}）。
+ *   3. **每消息格式开销**：每条消息一个小常量（{@link PER_MESSAGE_OVERHEAD}），覆盖 role / 分隔符 / 模板包装。
+ *
+ * CJK / image / chars-1/4 规则全部沿用 estimateTokensByChars，整体仍偏**保守高估**（压缩触发判据宁高勿低）。
+ * tools / systemPrompt **不传**时本函数退化为「estimateTokensByChars(messages) + 每消息常量」——比纯 messages-only
+ * 仍多算每消息常量，但语义一致。
+ */
+export function estimateRequestTokens(input: RequestTokenInput): number {
+  let tokens = estimateTokensByChars(input.messages);
+  tokens += input.messages.length * PER_MESSAGE_OVERHEAD;
+  if (input.systemPrompt) {
+    tokens += estimateText(input.systemPrompt);
+  }
+  if (input.tools) {
+    for (const t of input.tools) {
+      tokens += estimateText(t.name);
+      tokens += estimateText(t.description);
+      tokens += estimateText(JSON.stringify(t.parameters));
+    }
+  }
+  return tokens;
+}
+
+/**
+ * Token 计数 seam（issue #55）。`estimate` = 同步、零依赖的字符估算（默认 {@link estimateRequestTokens}）；
+ * `count` = 未来 opt-in 的**真** tokenizer（async）。
+ *
+ * **当前不实现 `count`**：pi-ai 0.74.2 无 `countTokens`（D0 已核），保留可选签名只为留一个不破坏 API 的接入口
+ * （将来接真 tokenizer / provider count endpoint 时填它，消费方按需 `await counter.count?.(...)`）。
+ */
+export interface TokenCounter {
+  estimate(input: RequestTokenInput): number;
+  count?(input: RequestTokenInput): Promise<number>;
+}
+
+/** 默认 TokenCounter：`estimate` = {@link estimateRequestTokens}；不提供 `count`。 */
+export const defaultTokenCounter: TokenCounter = {
+  estimate: estimateRequestTokens,
+};
 
 /**
  * 构造一个 autoCompaction hook。三条**使用须知**（issue #13，违反会得到悄无声息的错误压缩）：
@@ -146,7 +208,7 @@ export function autoCompaction(opts: AutoCompactionOptions): Hook {
   if (resummarizeEvery < 1) {
     throw new Error("autoCompaction: resummarizeEvery must be >= 1");
   }
-  const estimate = opts.estimateTokens ?? estimateTokensByChars;
+  const counter = opts.tokenCounter ?? defaultTokenCounter;
   const threshold = opts.maxContextTokens * triggerRatio;
   const wrap =
     opts.summaryText ??
@@ -159,8 +221,13 @@ export function autoCompaction(opts: AutoCompactionOptions): Hook {
     name: "autoCompaction",
 
     async transformMessagesBeforeLlm(messages, ctx) {
-      // 未到 token 阈值 → 原样。
-      if (estimate(messages) <= threshold) return undefined;
+      // 未到 token 阈值 → 原样。tools / systemPrompt 由 ctx.config 提供，计入每请求随发的固定开销（X1）。
+      const estimated = counter.estimate({
+        messages,
+        tools: ctx.config.tools,
+        systemPrompt: ctx.config.systemPrompt,
+      });
+      if (estimated <= threshold) return undefined;
       // 已经压无可压（tail 即全部）→ 总结救不了，交给 overflow 兜底，不在这里空转。
       if (messages.length <= keepRecent) return undefined;
 

--- a/packages/plugins/src/auto-compaction.ts
+++ b/packages/plugins/src/auto-compaction.ts
@@ -27,10 +27,31 @@ import { createUserMessage } from "@harness-pi/core";
 import type { Message, Tool } from "@earendil-works/pi-ai";
 
 export interface AutoCompactionOptions {
-  /** context token 预算（通常 = 模型上下文窗口，或你愿意用满的上限）。须 > 0。 */
-  maxContextTokens: number;
-  /** 触发比例：估算 tokens > `maxContextTokens * triggerRatio` 才压缩。默认 0.8，须 ∈ (0, 1]。 */
+  /**
+   * context token 预算（百分比触发路径）。须 > 0。
+   *
+   * **触发路径优先级（X2 / #57）**：
+   *   - 显式给了 `maxContextTokens` → 永远走百分比路径 `> maxContextTokens * triggerRatio`（尊重调用方的显式上限，
+   *     与旧行为一致；现有测试多走此路径）。
+   *   - 未给 `maxContextTokens`、但 `ctx.config.model.contextWindow > 0` → 走**绝对窗口路径**
+   *     `> contextWindow − reserveForOutput − safetyBuffer`（X2 的有效窗口阈值，更贴近真实窗口压力）。
+   *   - 两者都不可得（无 maxContextTokens 且 contextWindow 为 0/缺）→ 算不出阈值，本 turn 不压缩
+   *     （contextWindow 是运行时值、构造期无从校验，故退化为 no-op 而非构造期报错）。
+   *
+   * 即：**显式 maxContextTokens 压过窗口路径**；窗口路径是「没显式上限时用模型自带窗口」的兜底主路。
+   */
+  maxContextTokens?: number;
+  /** 触发比例（百分比路径）：估算 tokens > `maxContextTokens * triggerRatio` 才压缩。默认 0.8，须 ∈ (0, 1]。 */
   triggerRatio?: number;
+  /**
+   * 窗口路径（X2 / #57）给模型输出 + summary/续答预留的 token 数（从 contextWindow 里扣掉）。
+   * 默认 `Math.min(model.maxTokens, 4096)`——既不超模型实际能输出的上限、又给个合理保底。须 ≥ 0。
+   */
+  reserveForOutput?: number;
+  /**
+   * 窗口路径（X2 / #57）的绝对安全缓冲（再从 contextWindow 里多扣一截，吸收估算误差）。默认 0，须 ≥ 0。
+   */
+  safetyBuffer?: number;
   /** 压缩后原样保留的最近消息条数（recent tail）。默认 6，须 ≥ 1。 */
   keepRecent?: number;
   /** 把一批早期消息总结成文本（可 async / 调 LLM）——与 compactSummarize 同契约。 */
@@ -200,7 +221,8 @@ export const defaultTokenCounter: TokenCounter = {
  *    每个 session 各 `autoCompaction(...)` 一次。
  */
 export function autoCompaction(opts: AutoCompactionOptions): Hook {
-  if (!(opts.maxContextTokens > 0)) {
+  // maxContextTokens 可选（X2）：给了就走百分比路径(并须 > 0)；不给则走窗口路径(阈值来自 ctx.config.model)。
+  if (opts.maxContextTokens !== undefined && !(opts.maxContextTokens > 0)) {
     throw new Error("autoCompaction: maxContextTokens must be > 0");
   }
   const triggerRatio = opts.triggerRatio ?? 0.8;
@@ -215,8 +237,17 @@ export function autoCompaction(opts: AutoCompactionOptions): Hook {
   if (resummarizeEvery < 1) {
     throw new Error("autoCompaction: resummarizeEvery must be >= 1");
   }
+  if (opts.reserveForOutput !== undefined && opts.reserveForOutput < 0) {
+    throw new Error("autoCompaction: reserveForOutput must be >= 0");
+  }
+  if (opts.safetyBuffer !== undefined && opts.safetyBuffer < 0) {
+    throw new Error("autoCompaction: safetyBuffer must be >= 0");
+  }
   const counter = opts.tokenCounter ?? defaultTokenCounter;
-  const threshold = opts.maxContextTokens * triggerRatio;
+  const safetyBuffer = opts.safetyBuffer ?? 0;
+  // 百分比路径阈值是构造期常量；窗口路径阈值依赖 ctx.config.model.contextWindow，须每请求算。
+  const percentThreshold =
+    opts.maxContextTokens !== undefined ? opts.maxContextTokens * triggerRatio : undefined;
   const wrap =
     opts.summaryText ??
     ((summary, n) => `[auto-compacted summary of ${n} earlier messages]\n${summary}`);
@@ -228,6 +259,20 @@ export function autoCompaction(opts: AutoCompactionOptions): Hook {
     name: "autoCompaction",
 
     async transformMessagesBeforeLlm(messages, ctx) {
+      // 触发阈值（X2 #57，优先级：显式 maxContextTokens 压过窗口路径）：
+      //   - 给了 maxContextTokens → 百分比路径常量 percentThreshold（旧行为，尊重显式上限）。
+      //   - 否则用 model.contextWindow > 0 → 窗口路径 contextWindow − reserveForOutput − safetyBuffer。
+      //   - 两者都不可得 → 算不出阈值，本 turn 不压缩（return undefined）。
+      let threshold = percentThreshold;
+      if (threshold === undefined) {
+        const contextWindow = ctx.config.model.contextWindow;
+        if (contextWindow > 0) {
+          const reserveForOutput = opts.reserveForOutput ?? Math.min(ctx.config.model.maxTokens, 4096);
+          threshold = contextWindow - reserveForOutput - safetyBuffer;
+        }
+      }
+      if (threshold === undefined) return undefined;
+
       // 未到 token 阈值 → 原样。tools / systemPrompt 由 ctx.config 提供，计入每请求随发的固定开销（X1）。
       const estimated = counter.estimate({
         messages,

--- a/packages/plugins/src/controllers/index.ts
+++ b/packages/plugins/src/controllers/index.ts
@@ -48,8 +48,12 @@ export type {
   CompactRestartResult,
 } from "./compact-restart-fresh.js";
 
-export { subAgentTool } from "./sub-agent-tool.js";
-export type { SubAgentToolOptions } from "./sub-agent-tool.js";
+export { subAgentTool, routedSubAgentTool } from "./sub-agent-tool.js";
+export type {
+  SubAgentToolOptions,
+  AgentSpec,
+  RoutedSubAgentToolOptions,
+} from "./sub-agent-tool.js";
 
 export { persistCompactionBoundary } from "./persist-compaction-boundary.js";
 export type { PersistCompactionBoundaryOptions } from "./persist-compaction-boundary.js";

--- a/packages/plugins/src/controllers/sub-agent-tool.ts
+++ b/packages/plugins/src/controllers/sub-agent-tool.ts
@@ -144,16 +144,11 @@ export interface AgentSpec {
   /** 给模型看的选择依据——拼进 tool description，让模型据此决定派给哪种 agent。 */
   whenToUse: string;
   /**
-   * 造这种 sub-agent 的 AgentSession 工厂。形如单 factory 版的 `(task, ctx)`，但多收一个**可选**
-   * 第三参 `maxTurns`——即本 spec 声明的 `maxTurns`（见下）。`AgentSession.maxTurns` 是构造期 readonly，
-   * 故由工厂在 `new AgentSession({ ..., maxTurns })` 时落地（不给就用工厂自己的默认）。
+   * 造这种 sub-agent 的 AgentSession 工厂——与单 factory 版 `SubAgentToolOptions.sessionFactory`
+   * 同型 `(task, ctx)`。这种 sub-agent 的轮数/预算（maxTurns 等）由工厂在 `new AgentSession(...)`
+   * 时自行闭包决定，不在 spec 上重复声明。
    */
-  sessionFactory: (task: string, ctx: HookContext, maxTurns?: number) => AgentSession;
-  /**
-   * 可选：本 spec 造出的 sub-agent 的轮数上限。给了就作为第三参透传给 `sessionFactory`，
-   * 由工厂在构造时落地。不给则第三参为 undefined，工厂沿用自身默认。
-   */
-  maxTurns?: number;
+  sessionFactory: (task: string, ctx: HookContext) => AgentSession;
 }
 
 export interface RoutedSubAgentToolOptions {
@@ -178,7 +173,7 @@ export interface RoutedSubAgentToolOptions {
  * 与单 factory 版共享同一套 bounded 机制：横向 `maxSubAgents` 扇出闸 + 纵向 `maxDepth` 跨层深度闸（#45）
  * 都对 routed 变体同样生效（复用 `DEPTH_KEY` 透传 + `spawnSubAgent`）。差别只在：参数多一个 `agent_type`
  * 枚举（值 = 各 spec 的 `type`），description 拼进每个 spec 的 `whenToUse` 供模型路由，execute 时按
- * `agent_type` 分派到对应 spec 的 `sessionFactory`（及其可选 `maxTurns`）。
+ * `agent_type` 分派到对应 spec 的 `sessionFactory`。
  *
  * **domain-free**：本工厂不认识任何业务；每种 sub-agent 用什么 tools/systemPrompt 全在调用方的 spec 里。
  */
@@ -248,7 +243,7 @@ export function routedSubAgentTool(opts: RoutedSubAgentToolOptions): HarnessTool
       }
       spawned++;
 
-      const sub = spec.sessionFactory(task, ctx, spec.maxTurns);
+      const sub = spec.sessionFactory(task, ctx);
       return spawnSubAgent(sub, task, depth, signal);
     },
   };

--- a/packages/plugins/src/controllers/sub-agent-tool.ts
+++ b/packages/plugins/src/controllers/sub-agent-tool.ts
@@ -9,7 +9,7 @@
  * `sessionFactory` 里。父 session 的 abort signal 透传给 sub-agent（协作式取消）。
  */
 
-import type { AgentSession, Hook, HarnessTool, HookContext, Message } from "@harness-pi/core";
+import type { AgentSession, Hook, HarnessTool, HookContext, Message, ToolExecResult } from "@harness-pi/core";
 import { Type } from "@earendil-works/pi-ai";
 
 /**
@@ -52,6 +52,46 @@ function messageText(m: Message | undefined): string {
         .join("");
 }
 
+/**
+ * 共享：spawn 一个 sub-agent session 并整形结果。单 factory 版与 routed 版（#59）都走这里——
+ * 纵向深度透传（给子挂 onSessionStart hook 把深度设为 父+1）、父 signal 透传、子终态回灌全在此收口。
+ * 横向/纵向闸由调用方在调用前各自判（错误文案各自独立），故本函数只管「确实要 spawn 时」的动作。
+ */
+async function spawnSubAgent(
+  sub: AgentSession,
+  task: string,
+  depth: number,
+  signal: AbortSignal,
+): Promise<ToolExecResult> {
+  // 纵向深度透传：给子 session 挂一个 onSessionStart hook，把子 ctx.state 的深度设为 当前+1。
+  // 子 session 自己的（routed）subAgentTool（若有）execute 时就读到递增后的深度——多分支各自从父继承，
+  // 互不串扰（每个子 session 有独立 ctx.state）。零内核改动：只用现成的 use()/onSessionStart。
+  const depthInjector: Hook = {
+    name: "subAgent.depth-injector",
+    internal: true,
+    onSessionStart(_input, subCtx) {
+      subCtx.state.set(DEPTH_KEY, depth + 1);
+    },
+  };
+  sub.use(depthInjector);
+  // 父 signal 透传 → sub-agent 可被父的 abort 协作式取消。
+  const summary = await sub.run(task, { signal });
+  const text = messageText(summary.lastMessage) || "(sub-agent produced no text output)";
+
+  // 把子代理终态放进 details（trace/metrics 用），content 回灌父模型。
+  return {
+    content: [{ type: "text", text }],
+    details: {
+      subAgent: {
+        reason: summary.reason,
+        turns: summary.turns,
+        usage: summary.usage,
+        ...(summary.stopReason ? { stopReason: summary.stopReason } : {}),
+      },
+    },
+  };
+}
+
 export function subAgentTool(opts: SubAgentToolOptions): HarnessTool {
   const max = opts.maxSubAgents ?? 8;
   const maxDepth = opts.maxDepth ?? 2;
@@ -86,34 +126,130 @@ export function subAgentTool(opts: SubAgentToolOptions): HarnessTool {
       }
       spawned++;
 
-      // 父 signal 透传 → sub-agent 可被父的 abort 协作式取消。
       const sub = opts.sessionFactory(task, ctx);
-      // 纵向深度透传：给子 session 挂一个 onSessionStart hook，把子 ctx.state 的深度设为 当前+1。
-      // 子 session 自己的 subAgentTool（若有）execute 时就读到递增后的深度——多分支各自从父继承，
-      // 互不串扰（每个子 session 有独立 ctx.state）。零内核改动：只用现成的 use()/onSessionStart。
-      const depthInjector: Hook = {
-        name: "subAgent.depth-injector",
-        internal: true,
-        onSessionStart(_input, subCtx) {
-          subCtx.state.set(DEPTH_KEY, depth + 1);
-        },
-      };
-      sub.use(depthInjector);
-      const summary = await sub.run(task, { signal });
-      const text = messageText(summary.lastMessage) || "(sub-agent produced no text output)";
+      return spawnSubAgent(sub, task, depth, signal);
+    },
+  };
+}
 
-      // 把子代理终态放进 details（trace/metrics 用），content 回灌父模型。
-      return {
-        content: [{ type: "text", text }],
-        details: {
-          subAgent: {
-            reason: summary.reason,
-            turns: summary.turns,
-            usage: summary.usage,
-            ...(summary.stopReason ? { stopReason: summary.stopReason } : {}),
-          },
-        },
-      };
+/* ──────────────── routed 变体（#59 / S3） ──────────────── */
+
+/**
+ * 一种可路由的 sub-agent 规格（**domain-free**：只是「类型标识 + 选择依据 + 怎么造 session」，
+ * 不含任何业务/文件布局概念）。父模型据 `whenToUse` 在多个 spec 间挑一个 `type` 来分派。
+ */
+export interface AgentSpec {
+  /** 路由标识。父模型用它在 `agent_type` 参数里点名；同一 tool 内须唯一。 */
+  type: string;
+  /** 给模型看的选择依据——拼进 tool description，让模型据此决定派给哪种 agent。 */
+  whenToUse: string;
+  /**
+   * 造这种 sub-agent 的 AgentSession 工厂。形如单 factory 版的 `(task, ctx)`，但多收一个**可选**
+   * 第三参 `maxTurns`——即本 spec 声明的 `maxTurns`（见下）。`AgentSession.maxTurns` 是构造期 readonly，
+   * 故由工厂在 `new AgentSession({ ..., maxTurns })` 时落地（不给就用工厂自己的默认）。
+   */
+  sessionFactory: (task: string, ctx: HookContext, maxTurns?: number) => AgentSession;
+  /**
+   * 可选：本 spec 造出的 sub-agent 的轮数上限。给了就作为第三参透传给 `sessionFactory`，
+   * 由工厂在构造时落地。不给则第三参为 undefined，工厂沿用自身默认。
+   */
+  maxTurns?: number;
+}
+
+export interface RoutedSubAgentToolOptions {
+  /** 候选 agent 规格（至少一个）。`agent_type` 枚举 = 全部 spec 的 `type`。 */
+  specs: AgentSpec[];
+  /** tool name（默认 "subAgent"）。 */
+  name?: string;
+  /**
+   * tool description 前缀（给模型看的总体说明）。各 spec 的 `whenToUse` 会**自动拼在其后**，
+   * 故这里只写「这是个会路由的子代理工具」之类的总纲，不必重复每种 agent 的用途。
+   */
+  description?: string;
+  /** 本 tool 实例最多派多少个 sub-agent（**横向**闸：跨所有 type 合计）。默认 8。 */
+  maxSubAgents?: number;
+  /** 跨层递归**纵向**深度闸（#45），语义同单 factory 版。默认 2。 */
+  maxDepth?: number;
+}
+
+/**
+ * routed sub-agent tool factory（#59）——在单 factory 版旁加一个**多规格、按 `agent_type` 路由**的变体。
+ *
+ * 与单 factory 版共享同一套 bounded 机制：横向 `maxSubAgents` 扇出闸 + 纵向 `maxDepth` 跨层深度闸（#45）
+ * 都对 routed 变体同样生效（复用 `DEPTH_KEY` 透传 + `spawnSubAgent`）。差别只在：参数多一个 `agent_type`
+ * 枚举（值 = 各 spec 的 `type`），description 拼进每个 spec 的 `whenToUse` 供模型路由，execute 时按
+ * `agent_type` 分派到对应 spec 的 `sessionFactory`（及其可选 `maxTurns`）。
+ *
+ * **domain-free**：本工厂不认识任何业务；每种 sub-agent 用什么 tools/systemPrompt 全在调用方的 spec 里。
+ */
+export function routedSubAgentTool(opts: RoutedSubAgentToolOptions): HarnessTool {
+  const specs = opts.specs;
+  if (specs.length === 0) {
+    throw new Error("routedSubAgentTool: specs must not be empty");
+  }
+  // type 须唯一——重复会让枚举/路由表二义，构造期 fail-loud 比运行时静默撞车好。
+  const byType = new Map<string, AgentSpec>();
+  for (const s of specs) {
+    if (byType.has(s.type)) {
+      throw new Error(`routedSubAgentTool: duplicate agent type "${s.type}"`);
+    }
+    byType.set(s.type, s);
+  }
+
+  const max = opts.maxSubAgents ?? 8;
+  const maxDepth = opts.maxDepth ?? 2;
+  let spawned = 0;
+
+  const types = specs.map((s) => s.type);
+  // description 拼进每个 spec 的 whenToUse → 模型据此挑 agent_type。
+  const routingLines = specs.map((s) => `- ${s.type}: ${s.whenToUse}`).join("\n");
+  const description =
+    (opts.description ??
+      "Delegate a self-contained sub-task to a bounded sub-agent, routed by agent_type.") +
+    `\n\nAvailable agent types:\n${routingLines}`;
+
+  return {
+    name: opts.name ?? "subAgent",
+    description,
+    parameters: Type.Object({
+      agent_type: Type.Union(
+        types.map((t) => Type.Literal(t)),
+        { description: `Which kind of sub-agent to route this task to. One of: ${types.join(", ")}.` },
+      ),
+      task: Type.String({
+        description: "A self-contained task for the chosen sub-agent to carry out.",
+      }),
+    }),
+
+    async execute(args, ctx, signal) {
+      const task = typeof args.task === "string" ? args.task : "";
+      // throw 是 HarnessTool 的错误合约（kernel 包成 isError 回灌模型）——空任务 / 非法 type / 超预算 / 超深都 fail-loud。
+      if (task.trim().length === 0) {
+        throw new Error("subAgent: empty task");
+      }
+      // 路由防御性校验：缺失 / 非枚举的 agent_type → 明确 error（不崩、不静默）。即使内核 validate 已按枚举
+      // schema 拦过，这里仍兜一层，便于直接 execute（绕过内核）时也有清晰错误。
+      const agentType = typeof args.agent_type === "string" ? args.agent_type : "";
+      const spec = byType.get(agentType);
+      if (!spec) {
+        throw new Error(
+          `subAgent: unknown agent_type "${agentType}" (expected one of: ${types.join(", ")})`,
+        );
+      }
+      // 纵向闸（#45）：读**当前** session 深度（缺省 0）。到顶就不 spawn——挡在横向计数之前，
+      // 让超深的尝试不消耗本层 maxSubAgents 预算（二闸正交）。
+      const depth = ctx.state.get(DEPTH_KEY) ?? 0;
+      if (depth >= maxDepth) {
+        throw new Error(`subAgent: depth limit (maxDepth=${maxDepth}) reached`);
+      }
+      // 横向闸：本 tool 实例的扇出预算（跨所有 type 合计）。
+      if (spawned >= max) {
+        throw new Error(`subAgent: budget exhausted (max ${max} sub-agents per tool)`);
+      }
+      spawned++;
+
+      const sub = spec.sessionFactory(task, ctx, spec.maxTurns);
+      return spawnSubAgent(sub, task, depth, signal);
     },
   };
 }

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -44,8 +44,17 @@ export type { LeaseDecisionOptions } from "./lease-decision.js";
 export { compactSummarize } from "./compact-summarize.js";
 export type { CompactSummarizeOptions } from "./compact-summarize.js";
 
-export { autoCompaction, estimateTokensByChars } from "./auto-compaction.js";
-export type { AutoCompactionOptions } from "./auto-compaction.js";
+export {
+  autoCompaction,
+  estimateTokensByChars,
+  estimateRequestTokens,
+  defaultTokenCounter,
+} from "./auto-compaction.js";
+export type {
+  AutoCompactionOptions,
+  RequestTokenInput,
+  TokenCounter,
+} from "./auto-compaction.js";
 
 export { microcompact } from "./microcompact.js";
 export type { MicrocompactOptions } from "./microcompact.js";

--- a/packages/plugins/src/microcompact.ts
+++ b/packages/plugins/src/microcompact.ts
@@ -23,7 +23,7 @@
 
 import type { Hook } from "@harness-pi/core";
 import type { Message } from "@earendil-works/pi-ai";
-import { estimateTokensByChars } from "./auto-compaction.js";
+import { defaultTokenCounter, type TokenCounter } from "./auto-compaction.js";
 
 export interface MicrocompactOptions {
   /** 只清这些工具产生的 toolResult。**不 hardcode 工具名**——由调用方传（domain-free）。string[] 会归一成 Set。 */
@@ -44,8 +44,12 @@ export interface MicrocompactOptions {
   gapMinutes?: number;
   /** 当前时刻（ms）。默认 `Date.now`；测试可注入以走 `gapMinutes` 路径。 */
   now?: () => number;
-  /** token 估算器。默认 {@link estimateTokensByChars}（与 autoCompaction 同款、保守高估）。 */
-  estimateTokens?: (messages: Message[]) => number;
+  /**
+   * Token 计数器（issue #55）。默认 {@link defaultTokenCounter}（请求级估算：messages + tool schema +
+   * systemPrompt + 每消息开销）。触发判据与初始 running-total 据此算，故有 tools 时**触发点比旧 messages-only
+   * 更早**。tools / systemPrompt 由内核经 `ctx.config` 提供。接真 tokenizer 时覆盖即可。
+   */
+  tokenCounter?: TokenCounter;
   /** 占位符文案（默认带工具名 + 原内容字符数提示）。 */
   placeholderText?: (toolName: string, originalChars: number) => string;
 }
@@ -66,7 +70,8 @@ function contentChars(content: ToolResult["content"]): number {
  * 构造一个 microcompact hook。
  *
  * 触发判据（满足任一即动手）：
- *   1. **体积**：`estimateTokens(messages) > triggerTokens` → 从最旧白名单 toolResult 起清，降到 `targetTokens` 以下即停。
+ *   1. **体积**：`tokenCounter.estimate({messages, tools, systemPrompt}) > triggerTokens`（请求级估算，含每请求随发的
+ *      tool schema + systemPrompt）→ 从最旧白名单 toolResult 起清，降到 `targetTokens` 以下即停。
  *   2. **gap**（可选）：`now() - 最后一条消息的 timestamp > gapMinutes` 分钟（cache 已冷）→ 把**所有**可清的白名单
  *      toolResult 清掉（cache 反正要冷启重发，激进清以缩短下次冷启动 prompt，不受 targetTokens 早停约束）。
  *
@@ -89,7 +94,7 @@ export function microcompact(opts: MicrocompactOptions): Hook {
     throw new Error("microcompact: gapMinutes must be > 0");
   }
   const now = opts.now ?? Date.now;
-  const estimate = opts.estimateTokens ?? estimateTokensByChars;
+  const counter = opts.tokenCounter ?? defaultTokenCounter;
   const placeholderText =
     opts.placeholderText ??
     ((tool, chars) => `[microcompact: ${tool} output cleared, ~${chars} chars]`);
@@ -98,7 +103,16 @@ export function microcompact(opts: MicrocompactOptions): Hook {
     name: "microcompact",
     timeout: 50,
 
-    transformMessagesBeforeLlm(messages, _ctx) {
+    transformMessagesBeforeLlm(messages, ctx) {
+      // 请求级估算：messages 之外把每请求随发的 tool schema + systemPrompt 也计入（X1，issue #55）。
+      // 这两项是**固定常量**（清消息不改它），故下面增量 running-total 的 delta 里会自然抵消（见 142 行注释）。
+      const reqExtras = {
+        tools: ctx.config.tools,
+        systemPrompt: ctx.config.systemPrompt,
+      };
+      // 单消息估值（不含 tools/systemPrompt；其每消息开销常量在 delta 里抵消）——用于增量 running-total。
+      const estimateOne = (m: Message): number => counter.estimate({ messages: [m] });
+
       // gap 判据：最后一条消息的 timestamp 距 now 超过 gapMinutes（cache 已冷）。
       let coldCache = false;
       if (opts.gapMinutes !== undefined && messages.length > 0) {
@@ -108,7 +122,11 @@ export function microcompact(opts: MicrocompactOptions): Hook {
       }
 
       // 体积没超阈值、且 cache 不冷 → 原样返回。
-      if (estimate(messages) <= opts.triggerTokens && !coldCache) return undefined;
+      if (
+        counter.estimate({ messages, ...reqExtras }) <= opts.triggerTokens &&
+        !coldCache
+      )
+        return undefined;
 
       // 找出**可清**的白名单 toolResult 下标（排除最近 keepRecent 条 toolResult）。
       const toolResultIdxs: number[] = [];
@@ -129,13 +147,15 @@ export function microcompact(opts: MicrocompactOptions): Hook {
       // 体积触发：从最旧开始清，清到 ≤ targetTokens 即停（不必全清）。
       // gap 触发（coldCache）：不设早停，把所有可清的都清掉（cache 反正冷了）。
       //
-      // **增量 running total，不每轮全量重估。** estimateTokensByChars 是逐消息/逐块累加，故替换一条时
-      // `estimate([原]) - estimate([占位])` 正是整体估值的精确变化量——结果与全量重估完全一致，但复杂度从
-      // O(N·K) 降到 O(N+K)。这点很关键：本 transform 是**同步**的，`timeout:50` 拦不住同步循环（计时器在
-      // 同步阻塞期间根本没机会 fire），而本插件正是为大文件读取场景设计、harness 又是多 session 跑在单
-      // event loop（WorkPool/LeaseQueue）——全量重估的 O(N·K) 会让一个 session 的压缩同步冻住其余所有 session。
+      // **增量 running total，不每轮全量重估。** estimateRequestTokens 在 messages 字符估算之上只加**固定常量**
+      // （tool schema + systemPrompt + 每消息开销 ×N，N 不变）；其 messages 部分逐消息可加，故替换一条时
+      // `estimateOne(原) - estimateOne(占位)` 正是整体估值的精确变化量——固定常量在差值里抵消，结果与
+      // 全量 `counter.estimate({messages: out, ...reqExtras})` 重估**完全一致**，复杂度仍从 O(N·K) 降到 O(N+K)。
+      // 这点很关键：本 transform 是**同步**的，`timeout:50` 拦不住同步循环（计时器在同步阻塞期间根本没机会
+      // fire），而本插件正是为大文件读取场景设计、harness 又是多 session 跑在单 event loop（WorkPool/
+      // LeaseQueue）——全量重估的 O(N·K) 会让一个 session 的压缩同步冻住其余所有 session。
       const out = messages.slice(); // copy-on-write，绝不改原数组 / session.messages
-      let total = estimate(out); // 开头估一次
+      let total = counter.estimate({ messages: out, ...reqExtras }); // 开头估一次（含固定常量）
       for (const idx of clearable) {
         if (!coldCache && total <= targetTokens) break; // O(1) 比较；降到目标即停（gap 路径不早停）
         const msg = out[idx]! as ToolResult;
@@ -144,7 +164,7 @@ export function microcompact(opts: MicrocompactOptions): Hook {
           ...msg,
           content: [{ type: "text" as const, text: placeholderText(msg.toolName, chars) }],
         };
-        total -= estimate([msg]) - estimate([placeholder]); // 精确减去本条清理带来的体积下降
+        total -= estimateOne(msg) - estimateOne(placeholder); // 精确减去本条清理带来的体积下降（固定常量抵消）
         out[idx] = placeholder;
       }
 

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-pi/tools",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "First-party coding tools for harness-pi agents",
   "license": "MIT",
   "repository": {

--- a/packages/tools/src/__tests__/pi-compat.test.ts
+++ b/packages/tools/src/__tests__/pi-compat.test.ts
@@ -39,7 +39,8 @@ const PI_053_CODING_DEFAULTS = ["read", "bash", "edit", "write"] as const;
 const PI_053_READ_ONLY_DEFAULTS = ["read", "grep", "find", "ls"] as const;
 
 const PI_053_SCHEMA_KEYS = {
-  read: ["path", "offset", "limit"],
+  // maxTokens 是 X3(#60)的第一方扩展,有意超出上游 0.53 的 read schema。
+  read: ["path", "offset", "limit", "maxTokens"],
   bash: ["command", "timeout"],
   edit: ["path", "oldText", "newText"],
   write: ["path", "content"],

--- a/packages/tools/src/__tests__/tools.test.ts
+++ b/packages/tools/src/__tests__/tools.test.ts
@@ -187,7 +187,43 @@ describe("read tool", () => {
       limit: 5,
       maxTokens: 100,
     });
-    expect(text(sliced)).toContain("xxxx");
+    // 切片成功路径要精确钉住窗口大小:以 5 行原文开头、且不含第 6 行
+    // (read 对部分读会追加续读页脚,故不能整串相等;但"恰好 5 行"必须钉死)。
+    const fiveLines = Array.from({ length: 5 }, () => "x".repeat(40)).join("\n");
+    const sixLines = Array.from({ length: 6 }, () => "x".repeat(40)).join("\n");
+    expect(text(sliced).startsWith(fiveLines)).toBe(true);
+    expect(text(sliced).startsWith(sixLines)).toBe(false);
+  });
+
+  it("treats an estimate exactly equal to maxTokens as within the cap (boundary, not off-by-one)", async () => {
+    // 整个特性就是一个阈值判定 `estimated > maxTokens`——把临界点两侧都钉死,
+    // 防 `>` 被改成 `>=` 这类回归在边界静默改变行为。
+    await writeFile(path.join(dir, "exact.txt"), "x".repeat(40)); // 40B / 4 = 10 === cap
+    const atCap = await runTool(createReadTool(dir), { path: "exact.txt", maxTokens: 10 });
+    expect(text(atCap)).toBe("x".repeat(40)); // 恰好等于 → 返回完整内容,不 throw
+
+    await writeFile(path.join(dir, "over.txt"), "x".repeat(41)); // 41B / 4 → ceil = 11 > cap
+    await expect(
+      runTool(createReadTool(dir), { path: "over.txt", maxTokens: 10 }),
+    ).rejects.toThrow(/exceeds maxTokens=10/); // 超 1 token → throw
+  });
+
+  it("rejects a negative maxTokens via the shared positive-integer validator", async () => {
+    await writeFile(path.join(dir, "notes.txt"), "hi");
+    await expect(
+      runTool(createReadTool(dir), { path: "notes.txt", maxTokens: -1 }),
+    ).rejects.toThrow(/must be a non-negative number/);
+  });
+
+  it("still applies normal byte truncation when content is within maxTokens", async () => {
+    // token 检查跑在 truncateHead 之前的 selected 上;未超 cap 时不该干扰既有 lines/bytes 截断。
+    await writeFile(path.join(dir, "big.txt"), "x".repeat(400)); // 400B / 4 = 100 估算
+    const result = await runTool(createReadTool(dir, { maxBytes: 100 }), {
+      path: "big.txt",
+      maxTokens: 200, // 100 <= 200 → 不 throw,落到字节截断
+    });
+    expect(result.details).toBeDefined(); // 发生了截断(details 带 truncation 元数据)
+    expect(Buffer.byteLength(text(result), "utf8")).toBeLessThan(400); // 返回的是截断后内容
   });
 
   it("rejects symlink escapes and bounded default exports reject outside cwd", async () => {

--- a/packages/tools/src/__tests__/tools.test.ts
+++ b/packages/tools/src/__tests__/tools.test.ts
@@ -123,6 +123,73 @@ describe("read tool", () => {
     expect(text(result)).toBe("outside");
   });
 
+  it("behaves identically to default truncation when maxTokens is unset", async () => {
+    await writeFile(path.join(dir, "notes.txt"), ["one", "two", "three"].join("\n"));
+    const withoutCap = await runTool(createReadTool(dir), { path: "notes.txt" });
+    expect(text(withoutCap)).toBe("one\ntwo\nthree");
+    expect(withoutCap.details).toBeUndefined();
+  });
+
+  it("returns content when estimated tokens are within maxTokens", async () => {
+    await writeFile(path.join(dir, "notes.txt"), "x".repeat(40));
+    // 40 bytes / 4 = 10 estimated tokens, under the cap.
+    const result = await runTool(createReadTool(dir), {
+      path: "notes.txt",
+      maxTokens: 100,
+    });
+    expect(text(result)).toBe("x".repeat(40));
+  });
+
+  it("returns a short error guiding offset+limit when maxTokens is exceeded", async () => {
+    await writeFile(path.join(dir, "big.txt"), "x".repeat(4_000));
+    // 4000 bytes / 4 = 1000 estimated tokens, over the cap of 100.
+    const promise = runTool(createReadTool(dir), {
+      path: "big.txt",
+      maxTokens: 100,
+    });
+    await expect(promise).rejects.toThrow(/exceeds maxTokens=100/);
+    await expect(promise).rejects.toThrow(/~1000 tokens/);
+    await expect(promise).rejects.toThrow(/offset\+limit/i);
+    const err = await promise.catch((e: Error) => e);
+    expect(Buffer.byteLength((err as Error).message, "utf8")).toBeLessThan(200);
+    // Does not leak truncated file content into the error message.
+    expect((err as Error).message).not.toContain("xxxx");
+  });
+
+  it("estimates denser bytesPerToken for json/jsonl than other extensions", async () => {
+    const payload = "x".repeat(300);
+    await writeFile(path.join(dir, "data.json"), payload);
+    await writeFile(path.join(dir, "data.txt"), payload);
+    // 300 bytes: json -> ceil(300/2)=150 tokens, txt -> ceil(300/4)=75 tokens.
+    // A cap of 100 trips the .json file but not the .txt file.
+    await expect(
+      runTool(createReadTool(dir), { path: "data.json", maxTokens: 100 }),
+    ).rejects.toThrow(/~150 tokens/);
+    const txtResult = await runTool(createReadTool(dir), {
+      path: "data.txt",
+      maxTokens: 100,
+    });
+    expect(text(txtResult)).toBe(payload);
+  });
+
+  it("estimates tokens on the offset+limit slice so a smaller range succeeds", async () => {
+    await writeFile(
+      path.join(dir, "lines.txt"),
+      Array.from({ length: 20 }, () => "x".repeat(40)).join("\n"),
+    );
+    // Whole file ~20*41/4 ≈ 205 tokens > 100, but a 5-line slice is well under.
+    await expect(
+      runTool(createReadTool(dir), { path: "lines.txt", maxTokens: 100 }),
+    ).rejects.toThrow(/exceeds maxTokens=100/);
+    const sliced = await runTool(createReadTool(dir), {
+      path: "lines.txt",
+      offset: 1,
+      limit: 5,
+      maxTokens: 100,
+    });
+    expect(text(sliced)).toContain("xxxx");
+  });
+
   it("rejects symlink escapes and bounded default exports reject outside cwd", async () => {
     const outside = path.join(path.dirname(dir), `${path.basename(dir)}-secret.txt`);
     await writeFile(outside, "secret");

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -24,6 +24,7 @@ import {
   DEFAULT_MAX_BYTES,
   DEFAULT_MAX_LINES,
   GREP_MAX_LINE_LENGTH,
+  estimateReadTokens,
   formatSize,
   truncateHead,
   truncateLine,
@@ -225,6 +226,7 @@ export function createReadTool(
       path: Type.String({ description: "Path to the file to read (relative or absolute)" }),
       offset: Type.Optional(Type.Number({ description: "Line number to start reading from (1-indexed)" })),
       limit: Type.Optional(Type.Number({ description: "Maximum number of lines to read" })),
+      maxTokens: Type.Optional(Type.Number({ description: "If the estimated token count of the content exceeds this, return a short error instead of content. Re-read a smaller range with offset+limit." })),
     }),
     isConcurrencySafe: () => true,
     async execute(args, _ctx, signal) {
@@ -256,6 +258,7 @@ export function createReadTool(
         requestedPath,
         offset: asOptionalPositiveInteger(args["offset"], "offset"),
         limit: asOptionalPositiveInteger(args["limit"], "limit"),
+        maxTokens: asOptionalPositiveInteger(args["maxTokens"], "maxTokens"),
         maxLines: options.maxLines,
         maxBytes: options.maxBytes,
       });
@@ -715,6 +718,7 @@ function buildReadTextOutput(opts: {
   requestedPath: string;
   offset?: number | undefined;
   limit?: number | undefined;
+  maxTokens?: number | undefined;
   maxLines?: number | undefined;
   maxBytes?: number | undefined;
 }): ReadTextOutput {
@@ -733,6 +737,15 @@ function buildReadTextOutput(opts: {
     userLimitedLines = endLine - startLine;
   } else {
     selected = allLines.slice(startLine).join("\n");
+  }
+
+  if (opts.maxTokens !== undefined) {
+    const estimated = estimateReadTokens(selected, opts.requestedPath);
+    if (estimated > opts.maxTokens) {
+      throw new Error(
+        `Content ~${estimated} tokens exceeds maxTokens=${opts.maxTokens}. Retry with offset+limit to read in smaller chunks.`,
+      );
+    }
   }
 
   const truncation = truncateHead(selected, {

--- a/packages/tools/src/truncate.ts
+++ b/packages/tools/src/truncate.ts
@@ -27,6 +27,17 @@ export function formatSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
 }
 
+/**
+ * Self-contained char-based token estimate for read output. Denser formats
+ * (json/jsonl) pack fewer chars per token, so use 2 bytes/token there and
+ * 4 bytes/token elsewhere. Estimate = ceil(utf8 bytes / bytesPerToken).
+ */
+export function estimateReadTokens(content: string, filePath: string): number {
+  const ext = filePath.slice(filePath.lastIndexOf(".") + 1).toLowerCase();
+  const bytesPerToken = ext === "json" || ext === "jsonl" ? 2 : 4;
+  return Math.ceil(Buffer.byteLength(content, "utf8") / bytesPerToken);
+}
+
 export function truncateHead(
   content: string,
   options: TruncationOptions = {},


### PR DESCRIPTION
**v0.2.3**(patch)。自 v0.2.2 以来的 6 个 PR,全部过 review-gate + CI 绿;D0 已用真 DashScope 验证 X1/X2/#53。

## 内容
| | PR | |
|---|---|---|
| X1 | #56 | TokenCounter + estimateRequestTokens 计入 tools/system/格式(D0 7x 低估校准) |
| X2 | #58 | per-model 有效窗口阈值(替「估算 80%」百分比)+ 阈值下界守卫 |
| S3 | #61 | AgentSpec 声明式路由 + routedSubAgentTool(domain-free,零内核) |
| X3 | #62 | read 大输出 token 维度封顶(maxTokens,默认 opt-in) |
| #53 | #63 | **非越界 LLM 错误提级 reason=error**(D0 挖出的真 bug,影响所有 consumer 的错误可观测性) |
| D0 | #64 | 真 provider smoke 脚本(验证上述修复;手动跑,不进 CI) |

## ⚠️ CHANGELOG / 迁移注意
- **breaking-ish**:`AutoCompactionOptions.estimateTokens` / `MicrocompactOptions.estimateTokens` → 重命名为 `tokenCounter: TokenCounter`(`estimateTokensByChars` 仍导出);仓内零残留调用,外部 typed consumer 会编译期失败(fail-loud,非静默)。
- **加性**:`SessionConfigView` 新增 `model.{contextWindow,maxTokens}` + `tools` + `systemPrompt`(hook-facing 公共面,仅内核 + 测试 helper 构造该 view)。
- **行为变更**:非越界 LLM 错误(resolved stopReason=error)现提级 `reason="error"` + fire `onError`(此前静默成 `done`);overflow / 同步抛路径不变。
- 默认 token 估算改 `estimateRequestTokens`(计入 tool schema/system)→ 阈值更准但**触发更早**;X3 `maxTokens` 默认关(不设=0.2.x 行为)。

## 验证
全仓 `pnpm -r build/typecheck/test` 全绿(core 281 / plugins 301 / tools 59 / adapters 61+18skip / coding-agent 240)。D0 真 DashScope smoke 全 ✓(#53 真 401→reason=error;X1 估算 7x→2.18x;容忍型确认)。

Closes #38 #39 (seam, 已发)— 本次主体见上表。