### PR TITLE
feat(plugins): C3 — CompactResumeFromBoundary(abort+resume-from-boundary)(#43 C3)

### DIFF
--- a/packages/plugins/src/__tests__/compact-resume-from-boundary.test.ts
+++ b/packages/plugins/src/__tests__/compact-resume-from-boundary.test.ts
@@ -1,0 +1,319 @@
+/**
+ * compactResumeFromBoundary 控制器测试（C3，docs/09 §4.2）。
+ * 它是 compactRestartFresh 的兄弟：overflow → compactOnOverflow abort 后，**不**丢 trace fresh 重跑，
+ * 而是写一条覆盖全量的 summary boundary、从 boundary resume + continue 续跑（保留压缩成果）。
+ *
+ * 经 testing.ts fake-model 驱动真 AgentSession + MemorySessionStore（core 直接导出）。验证：
+ *   - overflow → 写 boundary → resume → continue → 第二段 done；restarts>=1。
+ *   - resume 后的 continue 段从 boundary 起算（fake 收到的首条 message 是 summary，且 lineage 同 sessionId）。
+ *   - maxRestarts 耗尽（持续 overflow）→ 返回 aborted summary、restarts===maxRestarts、不无限循环。
+ *   - 复用 compactOnOverflow + isCompactionRestart（import，不重定义）。
+ *   - 不挂 compactOnOverflow → overflow 不变 compaction-abort → 控制器不 resume（行为=普通 run）。
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  AgentSession,
+  MemorySessionStore,
+  createUserMessage,
+  type Hook,
+  type Message,
+} from "@harness-pi/core";
+import { createFakeModel } from "@harness-pi/core/testing";
+import {
+  compactOnOverflow,
+  CompactResumeFromBoundary,
+  isCompactionRestart,
+  COMPACTION_OVERFLOW_REASON,
+} from "../controllers/index.js";
+
+describe("CompactResumeFromBoundary", () => {
+  it("happy path: no overflow → no restart, behaves like a plain run", async () => {
+    const store = new MemorySessionStore();
+    const model = createFakeModel([
+      { content: [{ type: "text", text: "ok" }], stopReason: "stop" },
+    ]);
+    const ctrl = new CompactResumeFromBoundary({
+      store,
+      sessionId: "s-happy",
+      sessionOptions: { model, tools: [], hooks: [compactOnOverflow()] },
+      summarize: () => createUserMessage("never"),
+    });
+    const res = await ctrl.run("solve it");
+
+    expect(res.reason).toBe("done");
+    expect(res.restarts).toBe(0);
+    // 没 overflow → 没写 boundary。
+    const path = await store.getPathToLeaf("s-happy");
+    expect(path.filter((e) => e.entry.kind === "compaction_boundary")).toHaveLength(0);
+    model.teardown();
+  });
+
+  it("overflow (length) → writes boundary, resumes from it, continue succeeds; restarts>=1", async () => {
+    const store = new MemorySessionStore();
+    // 首跑 turn0 截断 → compactOnOverflow abort。resume-continue turn0 正常 done。
+    const model = createFakeModel([
+      { content: [{ type: "text", text: "truncated" }], stopReason: "length" },
+      { content: [{ type: "text", text: "recovered" }], stopReason: "stop" },
+    ]);
+    const summary = createUserMessage("SUMMARY-OF-OVERFLOWING-TRACE");
+    const ctrl = new CompactResumeFromBoundary({
+      store,
+      sessionId: "s-recover",
+      sessionOptions: { model, tools: [], hooks: [compactOnOverflow()] },
+      summarize: () => summary,
+    });
+    const res = await ctrl.run("solve it");
+
+    expect(res.reason).toBe("done");
+    expect(res.restarts).toBe(1);
+
+    // 恰好写了一条 boundary，summary 就是我们提供的那条。
+    const path = await store.getPathToLeaf("s-recover");
+    const boundaries = path
+      .filter((e) => e.entry.kind === "compaction_boundary")
+      .map((e) => (e.entry as { kind: "compaction_boundary"; summary: Message }).summary);
+    expect(boundaries).toEqual([summary]);
+    model.teardown();
+  });
+
+  it("overflow surfaced as an error stopReason also triggers a boundary + resume", async () => {
+    const store = new MemorySessionStore();
+    const model = createFakeModel([
+      { content: [], throwError: new Error("maximum context length exceeded") },
+      { content: [{ type: "text", text: "recovered" }], stopReason: "stop" },
+    ]);
+    const ctrl = new CompactResumeFromBoundary({
+      store,
+      sessionId: "s-err",
+      sessionOptions: { model, tools: [], hooks: [compactOnOverflow()] },
+      summarize: () => createUserMessage("S"),
+    });
+    const res = await ctrl.run("solve it");
+
+    expect(res.reason).toBe("done");
+    expect(res.restarts).toBe(1);
+    model.teardown();
+  });
+
+  it("resume continues FROM the boundary — the continue() call sees [summary] as its first message, same lineage", async () => {
+    // 这是 C3 区别于 fresh 的全部理由：保留 summary 成果、从 boundary 起算（resume → [summary]）。
+    const store = new MemorySessionStore();
+    const model = createFakeModel([
+      { content: [{ type: "text", text: "truncated" }], stopReason: "length" }, // 首跑 → overflow
+      { content: [{ type: "text", text: "recovered" }], stopReason: "stop" }, // resume-continue
+    ]);
+    const summary = createUserMessage("BOUNDARY-SUMMARY");
+    const ctrl = new CompactResumeFromBoundary({
+      store,
+      sessionId: "s-from-boundary",
+      sessionOptions: { model, tools: [], hooks: [compactOnOverflow()] },
+      summarize: () => summary,
+    });
+    const res = await ctrl.run("the original prompt");
+
+    expect(res.reason).toBe("done");
+    expect(res.restarts).toBe(1);
+
+    const calls = model.getCalls();
+    // 最后一次 LLM 调用是 resume 后的 continue：context 以 boundary summary 起头（不是原 prompt）。
+    const continueCall = calls[calls.length - 1]!;
+    expect(continueCall.messages[0]).toBe(summary);
+    // resume 出的 [summary] 覆盖全量 → continue 段 context 不再含原始 user prompt。
+    expect(
+      continueCall.messages.some(
+        (m) => m.role === "user" && m !== summary,
+      ),
+    ).toBe(false);
+
+    // 同一 lineage：所有 entry 都在同一个 sessionId 下重建。
+    const resumed = await AgentSession.resume(store, "s-from-boundary", { model, tools: [] });
+    expect(resumed.id).toBe("s-from-boundary");
+    model.teardown();
+  });
+
+  it("persistent overflow stops after maxRestarts and returns the aborted summary (no fake recovery, no infinite loop)", async () => {
+    const store = new MemorySessionStore();
+    // 每段都 length-截断 → 永远 overflow。备足 response 防 fake 跑空。
+    const model = createFakeModel(
+      Array.from({ length: 6 }, () => ({
+        content: [{ type: "text" as const, text: "x" }],
+        stopReason: "length" as const,
+      })),
+    );
+    const ctrl = new CompactResumeFromBoundary({
+      store,
+      sessionId: "s-persist",
+      sessionOptions: { model, tools: [], hooks: [compactOnOverflow()] },
+      summarize: () => createUserMessage("S"),
+      maxRestarts: 2,
+    });
+    const res = await ctrl.run("oversized");
+
+    expect(res.restarts).toBe(2);
+    expect(res.reason).toBe("aborted");
+    expect(res.abortReason).toBe(COMPACTION_OVERFLOW_REASON);
+    // 恰好 maxRestarts 次 resume → maxRestarts 条 boundary，不多写（不无限循环）。
+    const path = await store.getPathToLeaf("s-persist");
+    expect(path.filter((e) => e.entry.kind === "compaction_boundary")).toHaveLength(2);
+    model.teardown();
+  });
+
+  it("maxRestarts: 0 never resumes — returns the first aborted summary", async () => {
+    const store = new MemorySessionStore();
+    const model = createFakeModel(
+      Array.from({ length: 3 }, () => ({
+        content: [{ type: "text" as const, text: "x" }],
+        stopReason: "length" as const,
+      })),
+    );
+    const ctrl = new CompactResumeFromBoundary({
+      store,
+      sessionId: "s-zero",
+      sessionOptions: { model, tools: [], hooks: [compactOnOverflow()] },
+      summarize: () => createUserMessage("S"),
+      maxRestarts: 0,
+    });
+    const res = await ctrl.run("p");
+
+    expect(res.restarts).toBe(0);
+    expect(res.reason).toBe("aborted");
+    expect(res.abortReason).toBe(COMPACTION_OVERFLOW_REASON);
+    const path = await store.getPathToLeaf("s-zero");
+    expect(path.filter((e) => e.entry.kind === "compaction_boundary")).toHaveLength(0);
+    model.teardown();
+  });
+
+  it("does NOT resume on a non-compaction abort (no compactOnOverflow hook → overflow stays a plain abort)", async () => {
+    const store = new MemorySessionStore();
+    const model = createFakeModel([
+      { content: [{ type: "text", text: "t" }], stopReason: "length" },
+    ]);
+    // 用一个非 compaction reason 的 overflow hook（即「没装 compactOnOverflow」的等价情形）。
+    const manualAbort: Hook = {
+      name: "manual",
+      onContextOverflow: (_i, ctx) => ctx.abort("manual:stop"),
+    };
+    let summarizeCalls = 0;
+    const ctrl = new CompactResumeFromBoundary({
+      store,
+      sessionId: "s-noncompact",
+      sessionOptions: { model, tools: [], hooks: [manualAbort] },
+      summarize: () => {
+        summarizeCalls++;
+        return createUserMessage("S");
+      },
+    });
+    const res = await ctrl.run("p");
+
+    expect(res.restarts).toBe(0);
+    expect(res.reason).toBe("aborted");
+    expect(res.abortReason).toBe("manual:stop");
+    // 不认 → 不 resume → 不 summarize、不写 boundary（行为=普通 run）。
+    expect(summarizeCalls).toBe(0);
+    const path = await store.getPathToLeaf("s-noncompact");
+    expect(path.filter((e) => e.entry.kind === "compaction_boundary")).toHaveLength(0);
+    model.teardown();
+  });
+
+  it("honors a custom compaction abort reason", async () => {
+    const store = new MemorySessionStore();
+    const model = createFakeModel([
+      { content: [{ type: "text", text: "t" }], stopReason: "length" },
+      { content: [{ type: "text", text: "ok" }], stopReason: "stop" },
+    ]);
+    const ctrl = new CompactResumeFromBoundary({
+      store,
+      sessionId: "s-custom",
+      sessionOptions: {
+        model,
+        tools: [],
+        hooks: [compactOnOverflow({ reason: "compaction:summarize-failed" })],
+      },
+      summarize: () => createUserMessage("S"),
+    });
+    const res = await ctrl.run("p");
+
+    expect(res.reason).toBe("done");
+    expect(res.restarts).toBe(1);
+    model.teardown();
+  });
+
+  it("stops resuming when the external signal is aborted", async () => {
+    const ac = new AbortController();
+    const store = new MemorySessionStore();
+    const model = createFakeModel(
+      Array.from({ length: 5 }, () => ({
+        content: [{ type: "text" as const, text: "x" }],
+        stopReason: "length" as const,
+      })),
+    );
+    const abortBoth: Hook = {
+      name: "abort-both",
+      onContextOverflow: (_i, ctx) => {
+        ctx.abort(COMPACTION_OVERFLOW_REASON); // 内部 abort 先发（首个 abort 胜出）
+        ac.abort(); // 同时 abort 外部 signal
+      },
+    };
+    const ctrl = new CompactResumeFromBoundary({
+      store,
+      sessionId: "s-signal",
+      sessionOptions: { model, tools: [], hooks: [abortBoth] },
+      summarize: () => createUserMessage("S"),
+    });
+    const res = await ctrl.run("p", { signal: ac.signal });
+
+    expect(res.restarts).toBe(0); // signal aborted → while 守卫拦下 resume
+    expect(res.reason).toBe("aborted");
+    model.teardown();
+  });
+
+  it("rejects negative maxRestarts at construction", () => {
+    const store = new MemorySessionStore();
+    const model = createFakeModel([]);
+    expect(
+      () =>
+        new CompactResumeFromBoundary({
+          store,
+          sessionId: "s-neg",
+          sessionOptions: { model, tools: [], hooks: [compactOnOverflow()] },
+          summarize: () => createUserMessage("S"),
+          maxRestarts: -1,
+        }),
+    ).toThrow(/maxRestarts/);
+    model.teardown();
+  });
+
+  it("summarize throwing → run() rejects (propagate) and writes NO orphan boundary", async () => {
+    const store = new MemorySessionStore();
+    const model = createFakeModel([
+      // 首跑 overflow → compactOnOverflow abort → 控制器要 summarize(此处抛错)。
+      { content: [{ type: "text", text: "truncated" }], stopReason: "length" },
+      { content: [{ type: "text", text: "recovered" }], stopReason: "stop" },
+    ]);
+    const ctrl = new CompactResumeFromBoundary({
+      store,
+      sessionId: "s-sumfail",
+      sessionOptions: { model, tools: [], hooks: [compactOnOverflow()] },
+      summarize: () => {
+        throw new Error("summarize backend down");
+      },
+    });
+    // summarize 在 appendEntry 之前抛 → run() reject(fail-loud,caller 自负 summarize 错误)。
+    await expect(ctrl.run("solve it")).rejects.toThrow("summarize backend down");
+    // 数据完整性:抛在写 boundary 之前 → store 无半成品 orphan compaction_boundary。
+    const path = await store.getPathToLeaf("s-sumfail");
+    expect(
+      path.filter((e) => e.entry.kind === "compaction_boundary"),
+    ).toHaveLength(0);
+    model.teardown();
+  });
+});
+
+describe("isCompactionRestart (reused, not redefined)", () => {
+  it("matches compaction:* abort reasons only", () => {
+    expect(isCompactionRestart("compaction:overflow")).toBe(true);
+    expect(isCompactionRestart("watchdog:timeout")).toBe(false);
+    expect(isCompactionRestart(undefined)).toBe(false);
+  });
+});

--- a/packages/plugins/src/controllers/compact-resume-from-boundary.ts
+++ b/packages/plugins/src/controllers/compact-resume-from-boundary.ts
@@ -1,0 +1,99 @@
+/**
+ * compactResumeFromBoundary —— compactRestartFresh 的兄弟（docs/09 §4.2），同样建在内核
+ * `onContextOverflow` → `compactOnOverflow()` abort 之上，但**恢复方式相反**：
+ *
+ *   - `compactRestartFresh`：overflow 时 abort + **fresh 重跑同一 prompt**，丢掉整段越界 ReAct trace。
+ *     便宜，但每次都从零开始——压缩成果（trace 里已做的工作）全部作废。
+ *   - `compactResumeFromBoundary`（本控制器）：overflow 时 abort 后，把当下 live messages **总结成一条
+ *     覆盖全量的 summary**、写一条 `compaction_boundary` entry，再 `AgentSession.resume()` 从 boundary
+ *     **续跑**（`continue()`）。**保留压缩后的成果**——summary 把越界 trace 浓缩成一条，从这条接着干。
+ *
+ * 二者都复用 `compactOnOverflow`（Hook）+ `isCompactionRestart`（谓词），区别仅在 abort 之后怎么恢复。
+ *
+ * 为什么不像 fresh 那样可能死循环：boundary **覆盖它之前的全部前缀**，resume 重建出的 messages 就是
+ * `[summary]` 一条——最大压缩。只要 summarize 真把内容压短，每次 resume 的起点都比上次小，进展有保证；
+ * 不像 fresh「重跑同一 prompt」在 **初始 prompt 本身过大** 时会反复同样越界。
+ *
+ * ⚠️ 诚实边界：
+ *   - **需要 `store`**：boundary 必须落盘，`resume()` 从 store 重建。compactRestartFresh 不需 store。
+ *   - **`maxRestarts` 耗尽**：若持续 overflow（如单条 summary 仍超窗），控制器在耗尽后返回**最后一次的
+ *     aborted summary**（不假装恢复成功）。
+ *   - **signal 只透传给 `run`/`continue`**：其余 run 选项不穿透（与 compactRestartFresh 一致）。
+ *   - **domain-free**：`summarize` 由调用方提供（可调 LLM），控制器/内核都不内置 LLM 调用。
+ *   - **`summarize` 抛错**：`run()` 直接 reject（fail-loud，caller 自负 summarize 错误）。因 summarize 在
+ *     `appendEntry` 之前调用，抛错时**不留半成品 orphan boundary**——store 不损坏。
+ */
+
+import { AgentSession, type AgentSessionOptions, type Message, type RunSummary, type SessionStore } from "@harness-pi/core";
+import { isCompactionRestart } from "./compact-restart-fresh.js";
+
+export interface CompactResumeFromBoundaryOptions {
+  /** 落盘 store（resume 从它读重建）。必需。 */
+  store: SessionStore;
+  /** session id（首跑 + resume 同一 lineage 用同一个）。必需。 */
+  sessionId: string;
+  /**
+   * 造首个 session + resume 都用的会话选项（model/tools/hooks/...）。
+   * **务必在 hooks 里装 `compactOnOverflow()`** —— 否则 overflow 不会变成 compaction abort、控制器无从感知。
+   */
+  sessionOptions: Omit<
+    AgentSessionOptions,
+    "store" | "sessionId" | "initialMessages" | "resumedMessageCount"
+  >;
+  /**
+   * 把 abort 时的 live messages 总结成一条覆盖全量的 summary message。可 async（调 LLM）。domain-free。
+   */
+  summarize: (messages: ReadonlyArray<Message>) => Message | Promise<Message>;
+  /** 最大重启次数（不含首跑），默认 3。 */
+  maxRestarts?: number;
+}
+
+export interface CompactResumeResult extends RunSummary {
+  /** 实际 resume-continue 次数。 */
+  restarts: number;
+}
+
+const DEFAULT_MAX_RESTARTS = 3;
+
+export class CompactResumeFromBoundary {
+  constructor(private readonly opts: CompactResumeFromBoundaryOptions) {
+    if ((opts.maxRestarts ?? DEFAULT_MAX_RESTARTS) < 0) {
+      throw new Error("CompactResumeFromBoundary: maxRestarts must be >= 0");
+    }
+  }
+
+  /**
+   * 跑 prompt；overflow-abort 则写 boundary（summary 覆盖全量）→ resume → continue 续跑，直到非
+   * compaction abort 或 maxRestarts 耗尽。耗尽返回最后一次的 aborted summary（不假装恢复）。
+   * 注意：只代理 `signal` 给每次 `run`/`continue`，其余 run 选项不穿透（与 compactRestartFresh 同）。
+   */
+  async run(
+    prompt: string,
+    opts?: { signal?: AbortSignal },
+  ): Promise<CompactResumeResult> {
+    const { store, sessionId, sessionOptions, summarize } = this.opts;
+    const max = this.opts.maxRestarts ?? DEFAULT_MAX_RESTARTS;
+    const runOpts = opts?.signal ? { signal: opts.signal } : {};
+
+    let session = new AgentSession({ ...sessionOptions, store, sessionId });
+    let summary = await session.run(prompt, runOpts);
+    let restarts = 0;
+
+    while (
+      summary.reason === "aborted" &&
+      isCompactionRestart(summary.abortReason) &&
+      restarts < max &&
+      !opts?.signal?.aborted
+    ) {
+      restarts++;
+      // 把越界 trace 总结成一条覆盖全量的 summary，写 boundary（覆盖它之前的全部前缀）。
+      const boundary = await summarize(session.messages);
+      await store.appendEntry(sessionId, { kind: "compaction_boundary", summary: boundary });
+      // 从 boundary resume：重建出的 messages 就是 [summary] 一条，从这条 continue 续跑。
+      session = await AgentSession.resume(store, sessionId, sessionOptions);
+      summary = await session.continue(runOpts);
+    }
+
+    return { ...summary, restarts };
+  }
+}

--- a/packages/plugins/src/controllers/index.ts
+++ b/packages/plugins/src/controllers/index.ts
@@ -48,6 +48,12 @@ export type {
   CompactRestartResult,
 } from "./compact-restart-fresh.js";
 
+export { CompactResumeFromBoundary } from "./compact-resume-from-boundary.js";
+export type {
+  CompactResumeFromBoundaryOptions,
+  CompactResumeResult,
+} from "./compact-resume-from-boundary.js";
+
 export { subAgentTool, routedSubAgentTool } from "./sub-agent-tool.js";
 export type {
   SubAgentToolOptions,


### PR DESCRIPTION
**0.3.0 Wave B 最后一项 · C3**(epic #43,issue #74)。compact-on-overflow 的「保留成果」恢复变体,补 compactRestartFresh(丢整段 trace fresh 重跑)之缺。**零内核改动**,纯组合现有能力。

## 设计
`CompactResumeFromBoundary` —— compactRestartFresh 的兄弟,同建在内核 onContextOverflow → `compactOnOverflow()` abort 上,恢复相反:
- overflow → abort → `summarize(session.messages)` 得一条**覆盖全量**的 summary → `store.appendEntry(sessionId,{kind:"compaction_boundary",summary})` → `AgentSession.resume(store,sessionId,sessionOptions)`(resume 遇 boundary 丢前缀 → 得 `[summary]`)→ `session.continue()`。循环至非 compaction-abort 或 maxRestarts。
- **保留压缩后成果**(summary)而非整段丢弃。**进展保证**:boundary 覆盖全量 → 每次 resume 起点 = `[summary]` 一条,不像 fresh 会因 prompt 过大死循环。
- 复用 `compactOnOverflow` + `isCompactionRestart`(从 compact-restart-fresh.js import,不重定义)。compactOnOverflow 由调用方装进 sessionOptions.hooks(不装 = overflow 不变 compaction-abort = 普通 run)。

## 诚实边界
需 store(resume 读它)· maxRestarts 耗尽返回最后 aborted summary(不假装恢复)· signal 只透传 run/continue · domain-free(summarize 调用方提供)· **summarize 抛错 → run() reject(fail-loud),因在 appendEntry 之前抛、不留 orphan boundary**。

## 验证(review-gate 3/3 PASS,inline-diff)
进展保证 + 循环终止(4 条件无死循环)对照 session.ts resume 逐条核验。全仓 build/typecheck/test 全绿(plugins **345**,+12 C3)。fake-model overflow(length + error-stopReason 两面)驱动真 AgentSession + MemorySessionStore,E2E 证明 resume-from-boundary(continue 段首条=summary、同 sessionId lineage)、maxRestarts 耗尽不死循环、无 compactOnOverflow 不 resume、**summarize 抛错无 orphan boundary**(数据完整性)。

## D0 关联
反应式 overflow 在容忍型 provider(Qwen)不 fire——C3 是给硬拒 provider / length-stopReason 的恢复路径;机制由确定性 fake-model overflow 测试验证(诚实定位)。

Closes #74