### PR TITLE
feat(plugins): C5 — 混合 token 计量(真 usage 基线 + 字符补尾)(#43 C5)

### DIFF
--- a/packages/plugins/src/__tests__/estimate-request-tokens.test.ts
+++ b/packages/plugins/src/__tests__/estimate-request-tokens.test.ts
@@ -5,6 +5,7 @@ import {
   estimateTokensByChars,
   estimateRequestTokens,
   defaultTokenCounter,
+  hybridTokenCounter,
   PER_MESSAGE_OVERHEAD,
 } from "../auto-compaction.js";
 
@@ -155,5 +156,104 @@ describe("defaultTokenCounter", () => {
 
   it("does not implement count (count? is a future opt-in seam)", () => {
     expect(defaultTokenCounter.count).toBeUndefined();
+  });
+});
+
+/** 造一条带真 Usage 的 assistant message。 */
+function assistantMsg(
+  text: string,
+  u: { input: number; output: number; cacheRead?: number; cacheWrite?: number },
+): Message {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    usage: {
+      input: u.input,
+      output: u.output,
+      cacheRead: u.cacheRead ?? 0,
+      cacheWrite: u.cacheWrite ?? 0,
+      totalTokens: u.input + u.output,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    timestamp: 0,
+  } as Message;
+}
+
+describe("hybridTokenCounter (C5, issue #13)", () => {
+  it("uses the most-recent real-usage assistant as baseline + char-estimates only the suffix", () => {
+    const messages = [m("hello"), assistantMsg("hi", { input: 1000, output: 200, cacheRead: 50 }), m("a follow-up")];
+    const suffix = [m("a follow-up")];
+    // 基线 = input+cacheRead+cacheWrite+output = 1000+50+0+200 = 1250；只对后缀字符估算。
+    expect(hybridTokenCounter.estimate({ messages })).toBe(1250 + estimateTokensByChars(suffix));
+  });
+
+  it("does NOT re-add tools/systemPrompt on the hybrid path (they're already in the real baseline)", () => {
+    // 关键正确性:有真基线时,tools/systemPrompt 不再加(避免双重计) —— 与 estimateRequestTokens 相反。
+    const messages = [m("hi"), assistantMsg("a", { input: 1000, output: 100 })];
+    const bigTool = tool("read", "read a file from disk", {
+      type: "object",
+      properties: Object.fromEntries(
+        Array.from({ length: 20 }, (_, i) => [`f${i}`, { type: "string", description: "x".repeat(50) }]),
+      ),
+    });
+    const without = hybridTokenCounter.estimate({ messages });
+    const withToolsSys = hybridTokenCounter.estimate({
+      messages,
+      tools: [bigTool],
+      systemPrompt: "a fairly long system prompt ".repeat(20),
+    });
+    expect(withToolsSys).toBe(without); // 真基线已含 tools/sys,不再加
+    // 对照:estimateRequestTokens(纯估算路径)会把它们加进去 → 严格更大。
+    expect(estimateRequestTokens({ messages, tools: [bigTool], systemPrompt: "a fairly long system prompt ".repeat(20) }))
+      .toBeGreaterThan(estimateRequestTokens({ messages }));
+  });
+
+  it("picks the LATEST assistant carrying real usage when several exist", () => {
+    const messages = [
+      m("q1"),
+      assistantMsg("a1", { input: 500, output: 100 }),
+      m("q2"),
+      assistantMsg("a2", { input: 1500, output: 300 }),
+      m("q3"),
+    ];
+    // 用最近的 a2 作基线(1800),后缀 = [q3]。
+    expect(hybridTokenCounter.estimate({ messages })).toBe(1800 + estimateTokensByChars([m("q3")]));
+  });
+
+  it("degrades to estimateRequestTokens (X1) when there is no assistant yet (turn-0)", () => {
+    const messages = [m("just a user message")];
+    const input = { messages, tools: [tool("read", "read", { type: "object", properties: {} })], systemPrompt: "sys" };
+    expect(hybridTokenCounter.estimate(input)).toBe(estimateRequestTokens(input));
+  });
+
+  it("treats an all-zero-usage assistant as 'no real usage' and degrades to X1 (fake-model parity)", () => {
+    // fake-model 的 assistant usage 全 0 → 视为无真值 → 退回 X1。这保证 fake 测试行为与 defaultTokenCounter 一致。
+    const messages = [m("hello"), assistantMsg("hi", { input: 0, output: 0 }), m("more")];
+    const input = { messages, tools: [tool("read", "read", { type: "object", properties: {} })], systemPrompt: "sys" };
+    expect(hybridTokenCounter.estimate(input)).toBe(estimateRequestTokens(input));
+  });
+
+  it("includes cacheWrite in the baseline (pins the +cacheWrite term)", () => {
+    const messages = [m("q"), assistantMsg("a", { input: 1000, output: 100, cacheRead: 50, cacheWrite: 30 })];
+    // 基线 = 1000+50+30+100 = 1180;后缀为空。
+    expect(hybridTokenCounter.estimate({ messages })).toBe(1180);
+  });
+
+  it("skips a later zero-usage assistant and uses an earlier REAL one as baseline", () => {
+    // 非平凡控制流:guard 用 continue(非 break),故越过零-usage 的 assistant 继续往前找真值。
+    const real = assistantMsg("real", { input: 800, output: 120 });
+    const zero = assistantMsg("zero", { input: 0, output: 0 });
+    const messages = [m("q1"), real, m("q2"), zero, m("q3")];
+    // 用更早的 real(基线 920),后缀 = real 之后的全部 [q2, zero, q3]。
+    const suffix = messages.slice(messages.indexOf(real) + 1);
+    expect(hybridTokenCounter.estimate({ messages })).toBe(920 + estimateTokensByChars(suffix));
+  });
+
+  it("treats an assistant with NO usage object as 'no real usage' (the !u guard branch)", () => {
+    // 显式构造一条无 usage 字段的 assistant —— 命中 `!u` 分支 → continue → 退回 X1。
+    const noUsage = { role: "assistant", content: [{ type: "text", text: "a" }], timestamp: 0 } as Message;
+    const messages = [m("hello"), noUsage, m("more")];
+    const input = { messages };
+    expect(hybridTokenCounter.estimate(input)).toBe(estimateRequestTokens(input));
   });
 });

--- a/packages/plugins/src/auto-compaction.ts
+++ b/packages/plugins/src/auto-compaction.ts
@@ -207,6 +207,42 @@ export const defaultTokenCounter: TokenCounter = {
 };
 
 /**
+ * 混合 token 计量（issue #13 / C5）：取 messages 里**最近一条带真 `Usage` 的 assistant** 作基线
+ * （`input + cacheRead + cacheWrite + output` —— 那一刻真实的 prompt+output 体积，**已含 tools/systemPrompt**），
+ * 只对其后的消息走字符估算补尾（{@link estimateTokensByChars}，messages-only，**不再加 tools/systemPrompt**：
+ * 它们已计在真基线里，再加会双重计）。有真 usage 时基线精确——修掉 D0 实测的残差（messages-only 低估
+ * ~7x；X1 加回 tools/sys 后仍 ~2x，因 chat 模板/tool schema 自有格式比 char/4 重）。
+ *
+ * 无可用真 usage 时退回 {@link estimateRequestTokens}（X1，含 tools/systemPrompt）：(a) turn-0 还没 assistant；
+ * (b) assistant `usage` 全 0（fake-model / provider 未回 usage）—— 视为「无真值」而非「真的 0」。这保证不挂真
+ * provider 时（如 fake-model 测试）行为与 {@link defaultTokenCounter} 完全一致。
+ *
+ * **不满足 additivity 契约**（基线随「最近 assistant」跳变、非逐条可加）——故**别**用作 microcompact 的增量
+ * counter；它专给 autoCompaction（每 turn 全量 estimate、无增量假设）做更准的触发判据。
+ */
+export const hybridTokenCounter: TokenCounter = {
+  estimate(input: RequestTokenInput): number {
+    const msgs = input.messages;
+    for (let i = msgs.length - 1; i >= 0; i--) {
+      const m = msgs[i];
+      if (m === undefined || m.role !== "assistant") continue;
+      const u = m.usage;
+      // 判别「有无真值」**故意只看 input+output、忽略 cache**：fake-model / 未回 usage 的标志是
+      // input==output==0(testing.ts zeroUsage);真 assistant 输出内容必有 output>0。别把判别改成含
+      // cacheRead/cacheWrite —— 否则纯缓存命中(理论上 input=output=0、cacheRead>0)会被误判为真值,
+      // 且会让 fake 全 0 的 parity 假设变脆。continue(非 break):越过零-usage 继续往前找最近真值。
+      if (!u || u.input + u.output <= 0) continue;
+      // 基线 = 那一刻真实 prompt+output footprint(= pi-ai 自己的 totalTokens;input 已排除 cached,故 +cache)。
+      const baseline = u.input + u.cacheRead + u.cacheWrite + u.output;
+      // 补尾只数后缀消息字符(messages-only)。注:未加后缀的每消息 framing(~4tok/条),故对后缀略偏低估;
+      // 后缀在 turn 间有界(就最近几条)、基线主导且精确,这点偏差对「宁高勿低」的触发阈值可忽略。
+      return baseline + estimateTokensByChars(msgs.slice(i + 1));
+    }
+    return estimateRequestTokens(input);
+  },
+};
+
+/**
  * 构造一个 autoCompaction hook。三条**使用须知**（issue #13，违反会得到悄无声息的错误压缩）：
  *
  * 1. **Hook 顺序**：本插件从 `transformMessagesBeforeLlm` 收到的 `messages`（≈ `session.messages`）估算
@@ -243,7 +279,8 @@ export function autoCompaction(opts: AutoCompactionOptions): Hook {
   if (opts.safetyBuffer !== undefined && opts.safetyBuffer < 0) {
     throw new Error("autoCompaction: safetyBuffer must be >= 0");
   }
-  const counter = opts.tokenCounter ?? defaultTokenCounter;
+  // 默认走混合计量（C5）：有真 usage 用真基线（更准、修 D0 残差），无真 usage（turn-0 / fake）退回 X1。
+  const counter = opts.tokenCounter ?? hybridTokenCounter;
   const safetyBuffer = opts.safetyBuffer ?? 0;
   // 百分比路径阈值是构造期常量；窗口路径阈值依赖 ctx.config.model.contextWindow，须每请求算。
   const percentThreshold =

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -49,6 +49,7 @@ export {
   estimateTokensByChars,
   estimateRequestTokens,
   defaultTokenCounter,
+  hybridTokenCounter,
 } from "./auto-compaction.js";
 export type {
   AutoCompactionOptions,


### PR DESCRIPTION
**0.3.0 Wave B · C5**(epic #43,issue #70)。autoCompaction 的「当前上下文大小」估算从纯字符升级为混合,**直接修掉 D0 实测的 ~2.18x 残差**。零内核。

## 改动
新增 `hybridTokenCounter`(TokenCounter):
- 取 messages 里**最近一条带真 Usage 的 assistant** 作基线 = `input+cacheRead+cacheWrite+output`(= pi-ai 自己的 totalTokens;input 已排除 cached,故 +cache。已含 tools/systemPrompt)。
- 只对其后消息走 `estimateTokensByChars`(messages-only)补尾——**不再加 tools/sys**(已在真基线,避免双重计)。
- 无真 usage 退回 `estimateRequestTokens`(X1):turn-0、或 assistant usage 全 0(fake/未回)。判别**故意只看 input+output 忽略 cache**(隔离 fake 全 0),`continue` 越过零-usage 继续找最近真值。
- autoCompaction 默认 counter 改 hybridTokenCounter(degrade 路径 == 旧默认 → fake 测试零改动)。

## 验证(review-gate 3/3 PASS,inline-diff,两轮)
- **基线公式对照 pi-ai 0.74.2 provider 源码验证**:openai-completions/anthropic/google 的 input 均排除 cached、totalTokens=input+cacheRead+cacheWrite+output,与 C5 基线恒等。
- 不双重计(test:有无 tools/sys 估值相同;对照 estimateRequestTokens 会更大)。
- degrade+fake parity:330/330 全绿(322 旧 + 8 新),现有 fake 测试零改动。
- additivity:microcompact 仍用 defaultTokenCounter(hybrid 非可加,未误用)。
- 默认改动安全:window/百分比阈值逻辑未动,degrade 时 == 旧默认。
8 测试:基线+补尾 / 不双重计(带 X1 对照)/ 最近 assistant / turn-0 退回 / 全 0 退回 / cacheWrite 项 / skip-zero-找更早真值(continue 非 break)/ `!u` 分支。

## 范围
token-budget 不在 C5:测累计总量(已真 usage 求和),与上下文大小是不同的量。

## review 闭环
吸收 review nit:加注释说明判别故意忽略 cache(防未来误「修」破坏 fake parity)+ 后缀 framing 略低估可忽略;补 cacheWrite≠0 / skip-zero / `!u` 硬化测试。

Closes #70