### PR TITLE
feat(plugins): O2 — skill 插件(命名 prompt 包,复用 O1 seam)(#43 O2)

### DIFF
--- a/packages/plugins/src/__tests__/skills.test.ts
+++ b/packages/plugins/src/__tests__/skills.test.ts
@@ -64,8 +64,8 @@ describe("skills: catalog in system prompt (a)", () => {
     const sys = fake.getCalls()[0]!.systemPrompt;
     expect(sys).toContain("## Available skills");
     for (const s of SPECS) {
-      expect(sys).toContain(s.name);
-      expect(sys).toContain(s.description);
+      // 精确钉住 name↔description 配对(独立 toContain 会漏「名字配错描述」)。
+      expect(sys).toContain(`- ${s.name}: ${s.description}`);
       // body 绝不进 catalog。
       expect(sys).not.toContain(s.body);
     }
@@ -177,6 +177,62 @@ describe("skills: tool activation reuses O1 activation set (d)", () => {
     const text = tr!.content.map((b) => b.text ?? "").join("");
     expect(text).toContain("FETCH BODY");
     expect(text).toContain("activated tools: WebFetch");
+    fake.teardown();
+  });
+});
+
+describe("skills: activation is a union, not overwrite (d2)", () => {
+  it("invoking a skill keeps previously-activated deferred tools visible", async () => {
+    const { hook, tool } = skills([
+      { name: "fetcher", description: "fetch web", body: "FETCH", tools: ["WebFetch"] },
+    ]);
+    const fake = createFakeModel([
+      {
+        content: [
+          { type: "toolCall", name: "skill", arguments: { name: "fetcher" } },
+        ],
+      },
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [trivialTool("WebFetch"), trivialTool("Grep"), tool],
+      hooks: [
+        // Grep 是 deferred 且**预激活**(alwaysListed)→ 一开始就可见;skill 再激活 WebFetch。
+        // 若 skill 用 overwrite(new Set(spec.tools))而非 union,会丢掉预激活的 Grep。
+        deferredTools({
+          deferred: ["WebFetch", "Grep"],
+          alwaysListed: ["Grep", tool.name],
+        }),
+        hook,
+      ],
+    });
+    await session.run("go");
+
+    const turn2 = namesOf(fake.getCalls()[1]!.tools);
+    // union:WebFetch 新激活 + Grep 预激活仍在(overwrite 会丢 Grep)。
+    expect(turn2).toEqual(expect.arrayContaining(["WebFetch", "Grep"]));
+    fake.teardown();
+  });
+});
+
+describe("skills: skill tool is a barrier", () => {
+  it("declares isConcurrencySafe === false (writes shared ctx.state activation set)", () => {
+    const { tool } = skills(SPECS);
+    expect(tool.isConcurrencySafe!({})).toBe(false);
+  });
+});
+
+describe("skills: custom toolName", () => {
+  it("honors opts.toolName in both tool.name and the catalog invoke hint", async () => {
+    const { hook, tool } = skills(SPECS, { toolName: "loadSkill" });
+    expect(tool.name).toBe("loadSkill");
+    const fake = createFakeModel([
+      { content: [{ type: "text", text: "ok" }], stopReason: "stop" },
+    ]);
+    const session = new AgentSession({ model: fake, tools: [tool], hooks: [hook] });
+    await session.run("go");
+    expect(fake.getCalls()[0]!.systemPrompt).toContain("`loadSkill`");
     fake.teardown();
   });
 });

--- a/packages/plugins/src/__tests__/skills.test.ts
+++ b/packages/plugins/src/__tests__/skills.test.ts
@@ -1,0 +1,216 @@
+/**
+ * skills —— 渐进式技能加载测试（issue #68 / O2）。
+ *
+ * 经 testing.ts fake-model 的 getCalls()——它捕获每次 Context.systemPrompt / Context.tools，
+ * 据此断言 catalog 进 system prompt（仅 name+description）、invoke 注入 body、非法 name throw、
+ * 工具激活复用 O1 激活集、opt-in 与 0.2.x 字节级一致、构造期 fail-loud。
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  AgentSession,
+  Type,
+  type HarnessTool,
+} from "@harness-pi/core";
+import { createFakeModel } from "@harness-pi/core/testing";
+import { skills } from "../skills.js";
+import { deferredTools } from "../deferred-tools.js";
+
+function trivialTool(name: string): HarnessTool {
+  return {
+    name,
+    description: `${name} tool`,
+    parameters: Type.Object({}),
+    isConcurrencySafe: () => true,
+    async execute() {
+      return { content: [{ type: "text", text: `${name} ran` }] };
+    },
+  };
+}
+
+function namesOf(
+  tools: ReadonlyArray<{ name: string }> | undefined,
+): string[] {
+  return (tools ?? []).map((t) => t.name);
+}
+
+const SPECS = [
+  {
+    name: "review-pr",
+    description: "Use when asked to review a pull request.",
+    body: "REVIEW BODY: read the diff, check correctness, summarize findings.",
+  },
+  {
+    name: "deep-research",
+    description: "Use for multi-source fact-checked research.",
+    body: "RESEARCH BODY: fan out searches, verify claims, cite sources.",
+  },
+];
+
+describe("skills: catalog in system prompt (a)", () => {
+  it("appends each skill's name + description, never the body", async () => {
+    const fake = createFakeModel([
+      { content: [{ type: "text", text: "ok" }], stopReason: "stop" },
+    ]);
+    const { hook, tool } = skills(SPECS);
+    const session = new AgentSession({
+      model: fake,
+      systemPrompt: "You are an agent.",
+      tools: [tool],
+      hooks: [hook],
+    });
+    await session.run("go");
+
+    const sys = fake.getCalls()[0]!.systemPrompt;
+    expect(sys).toContain("## Available skills");
+    for (const s of SPECS) {
+      expect(sys).toContain(s.name);
+      expect(sys).toContain(s.description);
+      // body 绝不进 catalog。
+      expect(sys).not.toContain(s.body);
+    }
+    // 原有 system prompt 保留。
+    expect(sys).toContain("You are an agent.");
+    fake.teardown();
+  });
+});
+
+describe("skills: invoke injects body (b)", () => {
+  it("skill({name}) returns the spec body as toolResult content", async () => {
+    const { hook, tool } = skills(SPECS);
+    const fake = createFakeModel([
+      {
+        content: [
+          { type: "toolCall", name: "skill", arguments: { name: "review-pr" } },
+        ],
+      },
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [tool],
+      hooks: [hook],
+    });
+    await session.run("go");
+
+    const tr = session.messages.find((m) => m.role === "toolResult") as
+      | { content: { text?: string }[]; isError?: boolean }
+      | undefined;
+    expect(tr).toBeDefined();
+    expect(tr!.isError).not.toBe(true);
+    const text = tr!.content.map((b) => b.text ?? "").join("");
+    expect(text).toContain("REVIEW BODY");
+    fake.teardown();
+  });
+});
+
+describe("skills: unknown name (c)", () => {
+  it("throws -> kernel wraps as isError toolResult mentioning 'unknown skill'", async () => {
+    const { hook, tool } = skills(SPECS);
+    const fake = createFakeModel([
+      {
+        content: [
+          { type: "toolCall", name: "skill", arguments: { name: "nope" } },
+        ],
+      },
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [tool],
+      hooks: [hook],
+    });
+    await session.run("go");
+
+    const tr = session.messages.find((m) => m.role === "toolResult") as
+      | { content: { text?: string }[]; isError?: boolean }
+      | undefined;
+    expect(tr).toBeDefined();
+    expect(tr!.isError).toBe(true);
+    const text = tr!.content.map((b) => b.text ?? "").join("");
+    expect(text).toContain("unknown skill");
+    fake.teardown();
+  });
+});
+
+describe("skills: tool activation reuses O1 activation set (d)", () => {
+  it("invoking a skill with tools activates them in the deferred listing next turn", async () => {
+    const { hook, tool } = skills([
+      {
+        name: "fetcher",
+        description: "Use to fetch web pages.",
+        body: "FETCH BODY",
+        tools: ["WebFetch"],
+      },
+    ]);
+    const fake = createFakeModel([
+      // turn-1：调 skill 激活 WebFetch（不收尾，继续循环）。
+      {
+        content: [
+          { type: "toolCall", name: "skill", arguments: { name: "fetcher" } },
+        ],
+      },
+      // turn-2：收尾。
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [trivialTool("WebFetch"), tool],
+      hooks: [
+        deferredTools({ deferred: ["WebFetch"], alwaysListed: [tool.name] }),
+        hook,
+      ],
+    });
+    await session.run("go");
+
+    const turn1 = namesOf(fake.getCalls()[0]!.tools);
+    const turn2 = namesOf(fake.getCalls()[1]!.tools);
+    // turn-1：WebFetch 仍 deferred、不可见。
+    expect(turn1).not.toContain("WebFetch");
+    // turn-2：skill 激活后下一 turn 出现在 listing（证明复用 O1 激活集）。
+    expect(turn2).toContain("WebFetch");
+
+    // toolResult 文案标注激活的工具。
+    const tr = session.messages.find((m) => m.role === "toolResult") as
+      | { content: { text?: string }[] }
+      | undefined;
+    const text = tr!.content.map((b) => b.text ?? "").join("");
+    expect(text).toContain("FETCH BODY");
+    expect(text).toContain("activated tools: WebFetch");
+    fake.teardown();
+  });
+});
+
+describe("skills: opt-in byte-equal (e)", () => {
+  it("without the skills hook, system prompt has no 'Available skills'", async () => {
+    const fake = createFakeModel([
+      { content: [{ type: "text", text: "ok" }], stopReason: "stop" },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      systemPrompt: "You are an agent.",
+      tools: [],
+      hooks: [],
+    });
+    await session.run("go");
+
+    expect(fake.getCalls()[0]!.systemPrompt).toBe("You are an agent.");
+    expect(fake.getCalls()[0]!.systemPrompt).not.toContain("Available skills");
+    fake.teardown();
+  });
+});
+
+describe("skills: construction-time fail-loud (f)", () => {
+  it("empty specs throws", () => {
+    expect(() => skills([])).toThrow();
+  });
+
+  it("duplicate skill name throws", () => {
+    expect(() =>
+      skills([
+        { name: "dup", description: "a", body: "A" },
+        { name: "dup", description: "b", body: "B" },
+      ]),
+    ).toThrow(/duplicate skill name/);
+  });
+});

--- a/packages/plugins/src/deferred-tools.ts
+++ b/packages/plugins/src/deferred-tools.ts
@@ -27,8 +27,10 @@ declare module "@harness-pi/core" {
   }
 }
 
-// `as const` 保留字面类型，让 TypedStateMap 走 typed overload 而不是 string fallback
-const KEY_ACTIVATED = "deferred.activated" as const;
+// `as const` 保留字面类型，让 TypedStateMap 走 typed overload 而不是 string fallback。
+// `KEY_ACTIVATED` 导出供 toolSearch / skills 复用同一激活集（单一 key 真相源，
+// 别在别处重复 declare module augmentation）。
+export const KEY_ACTIVATED = "deferred.activated" as const;
 const KEY_LISTING = "deferred.activeListing" as const;
 
 export interface DeferredToolsOptions {

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -119,3 +119,6 @@ export type { DeferredToolsOptions } from "./deferred-tools.js";
 
 export { toolSearch } from "./tool-search.js";
 export type { ToolSearchOptions } from "./tool-search.js";
+
+export { skills } from "./skills.js";
+export type { SkillSpec, SkillsOptions } from "./skills.js";

--- a/packages/plugins/src/skills.ts
+++ b/packages/plugins/src/skills.ts
@@ -1,0 +1,102 @@
+/**
+ * skills —— 渐进式技能加载（issue #68 / O2）。
+ *
+ * 把一组 "skill"（一段命名的 prompt 全文 + 可选要激活的工具）做成 catalog + 加载工具：
+ * - **发现**：`hook` 在 system prompt 末尾追加一段简洁 catalog（仅 name + description，
+ *   **绝不含 body**），随 system prompt 每 turn 已发、无额外注入成本。模型据此挑技能。
+ * - **加载**：`skill` 工具按名取回该 skill 的 body 全文作 toolResult 注入；若 skill 声明了
+ *   `tools`，把它们写进 O1 的 `"deferred.activated"` 激活集，**下一 turn** 才在 listing 里出现
+ *   （仅当也挂了 {@link deferredTools} 且这些工具被 deferred 时才有视觉效果——O1/O2 共享同一 seam）。
+ *
+ * domain-free：`SkillSpec` 不绑任何具体领域，纯 name/description/body/tools。
+ * opt-in：不挂 skills 时行为与 0.2.x 一致（system prompt 不含 "Available skills"）。
+ */
+
+import { Type } from "@harness-pi/core";
+import type {
+  HarnessTool,
+  Hook,
+  HookContext,
+  ToolExecResult,
+} from "@harness-pi/core";
+import { KEY_ACTIVATED } from "./deferred-tools.js";
+
+export interface SkillSpec {
+  /** 技能名，调 `skill` 工具时按此名取回。catalog 内唯一。 */
+  name: string;
+  /** 进 catalog 给模型选用的简短描述（whenToUse 性质）。 */
+  description: string;
+  /** invoke 时注入的全文 prompt —— 只在被调用时进 toolResult，**绝不进 catalog**。 */
+  body: string;
+  /** 可选：invoke 时激活的工具名（复用 O1 的 deferred.activated 激活集）。 */
+  tools?: string[];
+}
+
+export interface SkillsOptions {
+  /** `skill` 工具名 —— 默认 `"skill"`。 */
+  toolName?: string;
+}
+
+export function skills(
+  specs: SkillSpec[],
+  opts: SkillsOptions = {},
+): { hook: Hook; tool: HarnessTool } {
+  // 构造期 fail-loud：空集 / 重名直接抛，别等运行时静默退化。
+  if (specs.length === 0) {
+    throw new Error("skills(): specs must be non-empty");
+  }
+  const byName = new Map<string, SkillSpec>();
+  for (const spec of specs) {
+    if (byName.has(spec.name)) {
+      throw new Error(`skills(): duplicate skill name "${spec.name}"`);
+    }
+    byName.set(spec.name, spec);
+  }
+
+  const toolName = opts.toolName ?? "skill";
+
+  const catalog =
+    `\n\n## Available skills\n` +
+    `Invoke the \`${toolName}\` tool with a skill name to load its full instructions.\n` +
+    specs.map((s) => `- ${s.name}: ${s.description}`).join("\n");
+
+  const hook: Hook = {
+    name: "skills",
+    transformSystemPromptBeforeLlm(systemPrompt) {
+      // catalog 只含 name + description，绝不含 body。
+      return systemPrompt + catalog;
+    },
+  };
+
+  const tool: HarnessTool = {
+    name: toolName,
+    description:
+      "Load a skill's full instructions by name. " +
+      "Available skill names are listed under '## Available skills' in the system prompt.",
+    parameters: Type.Object({
+      name: Type.String({ description: "Name of the skill to load." }),
+    }),
+    // 可能写 ctx.state（激活集），且注入语义应顺序化 —— 屏障型。
+    isConcurrencySafe: () => false,
+    async execute(args, ctx: HookContext): Promise<ToolExecResult> {
+      const name = args.name as string;
+      const spec = byName.get(name);
+      if (!spec) {
+        const available = [...byName.keys()].join(", ");
+        throw new Error(`unknown skill "${name}" (available: ${available})`);
+      }
+
+      if (spec.tools?.length) {
+        const cur = ctx.state.get(KEY_ACTIVATED) ?? new Set<string>();
+        ctx.state.set(KEY_ACTIVATED, new Set([...cur, ...spec.tools]));
+      }
+
+      const note = spec.tools?.length
+        ? `\n\n(activated tools: ${spec.tools.join(", ")} — available next turn.)`
+        : "";
+      return { content: [{ type: "text", text: spec.body + note }] };
+    },
+  };
+
+  return { hook, tool };
+}

--- a/packages/plugins/src/skills.ts
+++ b/packages/plugins/src/skills.ts
@@ -10,6 +10,10 @@
  *
  * domain-free：`SkillSpec` 不绑任何具体领域，纯 name/description/body/tools。
  * opt-in：不挂 skills 时行为与 0.2.x 一致（system prompt 不含 "Available skills"）。
+ *
+ * 注意（已知小限制，非本插件引入）：catalog 经 `transformSystemPromptBeforeLlm` 追加在 **pipe 之后**，
+ * 而 `SessionConfigView.systemPrompt`（token-budget / autoCompaction 读的）暴露的是 **pipe 前**的 base，
+ * 故 catalog 的字节不计入 token 估算。catalog 仅 name+description、体积小，影响可忽略。
  */
 
 import { Type } from "@harness-pi/core";

--- a/packages/plugins/src/tool-search.ts
+++ b/packages/plugins/src/tool-search.ts
@@ -13,8 +13,7 @@
 
 import { Type } from "@harness-pi/core";
 import type { HarnessTool, HookContext, ToolExecResult } from "@harness-pi/core";
-
-const KEY_ACTIVATED = "deferred.activated" as const;
+import { KEY_ACTIVATED } from "./deferred-tools.js";
 
 export interface ToolSearchOptions {
   /**


### PR DESCRIPTION
**0.3.0 Wave C · O2**(epic #43,issue #68)。可发现 + 按需加载的命名 prompt 包(对照 cc SkillTool)。**零内核改动**,复用 O1(#66)建立的 seam——验证「同一 seam 两个 plugin 实例」的设计意图。

## 设计(复用 O1)
- `SkillSpec`(domain-free):`{ name, description, body, tools? }`。
- `skills(specs, opts?)` → `{ hook, tool }`:
  - **发现** hook:`transformSystemPromptBeforeLlm` 追加简洁 catalog(`## Available skills` + 各 `name: description`,**绝不含 body**)。随 system prompt 每 turn 已发、无额外注入成本。
  - **加载** tool(`skill`,名可覆盖):`{name}` → 返回 body 作 toolResult content;若 spec.tools 非空 → 写进 O1 的 `deferred.activated` 激活集 → 下一 turn 那些 deferred 工具可见(仅当也挂 deferredTools)。unknown name → throw。`isConcurrencySafe=false`。
- **key 去重**:`KEY_ACTIVATED` 从 deferred-tools.ts module-private 改为 export;tool-search.ts 删本地重复常量改 import(单一真相源,纯删重复不改行为)。

## 验证(review-gate 3/3 PASS,inline-diff)
- domain-free / opt-in:不挂 skills 时 system prompt 不含 "Available skills"(test e,byte-equal)。
- catalog 不泄漏 body(test a,精确钉 `- name: description` 配对)。
- O1 复用正确:union 非 overwrite(test d2:预激活 Grep + skill 激活 WebFetch → 两个都在)、单一 key 真相源、tool-search 改动纯 dedup。
- 构造 fail-loud(空 specs/重名)+ unknown name 运行期 isError。
全仓 build/typecheck/test 全绿(core 286 / plugins 322 含 +10 skills / 下游不破)。

## review 闭环
折入 test-review 覆盖缺口:union/barrier/toolName 测试 + catalog 精确行 + token-underreport 注释(catalog post-pipe 不计入估算,小限制可忽略)。

## 0.3.0 从简
per-skill model/allowedTools override、fork 模式**不做**(只 inline body 注入 + 可选工具组激活)。

Closes #68