### PR TITLE
feat(plugins): X4 — token-budget 每 turn 持续注入 remaining + 临界 urgency (#43 X4)

### DIFF
--- a/docs/05-plugins.md
+++ b/docs/05-plugins.md
@@ -1111,7 +1111,9 @@ export function getCostStats(ctx: HookContext): CostStats | undefined {
 
 #### Hook 形态
 
-Event (`onSessionStart` 建 tracker + `onTurnEnd` 检查 + 可触发 `continue: true` 注 nudge 或 abort)
+Event (`onSessionStart` 建 tracker + `onTurnStart` 每 turn 注入 remaining 提示 + `onTurnEnd` 做停止决策)
+
+> **X4(#43）更新**：持续反馈已移到 `onTurnStart`——**每 turn**(含第 1 call)注入结构化 remaining 提示,越过 `completionThreshold` 升级为 urgency;`onTurnEnd` 只保留停止决策(预算耗尽 / diminishing)。下方「完整设计」代码块为**早期示意**(命名/结构与现行 `packages/plugins/src/token-budget.ts` 已有出入),以实现为准。
 
 #### 完整设计
 

--- a/packages/plugins/src/__tests__/plugins-edge.test.ts
+++ b/packages/plugins/src/__tests__/plugins-edge.test.ts
@@ -570,7 +570,7 @@ describe("token-budget edge", () => {
     expect(summary.reason).toBe("done");
   });
 
-  it("nudge attached when token% in middle range", async () => {
+  it("injects a budget reminder into the next call (now unconditional per-turn via onTurnStart)", async () => {
     const model = createFakeModel([
       {
         content: [
@@ -606,6 +606,102 @@ describe("token-budget edge", () => {
         (m.content as string).includes("tokens"),
     );
     expect(nudge).toBeDefined();
+  });
+
+  it("X4: continuous remaining reminder fires on the very first call (turn-start, not only at stop)", async () => {
+    const model = createFakeModel([
+      { content: [{ type: "text", text: "ok" }], usage: { input: 5, output: 2 } },
+    ]);
+    let firstCall: any[] = [];
+    let captured = false;
+    const spy: Hook = {
+      name: "spy",
+      transformMessagesBeforeLlm(msgs) {
+        if (!captured) {
+          firstCall = msgs;
+          captured = true;
+        }
+        return undefined;
+      },
+    };
+    const session = new AgentSession({
+      model,
+      tools: [],
+      hooks: [tokenBudget({ budget: 1000 }), spy],
+    });
+    await session.run("go");
+    // 第 1 个 LLM call 就带 remaining 反馈(onTurnStart 持续注入),不是只在停时。
+    const reminder = firstCall.find(
+      (m: any) =>
+        typeof m.content === "string" &&
+        (m.content as string).includes("system-reminder") &&
+        (m.content as string).includes("remaining"),
+    );
+    expect(reminder).toBeDefined();
+    // <completionThreshold(此处 0%)不应升级为 urgency —— 锁住升级是条件性的。
+    expect(reminder!.content as string).not.toContain("near the budget limit");
+  });
+
+  it("X4: reminder still fires above completionThreshold (0.9~1.0 gap) and escalates to urgency", async () => {
+    const model = createFakeModel([
+      // turn-1 用掉 95/100 → 越过 completionThreshold(默认 0.9):旧代码此区间不 nudge,X4 仍注入 + urgency。
+      {
+        content: [{ type: "toolCall", name: "echo", arguments: { msg: "x" } }],
+        usage: { input: 95, output: 0 },
+        stopReason: "toolUse",
+      },
+      { content: [{ type: "text", text: "ok" }], usage: { input: 1, output: 1 } },
+    ]);
+    let seen: any[] = [];
+    const spy: Hook = {
+      name: "spy",
+      transformMessagesBeforeLlm(msgs) {
+        seen = msgs;
+        return undefined;
+      },
+    };
+    const session = new AgentSession({
+      model,
+      tools: [echoTool],
+      hooks: [costTracker(), tokenBudget({ budget: 100 }), spy],
+    });
+    await session.run("go");
+    // turn-2 在 95/100(>0.9)仍收到 reminder,且含 urgency 收尾提示。
+    const reminder = seen.find(
+      (m: any) =>
+        typeof m.content === "string" &&
+        (m.content as string).includes("system-reminder") &&
+        (m.content as string).includes("remaining"),
+    );
+    expect(reminder).toBeDefined();
+    expect(reminder!.content as string).toContain("near the budget limit");
+  });
+
+  it("X4: diminishing-returns still stops the run under the every-turn nudgeCount", async () => {
+    // 每 turn ~50 token(<diminishingThreshold 500),累计远未爆 budget。X4 把 nudgeCount 改为每 turn
+    // 递增——这里锁住「连续小 delta + nudgeCount 累积 → diminishing 收敛仍能强停」,防未来重构回退。
+    const model = createFakeModel(
+      Array.from({ length: 6 }, () => ({
+        content: [{ type: "text", text: "x" }],
+        usage: { input: 50, output: 0 },
+        stopReason: "toolUse" as const,
+      })),
+    );
+    const session = new AgentSession({
+      model,
+      tools: [],
+      hooks: [
+        costTracker(),
+        tokenBudget({
+          budget: 100_000,
+          diminishingThreshold: 500,
+          diminishingMinNudges: 3,
+        }),
+      ],
+    });
+    const summary = await session.run("go");
+    expect(summary.reason).toBe("aborted");
+    expect(summary.abortReason).toContain("diminishing returns");
   });
 });
 

--- a/packages/plugins/src/token-budget.ts
+++ b/packages/plugins/src/token-budget.ts
@@ -18,14 +18,14 @@ declare module "@harness-pi/core" {
 export interface TokenBudgetOptions {
   /** session 总 token 预算。null = 不限。 */
   budget: number | null;
-  /** 当前累计超 budget × completionThreshold 时停止 nudge（默认 0.9）。 */
+  /** 累计超 budget × completionThreshold 时,每 turn 的 remaining 提示升级为「该收尾」urgency（默认 0.9）。 */
   completionThreshold?: number;
   /** Diminishing returns 阈值。连续 N turn delta < 这个值视为收敛（默认 500）。 */
   diminishingThreshold?: number;
-  /** 触发 diminishing 判定前最少 continuation 次数（默认 3）。 */
+  /** 触发 diminishing 判定前最少 turn 数（默认 3）。 */
   diminishingMinNudges?: number;
-  /** 触发 nudge 的文案。 */
-  nudgeMessage?: (pct: number, turnTokens: number, budget: number) => string;
+  /** 每 turn 注入的 remaining 提示文案。`usedTokens` 是**累计**已用 token（非单 turn）。 */
+  nudgeMessage?: (pct: number, usedTokens: number, budget: number) => string;
 }
 
 interface BudgetTracker {
@@ -41,10 +41,11 @@ const KEY = "token-budget.tracker" as const;
 
 function defaultNudge(
   pct: number,
-  turnTokens: number,
+  usedTokens: number,
   budget: number,
 ): string {
-  return `You've used ${turnTokens.toLocaleString()} / ${budget.toLocaleString()} tokens (${pct}%). Continue if more useful work remains; otherwise summarize and stop.`;
+  const remaining = Math.max(0, budget - usedTokens);
+  return `Token budget: ${usedTokens.toLocaleString()} / ${budget.toLocaleString()} tokens used (${pct}%), ${remaining.toLocaleString()} remaining. Plan remaining work to fit the budget; summarize and stop if little remains.`;
 }
 
 function readCumulativeTokens(ctx: HookContext): number {
@@ -87,6 +88,24 @@ export function tokenBudget(opts: TokenBudgetOptions): Hook {
       tr.fallbackOutput += input.msg.usage.output ?? 0;
     },
 
+    // X4（issue #43）：每 turn 开始注入「剩余预算」结构化提示——**持续反馈**(不只停时)，让模型据此
+    // 规划剩余工作。补上原先 0.9~1.0 临界区无反馈的缺口。additionalContext 一次性消费语义正好匹配
+    // 「每 call 注入」；走通用 prompt 注入，不依赖 provider beta（实仓核验 pi-ai 无 task_budget）。
+    onTurnStart(_input, ctx): HookResult | void {
+      if (opts.budget == null || opts.budget <= 0) return;
+      const totalTokens = readCumulativeTokens(ctx);
+      const pct = Math.round((totalTokens / opts.budget) * 100);
+      // 越过 completionThreshold 进入临界区 → reminder 升级为「该收尾」紧急提示（补原先 0.9~1.0 无反馈的缺口）。
+      const urgent = totalTokens >= opts.budget * completionThreshold;
+      const body =
+        nudgeMsg(pct, totalTokens, opts.budget) +
+        (urgent ? " You are near the budget limit — wrap up and stop soon." : "");
+      return {
+        additionalContext: `<system-reminder>${body}</system-reminder>`,
+      };
+    },
+
+    // turn 收尾只做**停止决策**（预算耗尽 / diminishing 收敛）——持续 remaining 反馈已移到 onTurnStart。
     onTurnEnd(_input, ctx): HookResult | void {
       if (opts.budget == null || opts.budget <= 0) return;
 
@@ -94,7 +113,6 @@ export function tokenBudget(opts: TokenBudgetOptions): Hook {
       if (!tr) return;
 
       const totalTokens = readCumulativeTokens(ctx);
-      const pct = Math.round((totalTokens / opts.budget) * 100);
       const delta = totalTokens - tr.lastTotalTokens;
 
       const isDiminishing =
@@ -116,16 +134,8 @@ export function tokenBudget(opts: TokenBudgetOptions): Hook {
         };
       }
 
-      if (totalTokens < opts.budget * completionThreshold) {
-        tr.nudgeCount++;
-        tr.lastDeltaTokens = delta;
-        tr.lastTotalTokens = totalTokens;
-        return {
-          additionalContext: `<system-reminder>${nudgeMsg(pct, totalTokens, opts.budget)}</system-reminder>`,
-        };
-      }
-
-      // 已到完成阈值但未爆——不强停，让 LLM 自然收尾
+      // 每 turn 推进收敛跟踪（nudgeCount 现作「已观察 turn 数」，喂 diminishing 判定）。
+      tr.nudgeCount++;
       tr.lastDeltaTokens = delta;
       tr.lastTotalTokens = totalTokens;
       return;


### PR DESCRIPTION
**0.3.0 Wave C · X4**(epic #43,issue #72)。token-budget 此前只在 onTurnEnd `<completionThreshold` 区间 nudge——0.9~1.0 临界区 + 「持续 remaining 反馈」缺失。X4 改为 **onTurnStart 每 turn 注入** remaining 提示,让模型规划剩余工作。零内核。

## 改动
- **onTurnStart**(新):每 turn(含第 1 call)注入 `<system-reminder>` remaining 提示(used/budget/pct/remaining);越过 `completionThreshold` 升级为「wrap up and stop soon」urgency。
- **onTurnEnd**:收窄为只做停止决策(预算耗尽 / diminishing);移除其 nudge 注入。
- `completionThreshold` 从「停 nudge 阈值」**重定为 urgency 升级阈值**(仍 live option);`defaultNudge` 含 remaining;`nudgeMessage` 形参 `turnTokens`→`usedTokens`(传累计值,名实相符)。
- 走通用 prompt 注入(additionalContext),不依赖 provider beta(pi-ai 无 task_budget)。

## 验证(review-gate 3/3 PASS,inline-diff)
经 session.ts 核实 onTurnStart 的 additionalContext 进**当前 turn** call。现有测试(exhausted-stop/null/budget=0/middle-range)全不破。+3 测试:第 1 call 就有 remaining(+负向 urgency 断言)/ >completionThreshold 临界区仍注入+urgency / diminishing-stop 在新 nudgeCount 语义下仍收敛。全仓全绿(plugins 333)。

## review 闭环(吸收 nits)
completionThreshold JSDoc / nudgeMessage 形参名同步;补 diminishing-stop + 负向 urgency 测试;重命名过时 "middle range" 测试;docs/05 §5.11 行为描述同步(标注代码块为早期示意、以实现为准)。

Closes #72