### PR TITLE
feat: O1 — deferredTools + 内置 toolSearch(transformToolsBeforeLlm pipe seam)(#43 O1)

### DIFF
--- a/packages/core/src/__tests__/dispatcher.test.ts
+++ b/packages/core/src/__tests__/dispatcher.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import { HookDispatcher, mergeResults } from "../dispatcher.js";
+import { HookDispatcher, mergeResults, defaultTimeoutFor } from "../dispatcher.js";
 import type { Hook, HookContext, MergedHookResult } from "../index.js";
 import { createTestContext } from "../testing.js";
 
@@ -221,6 +221,100 @@ describe("HookDispatcher transform pipe", () => {
     expect(out).toHaveLength(2);
     expect((out[0] as any).content).toBe("from A");
     expect((out[1] as any).content).toBe("from B");
+  });
+
+  it("tools: 0 hook returns value unchanged", async () => {
+    const d = new HookDispatcher([]);
+    const tools = [
+      { name: "a", description: "", parameters: {} as any },
+      { name: "b", description: "", parameters: {} as any },
+    ];
+    const out = await d.firePipeTools(tools, fakeCtx());
+    expect(out).toBe(tools);
+  });
+
+  it("tools: chained narrowing across hooks", async () => {
+    const hooks: Hook[] = [
+      {
+        name: "a",
+        transformToolsBeforeLlm: (tools) =>
+          tools.filter((t) => t.name !== "drop-a"),
+      },
+      {
+        name: "b",
+        transformToolsBeforeLlm: (tools) =>
+          tools.filter((t) => t.name !== "drop-b"),
+      },
+    ];
+    const d = new HookDispatcher(hooks);
+    const tools = [
+      { name: "keep", description: "", parameters: {} as any },
+      { name: "drop-a", description: "", parameters: {} as any },
+      { name: "drop-b", description: "", parameters: {} as any },
+    ];
+    const out = await d.firePipeTools(tools, fakeCtx());
+    expect(out.map((t) => t.name)).toEqual(["keep"]);
+  });
+
+  it("tools: a hook throwing is dropped, chain continues", async () => {
+    const log = vi.fn();
+    const hooks: Hook[] = [
+      {
+        name: "thrower",
+        transformToolsBeforeLlm: () => {
+          throw new Error("boom");
+        },
+      },
+      {
+        name: "good",
+        transformToolsBeforeLlm: (tools) =>
+          tools.filter((t) => t.name !== "drop"),
+      },
+    ];
+    const d = new HookDispatcher(hooks, (info) => log(info));
+    const tools = [
+      { name: "keep", description: "", parameters: {} as any },
+      { name: "drop", description: "", parameters: {} as any },
+    ];
+    const out = await d.firePipeTools(tools, fakeCtx());
+    // thrower 被丢弃（保留 input），good 仍生效。
+    expect(out.map((t) => t.name)).toEqual(["keep"]);
+    expect(log).toHaveBeenCalledWith(
+      expect.objectContaining({ hookName: "thrower" }),
+    );
+  });
+
+  it("tools: a hook timing out is dropped, chain continues", async () => {
+    const log = vi.fn();
+    const hooks: Hook[] = [
+      {
+        name: "slow",
+        timeout: 20,
+        transformToolsBeforeLlm: () =>
+          new Promise((resolve) => setTimeout(() => resolve([]), 200)),
+      },
+      {
+        name: "fast",
+        transformToolsBeforeLlm: (tools) =>
+          tools.filter((t) => t.name !== "drop"),
+      },
+    ];
+    const d = new HookDispatcher(hooks, (info) => log(info));
+    const tools = [
+      { name: "keep", description: "", parameters: {} as any },
+      { name: "drop", description: "", parameters: {} as any },
+    ];
+    const out = await d.firePipeTools(tools, fakeCtx());
+    expect(out.map((t) => t.name)).toEqual(["keep"]);
+    expect(log).toHaveBeenCalledWith(
+      expect.objectContaining({ hookName: "slow", timeoutMs: 20 }),
+    );
+  });
+});
+
+describe("defaultTimeoutFor", () => {
+  it("transformToolsBeforeLlm gets pipe-class 500ms", () => {
+    expect(defaultTimeoutFor("transformToolsBeforeLlm")).toBe(500);
   });
 });
 

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -18,7 +18,7 @@
  *   - 如果 dashboard 按 sink call 计数，两路径会差一截；按字节数 / 行数计就一致。
  */
 
-import type { ToolCall } from "@earendil-works/pi-ai";
+import type { Tool, ToolCall } from "@earendil-works/pi-ai";
 import type {
   ContextOverflowInput,
   ContinuationCheckInput,
@@ -73,6 +73,7 @@ const DECISION_METHODS = new Set([
 const PIPE_METHODS = new Set([
   "transformSystemPromptBeforeLlm",
   "transformMessagesBeforeLlm",
+  "transformToolsBeforeLlm",
 ] as const);
 
 /* ────────────── Decision outcome ────────────── */
@@ -351,6 +352,24 @@ export class HookDispatcher {
       const inv = await this._invokeSafe<Message[] | void>(
         h,
         "transformMessagesBeforeLlm",
+        [v, ctx],
+        "pipe",
+      );
+      if (Array.isArray(inv.value)) v = inv.value;
+    }
+    return v;
+  }
+
+  async firePipeTools(
+    value: Tool[],
+    ctx: HookContext,
+  ): Promise<Tool[]> {
+    let v = value;
+    for (const h of this.hooks) {
+      if (typeof h.transformToolsBeforeLlm !== "function") continue;
+      const inv = await this._invokeSafe<Tool[] | void>(
+        h,
+        "transformToolsBeforeLlm",
         [v, ctx],
         "pipe",
       );

--- a/packages/core/src/hook.ts
+++ b/packages/core/src/hook.ts
@@ -517,6 +517,16 @@ export interface Hook {
     messages: Message[],
     ctx: HookContext,
   ): Message[] | void | Promise<Message[] | void>;
+  /**
+   * listing-only：transform LLM call 这一帧随发的 tool listing（裸 pi-ai `Tool`，仅
+   * name/description/parameters）。返回 `Tool[]` 收窄/重排可见工具，`void` 保持不变。
+   * **不影响 execution**：执行/校验始终走 `session.tools` 全集，filter 掉的工具仍可被调用。
+   * 值类型刻意用裸 `Tool` 而非 `HarnessTool`，从类型层堵死在 listing 里塞 `execute`。
+   */
+  transformToolsBeforeLlm?(
+    tools: Tool[],
+    ctx: HookContext,
+  ): Tool[] | void | Promise<Tool[] | void>;
 
   // ─────────── Around (nested) ───────────
   wrapTurn?(ctx: HookContext, next: () => Promise<void>): Promise<void>;

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -1258,11 +1258,12 @@ export class AgentSession {
     );
     this._pendingAttachments = [];
 
-    const piTools = this.tools.map((t) => ({
+    const baseTools = this.tools.map((t) => ({
       name: t.name,
       description: t.description,
       parameters: t.parameters,
     }));
+    const piTools = await this._dispatcher.firePipeTools(baseTools, this._ctx);
     const context: Context = {
       messages: stripHarnessOnlyFields(transformed),
       tools: piTools,

--- a/packages/plugins/src/__tests__/deferred-tools.test.ts
+++ b/packages/plugins/src/__tests__/deferred-tools.test.ts
@@ -91,6 +91,92 @@ describe("deferredTools: activation takes effect next turn (b)", () => {
     const turn2 = namesOf(fake.getCalls()[1]!.tools);
     expect(turn1).not.toContain("WebFetch");
     expect(turn2).toContain("WebFetch");
+    // 激活是**累加**进 listing，不是替换 —— 原本可见的工具仍在。
+    expect(turn2).toEqual(expect.arrayContaining(["read", "toolSearch", "WebFetch"]));
+    fake.teardown();
+  });
+
+  it("keyword fuzzy-match activates matching tools next turn", async () => {
+    const search = toolSearch();
+    const fake = createFakeModel([
+      // keyword "fetch" 命中 WebFetch 的 name+description（"WebFetch tool"）。
+      {
+        content: [
+          { type: "toolCall", name: "toolSearch", arguments: { keyword: "fetch" } },
+        ],
+      },
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [trivialTool("read"), trivialTool("WebFetch"), search],
+      hooks: [
+        deferredTools({ deferred: ["WebFetch"], alwaysListed: ["read", search.name] }),
+      ],
+    });
+    await session.run("go");
+
+    expect(namesOf(fake.getCalls()[0]!.tools)).not.toContain("WebFetch");
+    expect(namesOf(fake.getCalls()[1]!.tools)).toContain("WebFetch");
+    fake.teardown();
+  });
+
+  it("no match (incl. phantom select name) activates nothing and says so", async () => {
+    const search = toolSearch();
+    const fake = createFakeModel([
+      {
+        content: [
+          { type: "toolCall", name: "toolSearch", arguments: { select: ["nonexistent"] } },
+        ],
+      },
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [trivialTool("read"), trivialTool("WebFetch"), search],
+      hooks: [
+        deferredTools({ deferred: ["WebFetch"], alwaysListed: ["read", search.name] }),
+      ],
+    });
+    await session.run("go");
+
+    const tr = session.messages.find((m) => m.role === "toolResult") as
+      | { content: { text?: string }[] }
+      | undefined;
+    expect(tr!.content.map((b) => b.text ?? "").join("")).toContain("No tools matched");
+    // 不存在的名字（模型瞎编）不激活任何工具：下一 turn WebFetch 仍隐藏。
+    expect(namesOf(fake.getCalls()[1]!.tools)).not.toContain("WebFetch");
+    fake.teardown();
+  });
+});
+
+describe("deferredTools: predicate-form deferred (function)", () => {
+  it("supports deferred as a (name) => boolean predicate", async () => {
+    const fake = createFakeModel([
+      { content: [{ type: "text", text: "ok" }], stopReason: "stop" },
+    ]);
+    const search = toolSearch();
+    const session = new AgentSession({
+      model: fake,
+      tools: [
+        trivialTool("read"),
+        trivialTool("WebFetch"),
+        trivialTool("WebSearch"),
+        search,
+      ],
+      hooks: [
+        deferredTools({
+          deferred: (n) => n.startsWith("Web"),
+          alwaysListed: ["read", search.name],
+        }),
+      ],
+    });
+    await session.run("go");
+
+    const listing = namesOf(fake.getCalls()[0]!.tools);
+    expect(listing).toEqual(expect.arrayContaining(["read", "toolSearch"]));
+    expect(listing).not.toContain("WebFetch");
+    expect(listing).not.toContain("WebSearch");
     fake.teardown();
   });
 });
@@ -186,6 +272,7 @@ describe("deferredTools + autoCompaction: estimation linkage (f)", () => {
     // 全集 3 个工具，deferred 掉一个大工具（bigTool），激活集只剩 read + toolSearch。
     // 通过自定义 tokenCounter 把「随发 tools 的条目数」暴露出来断言。
     const seenToolCounts: number[] = [];
+    const seenToolNames: string[][] = [];
     const bigTool = trivialTool("WebFetch");
     const search = toolSearch();
     // 跑 2 个 turn：turn-0 的 estimate 在本 turn 的 deferredTools 写 activeListing **之前**跑
@@ -211,6 +298,7 @@ describe("deferredTools + autoCompaction: estimation linkage (f)", () => {
           tokenCounter: {
             estimate: ({ tools }) => {
               seenToolCounts.push((tools ?? []).length);
+              seenToolNames.push(namesOf(tools));
               return 0;
             },
           },
@@ -226,6 +314,9 @@ describe("deferredTools + autoCompaction: estimation linkage (f)", () => {
     expect(seenToolCounts[0]).toBe(3);
     // turn-1：读到上一 turn 写入的激活子集 → 2（证明 estimate 确实改读 activeListing 而非永远全集）。
     expect(seenToolCounts[1]).toBe(2);
+    // 且被丢的恰是 deferred 的 WebFetch（不只是数量对，drop 对了工具）。
+    expect(seenToolNames[1]).toEqual(expect.arrayContaining(["read", "toolSearch"]));
+    expect(seenToolNames[1]).not.toContain("WebFetch");
     fake.teardown();
   });
 });

--- a/packages/plugins/src/__tests__/deferred-tools.test.ts
+++ b/packages/plugins/src/__tests__/deferred-tools.test.ts
@@ -1,0 +1,254 @@
+/**
+ * deferredTools + toolSearch 集成测试（issue #66 / O1）。
+ *
+ * 经 testing.ts fake-model 的 getCalls()——它捕获每次 Context.tools（即 LLM 看到的 listing），
+ * 据此断言 listing 子集化、激活下一 turn 生效、opt-in 字节级一致、execution 解耦、估算联动、fail-open。
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  AgentSession,
+  Type,
+  type HarnessTool,
+  type Hook,
+} from "@harness-pi/core";
+import { createFakeModel } from "@harness-pi/core/testing";
+import { deferredTools } from "../deferred-tools.js";
+import { toolSearch } from "../tool-search.js";
+import { autoCompaction } from "../auto-compaction.js";
+import { permissionGate } from "../permission-gate.js";
+
+function trivialTool(name: string): HarnessTool {
+  return {
+    name,
+    description: `${name} tool`,
+    parameters: Type.Object({}),
+    isConcurrencySafe: () => true,
+    async execute() {
+      return { content: [{ type: "text", text: `${name} ran` }] };
+    },
+  };
+}
+
+function namesOf(
+  tools: ReadonlyArray<{ name: string }> | undefined,
+): string[] {
+  return (tools ?? []).map((t) => t.name);
+}
+
+describe("deferredTools: listing subset (a)", () => {
+  it("hides deferred tools, keeps non-deferred + alwaysListed", async () => {
+    const fake = createFakeModel([
+      { content: [{ type: "text", text: "ok" }], stopReason: "stop" },
+    ]);
+    const search = toolSearch();
+    const session = new AgentSession({
+      model: fake,
+      tools: [trivialTool("read"), trivialTool("WebFetch"), search],
+      hooks: [
+        deferredTools({
+          deferred: ["WebFetch"],
+          alwaysListed: ["read", search.name],
+        }),
+      ],
+    });
+    await session.run("go");
+
+    const listing = namesOf(fake.getCalls()[0]!.tools);
+    expect(listing).toContain("read");
+    expect(listing).toContain("toolSearch");
+    expect(listing).not.toContain("WebFetch");
+    fake.teardown();
+  });
+});
+
+describe("deferredTools: activation takes effect next turn (b)", () => {
+  it("toolSearch({select}) in turn-1 makes the tool visible in turn-2", async () => {
+    const search = toolSearch();
+    const fake = createFakeModel([
+      // turn-1：模型调 toolSearch 激活 WebFetch（不收尾，继续循环）。
+      {
+        content: [
+          { type: "toolCall", name: "toolSearch", arguments: { select: ["WebFetch"] } },
+        ],
+      },
+      // turn-2：收尾。
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [trivialTool("read"), trivialTool("WebFetch"), search],
+      hooks: [
+        deferredTools({
+          deferred: ["WebFetch"],
+          alwaysListed: ["read", search.name],
+        }),
+      ],
+    });
+    await session.run("go");
+
+    const turn1 = namesOf(fake.getCalls()[0]!.tools);
+    const turn2 = namesOf(fake.getCalls()[1]!.tools);
+    expect(turn1).not.toContain("WebFetch");
+    expect(turn2).toContain("WebFetch");
+    fake.teardown();
+  });
+});
+
+describe("deferredTools: opt-in byte-equal (c)", () => {
+  it("without deferredTools, every call sees the full tool set", async () => {
+    const fake = createFakeModel([
+      {
+        content: [{ type: "toolCall", name: "read", arguments: {} }],
+      },
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const tools = [trivialTool("read"), trivialTool("WebFetch"), toolSearch()];
+    const fullNames = namesOf(tools).sort();
+    const session = new AgentSession({ model: fake, tools, hooks: [] });
+    await session.run("go");
+
+    for (const call of fake.getCalls()) {
+      expect(namesOf(call.tools).sort()).toEqual(fullNames);
+    }
+    fake.teardown();
+  });
+});
+
+describe("deferredTools: execution decoupled from listing (d)", () => {
+  it("a deferred-but-not-activated tool still executes (findToolByName uses full set)", async () => {
+    const fake = createFakeModel([
+      // 模型直接调 WebFetch —— 它当前不在 listing 里，但仍在 session.tools 全集。
+      { content: [{ type: "toolCall", name: "WebFetch", arguments: {} }] },
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const search = toolSearch();
+    const session = new AgentSession({
+      model: fake,
+      tools: [trivialTool("read"), trivialTool("WebFetch"), search],
+      hooks: [
+        deferredTools({ deferred: ["WebFetch"], alwaysListed: [search.name] }),
+      ],
+    });
+    await session.run("go");
+
+    // listing 子集化：WebFetch 不可见。
+    expect(namesOf(fake.getCalls()[0]!.tools)).not.toContain("WebFetch");
+    // 但执行照样发生：toolResult 拿到 WebFetch 的输出。
+    const tr = session.messages.find((m) => m.role === "toolResult") as
+      | { content: { text?: string }[]; isError?: boolean }
+      | undefined;
+    expect(tr).toBeDefined();
+    expect(tr!.isError).not.toBe(true);
+    expect(tr!.content[0]!.text).toBe("WebFetch ran");
+    fake.teardown();
+  });
+
+  it("permission gate still blocks an activated/visible-or-not deferred tool (listing-independent闸)", async () => {
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "WebFetch", arguments: {} }] },
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const search = toolSearch();
+    const session = new AgentSession({
+      model: fake,
+      tools: [trivialTool("WebFetch"), search],
+      hooks: [
+        deferredTools({ deferred: ["WebFetch"], alwaysListed: [search.name] }),
+        permissionGate({
+          rules: [{ match: "WebFetch", decision: "deny", reason: "WebFetch is off" }],
+          fallback: "allow",
+        }),
+      ],
+    });
+    await session.run("go");
+
+    const tr = session.messages.find((m) => m.role === "toolResult") as
+      | { content: { text?: string }[]; isError?: boolean }
+      | undefined;
+    expect(tr).toBeDefined();
+    expect(tr!.isError).toBe(true);
+    const text = tr!.content.map((b) => b.text ?? "").join("");
+    expect(text).toContain("WebFetch is off");
+    fake.teardown();
+  });
+});
+
+describe("toolSearch: barrier (e)", () => {
+  it("declares isConcurrencySafe === false", () => {
+    const search = toolSearch();
+    expect(search.isConcurrencySafe!({})).toBe(false);
+  });
+});
+
+describe("deferredTools + autoCompaction: estimation linkage (f)", () => {
+  it("autoCompaction reads the activated subset, not the full set", async () => {
+    // 全集 3 个工具，deferred 掉一个大工具（bigTool），激活集只剩 read + toolSearch。
+    // 通过自定义 tokenCounter 把「随发 tools 的条目数」暴露出来断言。
+    const seenToolCounts: number[] = [];
+    const bigTool = trivialTool("WebFetch");
+    const search = toolSearch();
+    // 跑 2 个 turn：turn-0 的 estimate 在本 turn 的 deferredTools 写 activeListing **之前**跑
+    //（内核固定 messages-pipe 先于 tools-pipe），读到 undefined → 退回全集 3；turn-1 的 estimate
+    // 读到 turn-0 写入的激活子集 → 2。这是一 turn 滞后，对「宁高勿低」的阈值无害。
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "read", arguments: {} }] },
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [trivialTool("read"), bigTool, search],
+      hooks: [
+        // deferredTools 排在 autoCompaction 之前（注册顺序）。
+        deferredTools({
+          deferred: ["WebFetch"],
+          alwaysListed: ["read", search.name],
+        }),
+        autoCompaction({
+          maxContextTokens: 1_000_000, // 阈值极高，不真压缩；只为触发 estimate 调用。
+          triggerRatio: 0.9,
+          keepRecent: 1,
+          tokenCounter: {
+            estimate: ({ tools }) => {
+              seenToolCounts.push((tools ?? []).length);
+              return 0;
+            },
+          },
+          summarize: () => "RECAP",
+        }),
+      ],
+    });
+    await session.run("go");
+
+    // 全集是 3（read / WebFetch / toolSearch）；激活子集排除 WebFetch → 2。
+    expect(seenToolCounts.length).toBeGreaterThanOrEqual(2);
+    // turn-0：activeListing 尚未写入 → 退回全集 3。
+    expect(seenToolCounts[0]).toBe(3);
+    // turn-1：读到上一 turn 写入的激活子集 → 2（证明 estimate 确实改读 activeListing 而非永远全集）。
+    expect(seenToolCounts[1]).toBe(2);
+    fake.teardown();
+  });
+});
+
+describe("deferredTools: fail-open (g)", () => {
+  it("transformToolsBeforeLlm throwing degrades that turn to the full listing", async () => {
+    const throwing: Hook = {
+      name: "deferred-thrower",
+      transformToolsBeforeLlm: () => {
+        throw new Error("boom");
+      },
+    };
+    const fake = createFakeModel([
+      { content: [{ type: "text", text: "ok" }], stopReason: "stop" },
+    ]);
+    const tools = [trivialTool("read"), trivialTool("WebFetch"), toolSearch()];
+    const fullNames = namesOf(tools).sort();
+    const session = new AgentSession({ model: fake, tools, hooks: [throwing] });
+    const summary = await session.run("go");
+
+    // 抛错被内核 fail-open 吞掉 → 该 turn 退化全集 listing，session 不崩。
+    expect(summary.reason).toBe("done");
+    expect(namesOf(fake.getCalls()[0]!.tools).sort()).toEqual(fullNames);
+    fake.teardown();
+  });
+});

--- a/packages/plugins/src/auto-compaction.ts
+++ b/packages/plugins/src/auto-compaction.ts
@@ -278,9 +278,11 @@ export function autoCompaction(opts: AutoCompactionOptions): Hook {
       if (threshold === undefined) return undefined;
 
       // 未到 token 阈值 → 原样。tools / systemPrompt 由 ctx.config 提供，计入每请求随发的固定开销（X1）。
+      // deferredTools 在场时，本 turn 实际随发的是激活子集（deferred.activeListing），按它估更准；
+      // 无 deferredTools 则退回 ctx.config.tools 全集（0.2.x 行为）。
       const estimated = counter.estimate({
         messages,
-        tools: ctx.config.tools,
+        tools: ctx.state.get("deferred.activeListing") ?? ctx.config.tools,
         systemPrompt: ctx.config.systemPrompt,
       });
       if (estimated <= threshold) return undefined;

--- a/packages/plugins/src/deferred-tools.ts
+++ b/packages/plugins/src/deferred-tools.ts
@@ -1,0 +1,71 @@
+/**
+ * deferredTools —— listing-only 的工具延迟暴露（issue #66 / O1）。
+ *
+ * 把一部分工具标成 "deferred"：默认**不进 LLM 看到的 tool listing**，直到被激活
+ * （典型由 {@link toolSearch} 工具命中后写入激活集）才在**下一 turn** 出现在 listing 里。
+ * 纯 listing 收窄 —— **不碰 execution**：deferred 工具始终在 `session.tools` 全集里，
+ * 一旦被调用，executor 照常 findToolByName / validateToolCall / 过权限闸。
+ *
+ * 激活集载体：`ctx.state` 的 `"deferred.activated"`（`Set<string>`），由 onSessionStart
+ * seed 成 `alwaysListed`。当前 turn 实际 listing 的子集顺手写进 `"deferred.activeListing"`，
+ * 给 autoCompaction 的 token 估算读（有 deferred 就估激活子集，没有退回全集）。
+ *
+ * **必须排在 autoCompaction 之前**（用 `requires` 声明）——否则 autoCompaction 读不到
+ * 本 turn 写入的 `deferred.activeListing`。
+ */
+
+import type { Hook, Tool } from "@harness-pi/core";
+
+/* ── 在 core 的 HookStateRegistry 上 augment 本 plugin 用到的 key ── */
+declare module "@harness-pi/core" {
+  interface HookStateRegistry {
+    "deferred.activated": Set<string>;
+    "deferred.activeListing": Tool[];
+  }
+}
+
+// `as const` 保留字面类型，让 TypedStateMap 走 typed overload 而不是 string fallback
+const KEY_ACTIVATED = "deferred.activated" as const;
+const KEY_LISTING = "deferred.activeListing" as const;
+
+export interface DeferredToolsOptions {
+  /**
+   * 哪些工具是 deferred：字符串数组（按名命中）或谓词（`(name) => boolean`）。
+   * deferred 工具默认不进 listing，激活后才可见。
+   */
+  deferred: string[] | ((name: string) => boolean);
+  /**
+   * 即便是 deferred 也**始终列出**的工具名（seed 进激活集）。典型：toolSearch 自己，
+   * 以及希望首 turn 就可见的常用工具。
+   */
+  alwaysListed?: string[];
+}
+
+export function deferredTools(opts: DeferredToolsOptions): Hook {
+  const isDeferred = (name: string): boolean =>
+    typeof opts.deferred === "function"
+      ? opts.deferred(name)
+      : opts.deferred.includes(name);
+
+  return {
+    name: "deferredTools",
+    // 软依赖：autoCompaction 的 token 估算会读 deferred.activeListing（激活子集），缺它也能独立工作。
+    // 两者都挂时，deferredTools 应排在 autoCompaction **之前**注册，让估算口径与本 turn listing 对齐。
+    // 用 prefers（不发 warning，opt-in 行为不受影响），与 tokenBudget→cost-tracker 同例。
+    prefers: ["autoCompaction"],
+
+    onSessionStart(_input, ctx) {
+      ctx.state.set(KEY_ACTIVATED, new Set(opts.alwaysListed ?? []));
+    },
+
+    transformToolsBeforeLlm(tools, ctx) {
+      const activated = ctx.state.get(KEY_ACTIVATED) ?? new Set<string>();
+      const result = tools.filter(
+        (t) => !isDeferred(t.name) || activated.has(t.name),
+      );
+      // 当前 turn 实际 listing 的子集 —— 给 autoCompaction 估算读（激活子集而非全集）。
+      ctx.state.set(KEY_LISTING, result);
+      return result;
+    },
+  };
+}

--- a/packages/plugins/src/deferred-tools.ts
+++ b/packages/plugins/src/deferred-tools.ts
@@ -10,8 +10,11 @@
  * seed 成 `alwaysListed`。当前 turn 实际 listing 的子集顺手写进 `"deferred.activeListing"`，
  * 给 autoCompaction 的 token 估算读（有 deferred 就估激活子集，没有退回全集）。
  *
- * **必须排在 autoCompaction 之前**（用 `requires` 声明）——否则 autoCompaction 读不到
- * 本 turn 写入的 `deferred.activeListing`。
+ * **估算联动有结构性的一 turn 滞后，与 hook 注册顺序无关**：autoCompaction 在
+ * `transformMessagesBeforeLlm` 读 `deferred.activeListing`，本 hook 在 `transformToolsBeforeLlm`
+ * 写它——内核固定 messages-pipe 先于 tools-pipe（且二者不同 method，重排注册顺序也改不了），
+ * 故 autoCompaction 读到的是**上一 turn**写入的激活子集；turn-0 读到 undefined → 退回全集
+ * （保守高估，安全侧：宁早压勿晚）。对压缩阈值无害，无需也无法靠排序消除。
  */
 
 import type { Hook, Tool } from "@harness-pi/core";
@@ -49,10 +52,8 @@ export function deferredTools(opts: DeferredToolsOptions): Hook {
 
   return {
     name: "deferredTools",
-    // 软依赖：autoCompaction 的 token 估算会读 deferred.activeListing（激活子集），缺它也能独立工作。
-    // 两者都挂时，deferredTools 应排在 autoCompaction **之前**注册，让估算口径与本 turn listing 对齐。
-    // 用 prefers（不发 warning，opt-in 行为不受影响），与 tokenBudget→cost-tracker 同例。
-    prefers: ["autoCompaction"],
+    // 不声明对 autoCompaction 的依赖：二者在不同 pipe method（tools vs messages），注册顺序对其
+    // 交互无影响（见文件头「结构性一 turn 滞后」）。autoCompaction 缺席时也独立工作（opt-in）。
 
     onSessionStart(_input, ctx) {
       ctx.state.set(KEY_ACTIVATED, new Set(opts.alwaysListed ?? []));

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -113,3 +113,9 @@ export type { TokenBudgetOptions } from "./token-budget.js";
 
 export { repeatedCallGuard } from "./repeated-call-guard.js";
 export type { RepeatedCallGuardOptions } from "./repeated-call-guard.js";
+
+export { deferredTools } from "./deferred-tools.js";
+export type { DeferredToolsOptions } from "./deferred-tools.js";
+
+export { toolSearch } from "./tool-search.js";
+export type { ToolSearchOptions } from "./tool-search.js";

--- a/packages/plugins/src/tool-search.ts
+++ b/packages/plugins/src/tool-search.ts
@@ -1,0 +1,109 @@
+/**
+ * toolSearch —— 激活 deferred 工具的普通 first-party 工具（issue #66 / O1）。
+ *
+ * 配合 {@link deferredTools} 用：deferred 工具默认不在 LLM 看到的 listing 里，模型调
+ * toolSearch（按名 `select` 或 `keyword` 本地模糊匹配）把命中的工具写进 `ctx.state` 的
+ * `"deferred.activated"` 激活集，**下一 turn** 它们才出现在 listing 里。
+ *
+ * 全本地、零 provider 依赖：数据源是 `ctx.config.tools`（session.tools 全集的冻结视图），
+ * keyword 在工具 name + description 上做最简包含匹配。
+ *
+ * 屏障型（`isConcurrencySafe: () => false`）：写 `ctx.state` 同一 key，绝不与同 turn 其他工具并行。
+ */
+
+import { Type } from "@harness-pi/core";
+import type { HarnessTool, HookContext, ToolExecResult } from "@harness-pi/core";
+
+const KEY_ACTIVATED = "deferred.activated" as const;
+
+export interface ToolSearchOptions {
+  /**
+   * 工具名 —— 默认 `"toolSearch"`。挂 deferredTools 时把这个名字放进 `alwaysListed`，
+   * 保证它首 turn 就可见。
+   */
+  name?: string;
+}
+
+export function toolSearch(opts: ToolSearchOptions = {}): HarnessTool {
+  const name = opts.name ?? "toolSearch";
+  return {
+    name,
+    description:
+      "Activate deferred tools so they become available next turn. " +
+      "Pass `select` (exact tool names) and/or `keyword` (fuzzy match against tool name + description). " +
+      "Returns the activated tools' schemas. Activation = visibility, not authorization.",
+    parameters: Type.Object({
+      select: Type.Optional(
+        Type.Array(Type.String(), {
+          description: "Exact tool names to activate.",
+        }),
+      ),
+      keyword: Type.Optional(
+        Type.String({
+          description:
+            "Keyword to fuzzy-match against tool name + description; matched tools are activated.",
+        }),
+      ),
+    }),
+    // 写 ctx.state 同一激活集 key —— 屏障型，绝不与同 turn 其他工具并行。
+    isConcurrencySafe: () => false,
+    async execute(args, ctx: HookContext): Promise<ToolExecResult> {
+      const select = (args.select as string[] | undefined) ?? [];
+      const keyword = (args.keyword as string | undefined)?.trim();
+
+      const catalog = ctx.config.tools;
+      const hits = new Set<string>();
+
+      // select：按名精确命中（仅命中确实存在的工具）。
+      const names = new Set(catalog.map((t) => t.name));
+      for (const s of select) {
+        if (names.has(s)) hits.add(s);
+      }
+
+      // keyword：在 name + description 上做最简本地包含匹配（大小写不敏感）。
+      if (keyword) {
+        const kw = keyword.toLowerCase();
+        for (const t of catalog) {
+          const hay = `${t.name} ${t.description}`.toLowerCase();
+          if (hay.includes(kw)) hits.add(t.name);
+        }
+      }
+
+      if (hits.size === 0) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `No tools matched select=${JSON.stringify(
+                select,
+              )} keyword=${JSON.stringify(keyword ?? null)}.`,
+            },
+          ],
+        };
+      }
+
+      const cur = ctx.state.get(KEY_ACTIVATED) ?? new Set<string>();
+      ctx.state.set(KEY_ACTIVATED, new Set([...cur, ...hits]));
+
+      const activatedNames = [...hits];
+      const schemas = catalog
+        .filter((t) => hits.has(t.name))
+        .map((t) => ({
+          name: t.name,
+          description: t.description,
+          parameters: t.parameters,
+        }));
+
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `activated: ${activatedNames.join(", ")} — available next turn.\n` +
+              JSON.stringify(schemas, null, 2),
+          },
+        ],
+      };
+    },
+  };
+}


### PR DESCRIPTION
**0.3.0 最大内核改动**(epic #43,issue #66)。大工具集 deferred:初始只列名,模型用内置 `toolSearch` 按需激活 → **下一 turn** piTools 含它。provider-无关(不赌 pi-ai tool_reference)。设计经 judge-panel 综合定案。

## 内核(~28 行,纯机制、domain-free)
新增**第三条对称 pipe** `transformToolsBeforeLlm`(对齐已有 transformMessages/SystemPromptBeforeLlm):
- `dispatcher.ts`:PIPE_METHODS 加项(自动获 500ms pipe 超时)+ `firePipeTools`(逐行复制 firePipeMessages,复用 _invokeSafe/timeout/fail-open)。
- `hook.ts`:加 `transformToolsBeforeLlm?(tools: Tool[], ctx)`,值类型**裸 pi-ai Tool**(无 execute)→ 类型层堵死在 listing 塞执行体。
- `session.ts:_phaseLlmCall`:piTools = map baseTools → firePipeTools。

## plugins
- `deferredTools({deferred, alwaysListed})`:listing filter(非 deferred ∪ 已激活)+ onSessionStart seed 激活集到 `ctx.state` Set。
- `toolSearch()`:first-party 工具,select/keyword 本地匹配 → 写激活集;`isConcurrencySafe=false` 屏障防写竞争。
- `autoCompaction`:估算 tools 改读 `ctx.state["deferred.activeListing"] ?? ctx.config.tools`。

## 三大不变量(review-gate 对照真 source 逐条核验 HOLDS)
- **domain-free**:内核只懂「tools 帧可被 pipe transform」,deferred/toolSearch/激活集 0 字进内核。
- **tools-frozen**:`this.tools` + configView 深冻一行不碰;pipe 改的是每 turn 一次性 piTools 局部帧。
- **execution/listing 解耦、无新攻击面**:execution/校验/onPreToolUse 全走 this.tools 全集;listing 子集化只改「LLM 看到啥」。deferred 未激活工具仍可执行(test d)、permissionGate 照常拦(test d)、瞎编名走既有 unknown-tool 路径。

## 已知取舍(诚实)
- **估算联动一 turn 滞后**(结构性:messages-pipe 固定先于 tools-pipe,与注册顺序无关):autoCompaction 读上一 turn 的激活子集,turn-0 退回全集=保守高估(安全侧,宁早压勿晚)。文件头如实注释 + test (f) 钉住。
- 0.3.0 从简:激活集不持久化(fork/resume 后空)、无 LRU、keyword 最简本地匹配。

## review 闭环
- 自查删掉 deferredTools 误用的 `prefers:["autoCompaction"]`(二者不同 pipe method、顺序无关;prefers 无人消费且 inline 注释与其语义矛盾)→ 注释改为如实说明结构性滞后。
- **review-gate 3/3 PASS**(inline-diff,三大不变量逐条核验)。折入 test-review 指出的覆盖缺口:keyword 整条分支 / no-match+phantom / predicate 形式 deferred / 强化 b(累加非替换)/ 强化 f(drop 对了工具)。

## 验证
全仓 build/typecheck/test 全绿:core 286(+6 firePipeTools 单测)/ plugins 312(+11 集成)/ 下游不破。

## O2 复用
skill 插件复用同一 pipe + ctx.state 激活集模式,内核不再改。

Closes #66