### PR TITLE
release: v0.2.4 — deferredTools/toolSearch + skill + 混合计量 + budget反馈 + overflow-resume

### DIFF
--- a/apps/coding-agent/package.json
+++ b/apps/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-pi/coding-agent",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Dogfood coding agent built on harness-pi — usable pi-tui CLI showcasing the harness-pi kernel",
   "license": "MIT",
   "repository": {

--- a/docs/05-plugins.md
+++ b/docs/05-plugins.md
@@ -1111,7 +1111,9 @@ export function getCostStats(ctx: HookContext): CostStats | undefined {
 
 #### Hook 形态
 
-Event (`onSessionStart` 建 tracker + `onTurnEnd` 检查 + 可触发 `continue: true` 注 nudge 或 abort)
+Event (`onSessionStart` 建 tracker + `onTurnStart` 每 turn 注入 remaining 提示 + `onTurnEnd` 做停止决策)
+
+> **X4(#43）更新**：持续反馈已移到 `onTurnStart`——**每 turn**(含第 1 call)注入结构化 remaining 提示,越过 `completionThreshold` 升级为 urgency;`onTurnEnd` 只保留停止决策(预算耗尽 / diminishing)。下方「完整设计」代码块为**早期示意**(命名/结构与现行 `packages/plugins/src/token-budget.ts` 已有出入),以实现为准。
 
 #### 完整设计
 

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-pi/adapters",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "SessionStore adapters for harness-pi (JSONL file + Postgres). Concrete I/O behind the kernel SessionStore protocol.",
   "license": "MIT",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-pi/core",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Agent kernel — pi-ai loop + first-class hook system",
   "license": "MIT",
   "repository": {

--- a/packages/core/src/__tests__/dispatcher.test.ts
+++ b/packages/core/src/__tests__/dispatcher.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import { HookDispatcher, mergeResults } from "../dispatcher.js";
+import { HookDispatcher, mergeResults, defaultTimeoutFor } from "../dispatcher.js";
 import type { Hook, HookContext, MergedHookResult } from "../index.js";
 import { createTestContext } from "../testing.js";
 
@@ -221,6 +221,100 @@ describe("HookDispatcher transform pipe", () => {
     expect(out).toHaveLength(2);
     expect((out[0] as any).content).toBe("from A");
     expect((out[1] as any).content).toBe("from B");
+  });
+
+  it("tools: 0 hook returns value unchanged", async () => {
+    const d = new HookDispatcher([]);
+    const tools = [
+      { name: "a", description: "", parameters: {} as any },
+      { name: "b", description: "", parameters: {} as any },
+    ];
+    const out = await d.firePipeTools(tools, fakeCtx());
+    expect(out).toBe(tools);
+  });
+
+  it("tools: chained narrowing across hooks", async () => {
+    const hooks: Hook[] = [
+      {
+        name: "a",
+        transformToolsBeforeLlm: (tools) =>
+          tools.filter((t) => t.name !== "drop-a"),
+      },
+      {
+        name: "b",
+        transformToolsBeforeLlm: (tools) =>
+          tools.filter((t) => t.name !== "drop-b"),
+      },
+    ];
+    const d = new HookDispatcher(hooks);
+    const tools = [
+      { name: "keep", description: "", parameters: {} as any },
+      { name: "drop-a", description: "", parameters: {} as any },
+      { name: "drop-b", description: "", parameters: {} as any },
+    ];
+    const out = await d.firePipeTools(tools, fakeCtx());
+    expect(out.map((t) => t.name)).toEqual(["keep"]);
+  });
+
+  it("tools: a hook throwing is dropped, chain continues", async () => {
+    const log = vi.fn();
+    const hooks: Hook[] = [
+      {
+        name: "thrower",
+        transformToolsBeforeLlm: () => {
+          throw new Error("boom");
+        },
+      },
+      {
+        name: "good",
+        transformToolsBeforeLlm: (tools) =>
+          tools.filter((t) => t.name !== "drop"),
+      },
+    ];
+    const d = new HookDispatcher(hooks, (info) => log(info));
+    const tools = [
+      { name: "keep", description: "", parameters: {} as any },
+      { name: "drop", description: "", parameters: {} as any },
+    ];
+    const out = await d.firePipeTools(tools, fakeCtx());
+    // thrower 被丢弃（保留 input），good 仍生效。
+    expect(out.map((t) => t.name)).toEqual(["keep"]);
+    expect(log).toHaveBeenCalledWith(
+      expect.objectContaining({ hookName: "thrower" }),
+    );
+  });
+
+  it("tools: a hook timing out is dropped, chain continues", async () => {
+    const log = vi.fn();
+    const hooks: Hook[] = [
+      {
+        name: "slow",
+        timeout: 20,
+        transformToolsBeforeLlm: () =>
+          new Promise((resolve) => setTimeout(() => resolve([]), 200)),
+      },
+      {
+        name: "fast",
+        transformToolsBeforeLlm: (tools) =>
+          tools.filter((t) => t.name !== "drop"),
+      },
+    ];
+    const d = new HookDispatcher(hooks, (info) => log(info));
+    const tools = [
+      { name: "keep", description: "", parameters: {} as any },
+      { name: "drop", description: "", parameters: {} as any },
+    ];
+    const out = await d.firePipeTools(tools, fakeCtx());
+    expect(out.map((t) => t.name)).toEqual(["keep"]);
+    expect(log).toHaveBeenCalledWith(
+      expect.objectContaining({ hookName: "slow", timeoutMs: 20 }),
+    );
+  });
+});
+
+describe("defaultTimeoutFor", () => {
+  it("transformToolsBeforeLlm gets pipe-class 500ms", () => {
+    expect(defaultTimeoutFor("transformToolsBeforeLlm")).toBe(500);
   });
 });
 

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -18,7 +18,7 @@
  *   - 如果 dashboard 按 sink call 计数，两路径会差一截；按字节数 / 行数计就一致。
  */
 
-import type { ToolCall } from "@earendil-works/pi-ai";
+import type { Tool, ToolCall } from "@earendil-works/pi-ai";
 import type {
   ContextOverflowInput,
   ContinuationCheckInput,
@@ -73,6 +73,7 @@ const DECISION_METHODS = new Set([
 const PIPE_METHODS = new Set([
   "transformSystemPromptBeforeLlm",
   "transformMessagesBeforeLlm",
+  "transformToolsBeforeLlm",
 ] as const);
 
 /* ────────────── Decision outcome ────────────── */
@@ -351,6 +352,24 @@ export class HookDispatcher {
       const inv = await this._invokeSafe<Message[] | void>(
         h,
         "transformMessagesBeforeLlm",
+        [v, ctx],
+        "pipe",
+      );
+      if (Array.isArray(inv.value)) v = inv.value;
+    }
+    return v;
+  }
+
+  async firePipeTools(
+    value: Tool[],
+    ctx: HookContext,
+  ): Promise<Tool[]> {
+    let v = value;
+    for (const h of this.hooks) {
+      if (typeof h.transformToolsBeforeLlm !== "function") continue;
+      const inv = await this._invokeSafe<Tool[] | void>(
+        h,
+        "transformToolsBeforeLlm",
         [v, ctx],
         "pipe",
       );

--- a/packages/core/src/hook.ts
+++ b/packages/core/src/hook.ts
@@ -517,6 +517,16 @@ export interface Hook {
     messages: Message[],
     ctx: HookContext,
   ): Message[] | void | Promise<Message[] | void>;
+  /**
+   * listing-only：transform LLM call 这一帧随发的 tool listing（裸 pi-ai `Tool`，仅
+   * name/description/parameters）。返回 `Tool[]` 收窄/重排可见工具，`void` 保持不变。
+   * **不影响 execution**：执行/校验始终走 `session.tools` 全集，filter 掉的工具仍可被调用。
+   * 值类型刻意用裸 `Tool` 而非 `HarnessTool`，从类型层堵死在 listing 里塞 `execute`。
+   */
+  transformToolsBeforeLlm?(
+    tools: Tool[],
+    ctx: HookContext,
+  ): Tool[] | void | Promise<Tool[] | void>;
 
   // ─────────── Around (nested) ───────────
   wrapTurn?(ctx: HookContext, next: () => Promise<void>): Promise<void>;

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -1258,11 +1258,12 @@ export class AgentSession {
     );
     this._pendingAttachments = [];
 
-    const piTools = this.tools.map((t) => ({
+    const baseTools = this.tools.map((t) => ({
       name: t.name,
       description: t.description,
       parameters: t.parameters,
     }));
+    const piTools = await this._dispatcher.firePipeTools(baseTools, this._ctx);
     const context: Context = {
       messages: stripHarnessOnlyFields(transformed),
       tools: piTools,

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-pi/plugins",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Standard library of harness-pi plugins + controllers + sinks",
   "license": "MIT",
   "repository": {

--- a/packages/plugins/src/__tests__/compact-resume-from-boundary.test.ts
+++ b/packages/plugins/src/__tests__/compact-resume-from-boundary.test.ts
@@ -1,0 +1,319 @@
+/**
+ * compactResumeFromBoundary 控制器测试（C3，docs/09 §4.2）。
+ * 它是 compactRestartFresh 的兄弟：overflow → compactOnOverflow abort 后，**不**丢 trace fresh 重跑，
+ * 而是写一条覆盖全量的 summary boundary、从 boundary resume + continue 续跑（保留压缩成果）。
+ *
+ * 经 testing.ts fake-model 驱动真 AgentSession + MemorySessionStore（core 直接导出）。验证：
+ *   - overflow → 写 boundary → resume → continue → 第二段 done；restarts>=1。
+ *   - resume 后的 continue 段从 boundary 起算（fake 收到的首条 message 是 summary，且 lineage 同 sessionId）。
+ *   - maxRestarts 耗尽（持续 overflow）→ 返回 aborted summary、restarts===maxRestarts、不无限循环。
+ *   - 复用 compactOnOverflow + isCompactionRestart（import，不重定义）。
+ *   - 不挂 compactOnOverflow → overflow 不变 compaction-abort → 控制器不 resume（行为=普通 run）。
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  AgentSession,
+  MemorySessionStore,
+  createUserMessage,
+  type Hook,
+  type Message,
+} from "@harness-pi/core";
+import { createFakeModel } from "@harness-pi/core/testing";
+import {
+  compactOnOverflow,
+  CompactResumeFromBoundary,
+  isCompactionRestart,
+  COMPACTION_OVERFLOW_REASON,
+} from "../controllers/index.js";
+
+describe("CompactResumeFromBoundary", () => {
+  it("happy path: no overflow → no restart, behaves like a plain run", async () => {
+    const store = new MemorySessionStore();
+    const model = createFakeModel([
+      { content: [{ type: "text", text: "ok" }], stopReason: "stop" },
+    ]);
+    const ctrl = new CompactResumeFromBoundary({
+      store,
+      sessionId: "s-happy",
+      sessionOptions: { model, tools: [], hooks: [compactOnOverflow()] },
+      summarize: () => createUserMessage("never"),
+    });
+    const res = await ctrl.run("solve it");
+
+    expect(res.reason).toBe("done");
+    expect(res.restarts).toBe(0);
+    // 没 overflow → 没写 boundary。
+    const path = await store.getPathToLeaf("s-happy");
+    expect(path.filter((e) => e.entry.kind === "compaction_boundary")).toHaveLength(0);
+    model.teardown();
+  });
+
+  it("overflow (length) → writes boundary, resumes from it, continue succeeds; restarts>=1", async () => {
+    const store = new MemorySessionStore();
+    // 首跑 turn0 截断 → compactOnOverflow abort。resume-continue turn0 正常 done。
+    const model = createFakeModel([
+      { content: [{ type: "text", text: "truncated" }], stopReason: "length" },
+      { content: [{ type: "text", text: "recovered" }], stopReason: "stop" },
+    ]);
+    const summary = createUserMessage("SUMMARY-OF-OVERFLOWING-TRACE");
+    const ctrl = new CompactResumeFromBoundary({
+      store,
+      sessionId: "s-recover",
+      sessionOptions: { model, tools: [], hooks: [compactOnOverflow()] },
+      summarize: () => summary,
+    });
+    const res = await ctrl.run("solve it");
+
+    expect(res.reason).toBe("done");
+    expect(res.restarts).toBe(1);
+
+    // 恰好写了一条 boundary，summary 就是我们提供的那条。
+    const path = await store.getPathToLeaf("s-recover");
+    const boundaries = path
+      .filter((e) => e.entry.kind === "compaction_boundary")
+      .map((e) => (e.entry as { kind: "compaction_boundary"; summary: Message }).summary);
+    expect(boundaries).toEqual([summary]);
+    model.teardown();
+  });
+
+  it("overflow surfaced as an error stopReason also triggers a boundary + resume", async () => {
+    const store = new MemorySessionStore();
+    const model = createFakeModel([
+      { content: [], throwError: new Error("maximum context length exceeded") },
+      { content: [{ type: "text", text: "recovered" }], stopReason: "stop" },
+    ]);
+    const ctrl = new CompactResumeFromBoundary({
+      store,
+      sessionId: "s-err",
+      sessionOptions: { model, tools: [], hooks: [compactOnOverflow()] },
+      summarize: () => createUserMessage("S"),
+    });
+    const res = await ctrl.run("solve it");
+
+    expect(res.reason).toBe("done");
+    expect(res.restarts).toBe(1);
+    model.teardown();
+  });
+
+  it("resume continues FROM the boundary — the continue() call sees [summary] as its first message, same lineage", async () => {
+    // 这是 C3 区别于 fresh 的全部理由：保留 summary 成果、从 boundary 起算（resume → [summary]）。
+    const store = new MemorySessionStore();
+    const model = createFakeModel([
+      { content: [{ type: "text", text: "truncated" }], stopReason: "length" }, // 首跑 → overflow
+      { content: [{ type: "text", text: "recovered" }], stopReason: "stop" }, // resume-continue
+    ]);
+    const summary = createUserMessage("BOUNDARY-SUMMARY");
+    const ctrl = new CompactResumeFromBoundary({
+      store,
+      sessionId: "s-from-boundary",
+      sessionOptions: { model, tools: [], hooks: [compactOnOverflow()] },
+      summarize: () => summary,
+    });
+    const res = await ctrl.run("the original prompt");
+
+    expect(res.reason).toBe("done");
+    expect(res.restarts).toBe(1);
+
+    const calls = model.getCalls();
+    // 最后一次 LLM 调用是 resume 后的 continue：context 以 boundary summary 起头（不是原 prompt）。
+    const continueCall = calls[calls.length - 1]!;
+    expect(continueCall.messages[0]).toBe(summary);
+    // resume 出的 [summary] 覆盖全量 → continue 段 context 不再含原始 user prompt。
+    expect(
+      continueCall.messages.some(
+        (m) => m.role === "user" && m !== summary,
+      ),
+    ).toBe(false);
+
+    // 同一 lineage：所有 entry 都在同一个 sessionId 下重建。
+    const resumed = await AgentSession.resume(store, "s-from-boundary", { model, tools: [] });
+    expect(resumed.id).toBe("s-from-boundary");
+    model.teardown();
+  });
+
+  it("persistent overflow stops after maxRestarts and returns the aborted summary (no fake recovery, no infinite loop)", async () => {
+    const store = new MemorySessionStore();
+    // 每段都 length-截断 → 永远 overflow。备足 response 防 fake 跑空。
+    const model = createFakeModel(
+      Array.from({ length: 6 }, () => ({
+        content: [{ type: "text" as const, text: "x" }],
+        stopReason: "length" as const,
+      })),
+    );
+    const ctrl = new CompactResumeFromBoundary({
+      store,
+      sessionId: "s-persist",
+      sessionOptions: { model, tools: [], hooks: [compactOnOverflow()] },
+      summarize: () => createUserMessage("S"),
+      maxRestarts: 2,
+    });
+    const res = await ctrl.run("oversized");
+
+    expect(res.restarts).toBe(2);
+    expect(res.reason).toBe("aborted");
+    expect(res.abortReason).toBe(COMPACTION_OVERFLOW_REASON);
+    // 恰好 maxRestarts 次 resume → maxRestarts 条 boundary，不多写（不无限循环）。
+    const path = await store.getPathToLeaf("s-persist");
+    expect(path.filter((e) => e.entry.kind === "compaction_boundary")).toHaveLength(2);
+    model.teardown();
+  });
+
+  it("maxRestarts: 0 never resumes — returns the first aborted summary", async () => {
+    const store = new MemorySessionStore();
+    const model = createFakeModel(
+      Array.from({ length: 3 }, () => ({
+        content: [{ type: "text" as const, text: "x" }],
+        stopReason: "length" as const,
+      })),
+    );
+    const ctrl = new CompactResumeFromBoundary({
+      store,
+      sessionId: "s-zero",
+      sessionOptions: { model, tools: [], hooks: [compactOnOverflow()] },
+      summarize: () => createUserMessage("S"),
+      maxRestarts: 0,
+    });
+    const res = await ctrl.run("p");
+
+    expect(res.restarts).toBe(0);
+    expect(res.reason).toBe("aborted");
+    expect(res.abortReason).toBe(COMPACTION_OVERFLOW_REASON);
+    const path = await store.getPathToLeaf("s-zero");
+    expect(path.filter((e) => e.entry.kind === "compaction_boundary")).toHaveLength(0);
+    model.teardown();
+  });
+
+  it("does NOT resume on a non-compaction abort (no compactOnOverflow hook → overflow stays a plain abort)", async () => {
+    const store = new MemorySessionStore();
+    const model = createFakeModel([
+      { content: [{ type: "text", text: "t" }], stopReason: "length" },
+    ]);
+    // 用一个非 compaction reason 的 overflow hook（即「没装 compactOnOverflow」的等价情形）。
+    const manualAbort: Hook = {
+      name: "manual",
+      onContextOverflow: (_i, ctx) => ctx.abort("manual:stop"),
+    };
+    let summarizeCalls = 0;
+    const ctrl = new CompactResumeFromBoundary({
+      store,
+      sessionId: "s-noncompact",
+      sessionOptions: { model, tools: [], hooks: [manualAbort] },
+      summarize: () => {
+        summarizeCalls++;
+        return createUserMessage("S");
+      },
+    });
+    const res = await ctrl.run("p");
+
+    expect(res.restarts).toBe(0);
+    expect(res.reason).toBe("aborted");
+    expect(res.abortReason).toBe("manual:stop");
+    // 不认 → 不 resume → 不 summarize、不写 boundary（行为=普通 run）。
+    expect(summarizeCalls).toBe(0);
+    const path = await store.getPathToLeaf("s-noncompact");
+    expect(path.filter((e) => e.entry.kind === "compaction_boundary")).toHaveLength(0);
+    model.teardown();
+  });
+
+  it("honors a custom compaction abort reason", async () => {
+    const store = new MemorySessionStore();
+    const model = createFakeModel([
+      { content: [{ type: "text", text: "t" }], stopReason: "length" },
+      { content: [{ type: "text", text: "ok" }], stopReason: "stop" },
+    ]);
+    const ctrl = new CompactResumeFromBoundary({
+      store,
+      sessionId: "s-custom",
+      sessionOptions: {
+        model,
+        tools: [],
+        hooks: [compactOnOverflow({ reason: "compaction:summarize-failed" })],
+      },
+      summarize: () => createUserMessage("S"),
+    });
+    const res = await ctrl.run("p");
+
+    expect(res.reason).toBe("done");
+    expect(res.restarts).toBe(1);
+    model.teardown();
+  });
+
+  it("stops resuming when the external signal is aborted", async () => {
+    const ac = new AbortController();
+    const store = new MemorySessionStore();
+    const model = createFakeModel(
+      Array.from({ length: 5 }, () => ({
+        content: [{ type: "text" as const, text: "x" }],
+        stopReason: "length" as const,
+      })),
+    );
+    const abortBoth: Hook = {
+      name: "abort-both",
+      onContextOverflow: (_i, ctx) => {
+        ctx.abort(COMPACTION_OVERFLOW_REASON); // 内部 abort 先发（首个 abort 胜出）
+        ac.abort(); // 同时 abort 外部 signal
+      },
+    };
+    const ctrl = new CompactResumeFromBoundary({
+      store,
+      sessionId: "s-signal",
+      sessionOptions: { model, tools: [], hooks: [abortBoth] },
+      summarize: () => createUserMessage("S"),
+    });
+    const res = await ctrl.run("p", { signal: ac.signal });
+
+    expect(res.restarts).toBe(0); // signal aborted → while 守卫拦下 resume
+    expect(res.reason).toBe("aborted");
+    model.teardown();
+  });
+
+  it("rejects negative maxRestarts at construction", () => {
+    const store = new MemorySessionStore();
+    const model = createFakeModel([]);
+    expect(
+      () =>
+        new CompactResumeFromBoundary({
+          store,
+          sessionId: "s-neg",
+          sessionOptions: { model, tools: [], hooks: [compactOnOverflow()] },
+          summarize: () => createUserMessage("S"),
+          maxRestarts: -1,
+        }),
+    ).toThrow(/maxRestarts/);
+    model.teardown();
+  });
+
+  it("summarize throwing → run() rejects (propagate) and writes NO orphan boundary", async () => {
+    const store = new MemorySessionStore();
+    const model = createFakeModel([
+      // 首跑 overflow → compactOnOverflow abort → 控制器要 summarize(此处抛错)。
+      { content: [{ type: "text", text: "truncated" }], stopReason: "length" },
+      { content: [{ type: "text", text: "recovered" }], stopReason: "stop" },
+    ]);
+    const ctrl = new CompactResumeFromBoundary({
+      store,
+      sessionId: "s-sumfail",
+      sessionOptions: { model, tools: [], hooks: [compactOnOverflow()] },
+      summarize: () => {
+        throw new Error("summarize backend down");
+      },
+    });
+    // summarize 在 appendEntry 之前抛 → run() reject(fail-loud,caller 自负 summarize 错误)。
+    await expect(ctrl.run("solve it")).rejects.toThrow("summarize backend down");
+    // 数据完整性:抛在写 boundary 之前 → store 无半成品 orphan compaction_boundary。
+    const path = await store.getPathToLeaf("s-sumfail");
+    expect(
+      path.filter((e) => e.entry.kind === "compaction_boundary"),
+    ).toHaveLength(0);
+    model.teardown();
+  });
+});
+
+describe("isCompactionRestart (reused, not redefined)", () => {
+  it("matches compaction:* abort reasons only", () => {
+    expect(isCompactionRestart("compaction:overflow")).toBe(true);
+    expect(isCompactionRestart("watchdog:timeout")).toBe(false);
+    expect(isCompactionRestart(undefined)).toBe(false);
+  });
+});

--- a/packages/plugins/src/__tests__/deferred-tools.test.ts
+++ b/packages/plugins/src/__tests__/deferred-tools.test.ts
@@ -91,6 +91,92 @@ describe("deferredTools: activation takes effect next turn (b)", () => {
     const turn2 = namesOf(fake.getCalls()[1]!.tools);
     expect(turn1).not.toContain("WebFetch");
     expect(turn2).toContain("WebFetch");
+    // 激活是**累加**进 listing，不是替换 —— 原本可见的工具仍在。
+    expect(turn2).toEqual(expect.arrayContaining(["read", "toolSearch", "WebFetch"]));
+    fake.teardown();
+  });
+
+  it("keyword fuzzy-match activates matching tools next turn", async () => {
+    const search = toolSearch();
+    const fake = createFakeModel([
+      // keyword "fetch" 命中 WebFetch 的 name+description（"WebFetch tool"）。
+      {
+        content: [
+          { type: "toolCall", name: "toolSearch", arguments: { keyword: "fetch" } },
+        ],
+      },
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [trivialTool("read"), trivialTool("WebFetch"), search],
+      hooks: [
+        deferredTools({ deferred: ["WebFetch"], alwaysListed: ["read", search.name] }),
+      ],
+    });
+    await session.run("go");
+
+    expect(namesOf(fake.getCalls()[0]!.tools)).not.toContain("WebFetch");
+    expect(namesOf(fake.getCalls()[1]!.tools)).toContain("WebFetch");
+    fake.teardown();
+  });
+
+  it("no match (incl. phantom select name) activates nothing and says so", async () => {
+    const search = toolSearch();
+    const fake = createFakeModel([
+      {
+        content: [
+          { type: "toolCall", name: "toolSearch", arguments: { select: ["nonexistent"] } },
+        ],
+      },
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [trivialTool("read"), trivialTool("WebFetch"), search],
+      hooks: [
+        deferredTools({ deferred: ["WebFetch"], alwaysListed: ["read", search.name] }),
+      ],
+    });
+    await session.run("go");
+
+    const tr = session.messages.find((m) => m.role === "toolResult") as
+      | { content: { text?: string }[] }
+      | undefined;
+    expect(tr!.content.map((b) => b.text ?? "").join("")).toContain("No tools matched");
+    // 不存在的名字（模型瞎编）不激活任何工具：下一 turn WebFetch 仍隐藏。
+    expect(namesOf(fake.getCalls()[1]!.tools)).not.toContain("WebFetch");
+    fake.teardown();
+  });
+});
+
+describe("deferredTools: predicate-form deferred (function)", () => {
+  it("supports deferred as a (name) => boolean predicate", async () => {
+    const fake = createFakeModel([
+      { content: [{ type: "text", text: "ok" }], stopReason: "stop" },
+    ]);
+    const search = toolSearch();
+    const session = new AgentSession({
+      model: fake,
+      tools: [
+        trivialTool("read"),
+        trivialTool("WebFetch"),
+        trivialTool("WebSearch"),
+        search,
+      ],
+      hooks: [
+        deferredTools({
+          deferred: (n) => n.startsWith("Web"),
+          alwaysListed: ["read", search.name],
+        }),
+      ],
+    });
+    await session.run("go");
+
+    const listing = namesOf(fake.getCalls()[0]!.tools);
+    expect(listing).toEqual(expect.arrayContaining(["read", "toolSearch"]));
+    expect(listing).not.toContain("WebFetch");
+    expect(listing).not.toContain("WebSearch");
     fake.teardown();
   });
 });
@@ -186,6 +272,7 @@ describe("deferredTools + autoCompaction: estimation linkage (f)", () => {
     // 全集 3 个工具，deferred 掉一个大工具（bigTool），激活集只剩 read + toolSearch。
     // 通过自定义 tokenCounter 把「随发 tools 的条目数」暴露出来断言。
     const seenToolCounts: number[] = [];
+    const seenToolNames: string[][] = [];
     const bigTool = trivialTool("WebFetch");
     const search = toolSearch();
     // 跑 2 个 turn：turn-0 的 estimate 在本 turn 的 deferredTools 写 activeListing **之前**跑
@@ -211,6 +298,7 @@ describe("deferredTools + autoCompaction: estimation linkage (f)", () => {
           tokenCounter: {
             estimate: ({ tools }) => {
               seenToolCounts.push((tools ?? []).length);
+              seenToolNames.push(namesOf(tools));
               return 0;
             },
           },
@@ -226,6 +314,9 @@ describe("deferredTools + autoCompaction: estimation linkage (f)", () => {
     expect(seenToolCounts[0]).toBe(3);
     // turn-1：读到上一 turn 写入的激活子集 → 2（证明 estimate 确实改读 activeListing 而非永远全集）。
     expect(seenToolCounts[1]).toBe(2);
+    // 且被丢的恰是 deferred 的 WebFetch（不只是数量对，drop 对了工具）。
+    expect(seenToolNames[1]).toEqual(expect.arrayContaining(["read", "toolSearch"]));
+    expect(seenToolNames[1]).not.toContain("WebFetch");
     fake.teardown();
   });
 });

--- a/packages/plugins/src/__tests__/deferred-tools.test.ts
+++ b/packages/plugins/src/__tests__/deferred-tools.test.ts
@@ -1,0 +1,254 @@
+/**
+ * deferredTools + toolSearch 集成测试（issue #66 / O1）。
+ *
+ * 经 testing.ts fake-model 的 getCalls()——它捕获每次 Context.tools（即 LLM 看到的 listing），
+ * 据此断言 listing 子集化、激活下一 turn 生效、opt-in 字节级一致、execution 解耦、估算联动、fail-open。
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  AgentSession,
+  Type,
+  type HarnessTool,
+  type Hook,
+} from "@harness-pi/core";
+import { createFakeModel } from "@harness-pi/core/testing";
+import { deferredTools } from "../deferred-tools.js";
+import { toolSearch } from "../tool-search.js";
+import { autoCompaction } from "../auto-compaction.js";
+import { permissionGate } from "../permission-gate.js";
+
+function trivialTool(name: string): HarnessTool {
+  return {
+    name,
+    description: `${name} tool`,
+    parameters: Type.Object({}),
+    isConcurrencySafe: () => true,
+    async execute() {
+      return { content: [{ type: "text", text: `${name} ran` }] };
+    },
+  };
+}
+
+function namesOf(
+  tools: ReadonlyArray<{ name: string }> | undefined,
+): string[] {
+  return (tools ?? []).map((t) => t.name);
+}
+
+describe("deferredTools: listing subset (a)", () => {
+  it("hides deferred tools, keeps non-deferred + alwaysListed", async () => {
+    const fake = createFakeModel([
+      { content: [{ type: "text", text: "ok" }], stopReason: "stop" },
+    ]);
+    const search = toolSearch();
+    const session = new AgentSession({
+      model: fake,
+      tools: [trivialTool("read"), trivialTool("WebFetch"), search],
+      hooks: [
+        deferredTools({
+          deferred: ["WebFetch"],
+          alwaysListed: ["read", search.name],
+        }),
+      ],
+    });
+    await session.run("go");
+
+    const listing = namesOf(fake.getCalls()[0]!.tools);
+    expect(listing).toContain("read");
+    expect(listing).toContain("toolSearch");
+    expect(listing).not.toContain("WebFetch");
+    fake.teardown();
+  });
+});
+
+describe("deferredTools: activation takes effect next turn (b)", () => {
+  it("toolSearch({select}) in turn-1 makes the tool visible in turn-2", async () => {
+    const search = toolSearch();
+    const fake = createFakeModel([
+      // turn-1：模型调 toolSearch 激活 WebFetch（不收尾，继续循环）。
+      {
+        content: [
+          { type: "toolCall", name: "toolSearch", arguments: { select: ["WebFetch"] } },
+        ],
+      },
+      // turn-2：收尾。
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [trivialTool("read"), trivialTool("WebFetch"), search],
+      hooks: [
+        deferredTools({
+          deferred: ["WebFetch"],
+          alwaysListed: ["read", search.name],
+        }),
+      ],
+    });
+    await session.run("go");
+
+    const turn1 = namesOf(fake.getCalls()[0]!.tools);
+    const turn2 = namesOf(fake.getCalls()[1]!.tools);
+    expect(turn1).not.toContain("WebFetch");
+    expect(turn2).toContain("WebFetch");
+    fake.teardown();
+  });
+});
+
+describe("deferredTools: opt-in byte-equal (c)", () => {
+  it("without deferredTools, every call sees the full tool set", async () => {
+    const fake = createFakeModel([
+      {
+        content: [{ type: "toolCall", name: "read", arguments: {} }],
+      },
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const tools = [trivialTool("read"), trivialTool("WebFetch"), toolSearch()];
+    const fullNames = namesOf(tools).sort();
+    const session = new AgentSession({ model: fake, tools, hooks: [] });
+    await session.run("go");
+
+    for (const call of fake.getCalls()) {
+      expect(namesOf(call.tools).sort()).toEqual(fullNames);
+    }
+    fake.teardown();
+  });
+});
+
+describe("deferredTools: execution decoupled from listing (d)", () => {
+  it("a deferred-but-not-activated tool still executes (findToolByName uses full set)", async () => {
+    const fake = createFakeModel([
+      // 模型直接调 WebFetch —— 它当前不在 listing 里，但仍在 session.tools 全集。
+      { content: [{ type: "toolCall", name: "WebFetch", arguments: {} }] },
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const search = toolSearch();
+    const session = new AgentSession({
+      model: fake,
+      tools: [trivialTool("read"), trivialTool("WebFetch"), search],
+      hooks: [
+        deferredTools({ deferred: ["WebFetch"], alwaysListed: [search.name] }),
+      ],
+    });
+    await session.run("go");
+
+    // listing 子集化：WebFetch 不可见。
+    expect(namesOf(fake.getCalls()[0]!.tools)).not.toContain("WebFetch");
+    // 但执行照样发生：toolResult 拿到 WebFetch 的输出。
+    const tr = session.messages.find((m) => m.role === "toolResult") as
+      | { content: { text?: string }[]; isError?: boolean }
+      | undefined;
+    expect(tr).toBeDefined();
+    expect(tr!.isError).not.toBe(true);
+    expect(tr!.content[0]!.text).toBe("WebFetch ran");
+    fake.teardown();
+  });
+
+  it("permission gate still blocks an activated/visible-or-not deferred tool (listing-independent闸)", async () => {
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "WebFetch", arguments: {} }] },
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const search = toolSearch();
+    const session = new AgentSession({
+      model: fake,
+      tools: [trivialTool("WebFetch"), search],
+      hooks: [
+        deferredTools({ deferred: ["WebFetch"], alwaysListed: [search.name] }),
+        permissionGate({
+          rules: [{ match: "WebFetch", decision: "deny", reason: "WebFetch is off" }],
+          fallback: "allow",
+        }),
+      ],
+    });
+    await session.run("go");
+
+    const tr = session.messages.find((m) => m.role === "toolResult") as
+      | { content: { text?: string }[]; isError?: boolean }
+      | undefined;
+    expect(tr).toBeDefined();
+    expect(tr!.isError).toBe(true);
+    const text = tr!.content.map((b) => b.text ?? "").join("");
+    expect(text).toContain("WebFetch is off");
+    fake.teardown();
+  });
+});
+
+describe("toolSearch: barrier (e)", () => {
+  it("declares isConcurrencySafe === false", () => {
+    const search = toolSearch();
+    expect(search.isConcurrencySafe!({})).toBe(false);
+  });
+});
+
+describe("deferredTools + autoCompaction: estimation linkage (f)", () => {
+  it("autoCompaction reads the activated subset, not the full set", async () => {
+    // 全集 3 个工具，deferred 掉一个大工具（bigTool），激活集只剩 read + toolSearch。
+    // 通过自定义 tokenCounter 把「随发 tools 的条目数」暴露出来断言。
+    const seenToolCounts: number[] = [];
+    const bigTool = trivialTool("WebFetch");
+    const search = toolSearch();
+    // 跑 2 个 turn：turn-0 的 estimate 在本 turn 的 deferredTools 写 activeListing **之前**跑
+    //（内核固定 messages-pipe 先于 tools-pipe），读到 undefined → 退回全集 3；turn-1 的 estimate
+    // 读到 turn-0 写入的激活子集 → 2。这是一 turn 滞后，对「宁高勿低」的阈值无害。
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "read", arguments: {} }] },
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [trivialTool("read"), bigTool, search],
+      hooks: [
+        // deferredTools 排在 autoCompaction 之前（注册顺序）。
+        deferredTools({
+          deferred: ["WebFetch"],
+          alwaysListed: ["read", search.name],
+        }),
+        autoCompaction({
+          maxContextTokens: 1_000_000, // 阈值极高，不真压缩；只为触发 estimate 调用。
+          triggerRatio: 0.9,
+          keepRecent: 1,
+          tokenCounter: {
+            estimate: ({ tools }) => {
+              seenToolCounts.push((tools ?? []).length);
+              return 0;
+            },
+          },
+          summarize: () => "RECAP",
+        }),
+      ],
+    });
+    await session.run("go");
+
+    // 全集是 3（read / WebFetch / toolSearch）；激活子集排除 WebFetch → 2。
+    expect(seenToolCounts.length).toBeGreaterThanOrEqual(2);
+    // turn-0：activeListing 尚未写入 → 退回全集 3。
+    expect(seenToolCounts[0]).toBe(3);
+    // turn-1：读到上一 turn 写入的激活子集 → 2（证明 estimate 确实改读 activeListing 而非永远全集）。
+    expect(seenToolCounts[1]).toBe(2);
+    fake.teardown();
+  });
+});
+
+describe("deferredTools: fail-open (g)", () => {
+  it("transformToolsBeforeLlm throwing degrades that turn to the full listing", async () => {
+    const throwing: Hook = {
+      name: "deferred-thrower",
+      transformToolsBeforeLlm: () => {
+        throw new Error("boom");
+      },
+    };
+    const fake = createFakeModel([
+      { content: [{ type: "text", text: "ok" }], stopReason: "stop" },
+    ]);
+    const tools = [trivialTool("read"), trivialTool("WebFetch"), toolSearch()];
+    const fullNames = namesOf(tools).sort();
+    const session = new AgentSession({ model: fake, tools, hooks: [throwing] });
+    const summary = await session.run("go");
+
+    // 抛错被内核 fail-open 吞掉 → 该 turn 退化全集 listing，session 不崩。
+    expect(summary.reason).toBe("done");
+    expect(namesOf(fake.getCalls()[0]!.tools).sort()).toEqual(fullNames);
+    fake.teardown();
+  });
+});

--- a/packages/plugins/src/__tests__/estimate-request-tokens.test.ts
+++ b/packages/plugins/src/__tests__/estimate-request-tokens.test.ts
@@ -5,6 +5,7 @@ import {
   estimateTokensByChars,
   estimateRequestTokens,
   defaultTokenCounter,
+  hybridTokenCounter,
   PER_MESSAGE_OVERHEAD,
 } from "../auto-compaction.js";
 
@@ -155,5 +156,104 @@ describe("defaultTokenCounter", () => {
 
   it("does not implement count (count? is a future opt-in seam)", () => {
     expect(defaultTokenCounter.count).toBeUndefined();
+  });
+});
+
+/** 造一条带真 Usage 的 assistant message。 */
+function assistantMsg(
+  text: string,
+  u: { input: number; output: number; cacheRead?: number; cacheWrite?: number },
+): Message {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    usage: {
+      input: u.input,
+      output: u.output,
+      cacheRead: u.cacheRead ?? 0,
+      cacheWrite: u.cacheWrite ?? 0,
+      totalTokens: u.input + u.output,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    timestamp: 0,
+  } as Message;
+}
+
+describe("hybridTokenCounter (C5, issue #13)", () => {
+  it("uses the most-recent real-usage assistant as baseline + char-estimates only the suffix", () => {
+    const messages = [m("hello"), assistantMsg("hi", { input: 1000, output: 200, cacheRead: 50 }), m("a follow-up")];
+    const suffix = [m("a follow-up")];
+    // 基线 = input+cacheRead+cacheWrite+output = 1000+50+0+200 = 1250；只对后缀字符估算。
+    expect(hybridTokenCounter.estimate({ messages })).toBe(1250 + estimateTokensByChars(suffix));
+  });
+
+  it("does NOT re-add tools/systemPrompt on the hybrid path (they're already in the real baseline)", () => {
+    // 关键正确性:有真基线时,tools/systemPrompt 不再加(避免双重计) —— 与 estimateRequestTokens 相反。
+    const messages = [m("hi"), assistantMsg("a", { input: 1000, output: 100 })];
+    const bigTool = tool("read", "read a file from disk", {
+      type: "object",
+      properties: Object.fromEntries(
+        Array.from({ length: 20 }, (_, i) => [`f${i}`, { type: "string", description: "x".repeat(50) }]),
+      ),
+    });
+    const without = hybridTokenCounter.estimate({ messages });
+    const withToolsSys = hybridTokenCounter.estimate({
+      messages,
+      tools: [bigTool],
+      systemPrompt: "a fairly long system prompt ".repeat(20),
+    });
+    expect(withToolsSys).toBe(without); // 真基线已含 tools/sys,不再加
+    // 对照:estimateRequestTokens(纯估算路径)会把它们加进去 → 严格更大。
+    expect(estimateRequestTokens({ messages, tools: [bigTool], systemPrompt: "a fairly long system prompt ".repeat(20) }))
+      .toBeGreaterThan(estimateRequestTokens({ messages }));
+  });
+
+  it("picks the LATEST assistant carrying real usage when several exist", () => {
+    const messages = [
+      m("q1"),
+      assistantMsg("a1", { input: 500, output: 100 }),
+      m("q2"),
+      assistantMsg("a2", { input: 1500, output: 300 }),
+      m("q3"),
+    ];
+    // 用最近的 a2 作基线(1800),后缀 = [q3]。
+    expect(hybridTokenCounter.estimate({ messages })).toBe(1800 + estimateTokensByChars([m("q3")]));
+  });
+
+  it("degrades to estimateRequestTokens (X1) when there is no assistant yet (turn-0)", () => {
+    const messages = [m("just a user message")];
+    const input = { messages, tools: [tool("read", "read", { type: "object", properties: {} })], systemPrompt: "sys" };
+    expect(hybridTokenCounter.estimate(input)).toBe(estimateRequestTokens(input));
+  });
+
+  it("treats an all-zero-usage assistant as 'no real usage' and degrades to X1 (fake-model parity)", () => {
+    // fake-model 的 assistant usage 全 0 → 视为无真值 → 退回 X1。这保证 fake 测试行为与 defaultTokenCounter 一致。
+    const messages = [m("hello"), assistantMsg("hi", { input: 0, output: 0 }), m("more")];
+    const input = { messages, tools: [tool("read", "read", { type: "object", properties: {} })], systemPrompt: "sys" };
+    expect(hybridTokenCounter.estimate(input)).toBe(estimateRequestTokens(input));
+  });
+
+  it("includes cacheWrite in the baseline (pins the +cacheWrite term)", () => {
+    const messages = [m("q"), assistantMsg("a", { input: 1000, output: 100, cacheRead: 50, cacheWrite: 30 })];
+    // 基线 = 1000+50+30+100 = 1180;后缀为空。
+    expect(hybridTokenCounter.estimate({ messages })).toBe(1180);
+  });
+
+  it("skips a later zero-usage assistant and uses an earlier REAL one as baseline", () => {
+    // 非平凡控制流:guard 用 continue(非 break),故越过零-usage 的 assistant 继续往前找真值。
+    const real = assistantMsg("real", { input: 800, output: 120 });
+    const zero = assistantMsg("zero", { input: 0, output: 0 });
+    const messages = [m("q1"), real, m("q2"), zero, m("q3")];
+    // 用更早的 real(基线 920),后缀 = real 之后的全部 [q2, zero, q3]。
+    const suffix = messages.slice(messages.indexOf(real) + 1);
+    expect(hybridTokenCounter.estimate({ messages })).toBe(920 + estimateTokensByChars(suffix));
+  });
+
+  it("treats an assistant with NO usage object as 'no real usage' (the !u guard branch)", () => {
+    // 显式构造一条无 usage 字段的 assistant —— 命中 `!u` 分支 → continue → 退回 X1。
+    const noUsage = { role: "assistant", content: [{ type: "text", text: "a" }], timestamp: 0 } as Message;
+    const messages = [m("hello"), noUsage, m("more")];
+    const input = { messages };
+    expect(hybridTokenCounter.estimate(input)).toBe(estimateRequestTokens(input));
   });
 });

--- a/packages/plugins/src/__tests__/plugins-edge.test.ts
+++ b/packages/plugins/src/__tests__/plugins-edge.test.ts
@@ -570,7 +570,7 @@ describe("token-budget edge", () => {
     expect(summary.reason).toBe("done");
   });
 
-  it("nudge attached when token% in middle range", async () => {
+  it("injects a budget reminder into the next call (now unconditional per-turn via onTurnStart)", async () => {
     const model = createFakeModel([
       {
         content: [
@@ -606,6 +606,102 @@ describe("token-budget edge", () => {
         (m.content as string).includes("tokens"),
     );
     expect(nudge).toBeDefined();
+  });
+
+  it("X4: continuous remaining reminder fires on the very first call (turn-start, not only at stop)", async () => {
+    const model = createFakeModel([
+      { content: [{ type: "text", text: "ok" }], usage: { input: 5, output: 2 } },
+    ]);
+    let firstCall: any[] = [];
+    let captured = false;
+    const spy: Hook = {
+      name: "spy",
+      transformMessagesBeforeLlm(msgs) {
+        if (!captured) {
+          firstCall = msgs;
+          captured = true;
+        }
+        return undefined;
+      },
+    };
+    const session = new AgentSession({
+      model,
+      tools: [],
+      hooks: [tokenBudget({ budget: 1000 }), spy],
+    });
+    await session.run("go");
+    // 第 1 个 LLM call 就带 remaining 反馈(onTurnStart 持续注入),不是只在停时。
+    const reminder = firstCall.find(
+      (m: any) =>
+        typeof m.content === "string" &&
+        (m.content as string).includes("system-reminder") &&
+        (m.content as string).includes("remaining"),
+    );
+    expect(reminder).toBeDefined();
+    // <completionThreshold(此处 0%)不应升级为 urgency —— 锁住升级是条件性的。
+    expect(reminder!.content as string).not.toContain("near the budget limit");
+  });
+
+  it("X4: reminder still fires above completionThreshold (0.9~1.0 gap) and escalates to urgency", async () => {
+    const model = createFakeModel([
+      // turn-1 用掉 95/100 → 越过 completionThreshold(默认 0.9):旧代码此区间不 nudge,X4 仍注入 + urgency。
+      {
+        content: [{ type: "toolCall", name: "echo", arguments: { msg: "x" } }],
+        usage: { input: 95, output: 0 },
+        stopReason: "toolUse",
+      },
+      { content: [{ type: "text", text: "ok" }], usage: { input: 1, output: 1 } },
+    ]);
+    let seen: any[] = [];
+    const spy: Hook = {
+      name: "spy",
+      transformMessagesBeforeLlm(msgs) {
+        seen = msgs;
+        return undefined;
+      },
+    };
+    const session = new AgentSession({
+      model,
+      tools: [echoTool],
+      hooks: [costTracker(), tokenBudget({ budget: 100 }), spy],
+    });
+    await session.run("go");
+    // turn-2 在 95/100(>0.9)仍收到 reminder,且含 urgency 收尾提示。
+    const reminder = seen.find(
+      (m: any) =>
+        typeof m.content === "string" &&
+        (m.content as string).includes("system-reminder") &&
+        (m.content as string).includes("remaining"),
+    );
+    expect(reminder).toBeDefined();
+    expect(reminder!.content as string).toContain("near the budget limit");
+  });
+
+  it("X4: diminishing-returns still stops the run under the every-turn nudgeCount", async () => {
+    // 每 turn ~50 token(<diminishingThreshold 500),累计远未爆 budget。X4 把 nudgeCount 改为每 turn
+    // 递增——这里锁住「连续小 delta + nudgeCount 累积 → diminishing 收敛仍能强停」,防未来重构回退。
+    const model = createFakeModel(
+      Array.from({ length: 6 }, () => ({
+        content: [{ type: "text", text: "x" }],
+        usage: { input: 50, output: 0 },
+        stopReason: "toolUse" as const,
+      })),
+    );
+    const session = new AgentSession({
+      model,
+      tools: [],
+      hooks: [
+        costTracker(),
+        tokenBudget({
+          budget: 100_000,
+          diminishingThreshold: 500,
+          diminishingMinNudges: 3,
+        }),
+      ],
+    });
+    const summary = await session.run("go");
+    expect(summary.reason).toBe("aborted");
+    expect(summary.abortReason).toContain("diminishing returns");
   });
 });
 

--- a/packages/plugins/src/__tests__/skills.test.ts
+++ b/packages/plugins/src/__tests__/skills.test.ts
@@ -64,8 +64,8 @@ describe("skills: catalog in system prompt (a)", () => {
     const sys = fake.getCalls()[0]!.systemPrompt;
     expect(sys).toContain("## Available skills");
     for (const s of SPECS) {
-      expect(sys).toContain(s.name);
-      expect(sys).toContain(s.description);
+      // 精确钉住 name↔description 配对(独立 toContain 会漏「名字配错描述」)。
+      expect(sys).toContain(`- ${s.name}: ${s.description}`);
       // body 绝不进 catalog。
       expect(sys).not.toContain(s.body);
     }
@@ -177,6 +177,62 @@ describe("skills: tool activation reuses O1 activation set (d)", () => {
     const text = tr!.content.map((b) => b.text ?? "").join("");
     expect(text).toContain("FETCH BODY");
     expect(text).toContain("activated tools: WebFetch");
+    fake.teardown();
+  });
+});
+
+describe("skills: activation is a union, not overwrite (d2)", () => {
+  it("invoking a skill keeps previously-activated deferred tools visible", async () => {
+    const { hook, tool } = skills([
+      { name: "fetcher", description: "fetch web", body: "FETCH", tools: ["WebFetch"] },
+    ]);
+    const fake = createFakeModel([
+      {
+        content: [
+          { type: "toolCall", name: "skill", arguments: { name: "fetcher" } },
+        ],
+      },
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [trivialTool("WebFetch"), trivialTool("Grep"), tool],
+      hooks: [
+        // Grep 是 deferred 且**预激活**(alwaysListed)→ 一开始就可见;skill 再激活 WebFetch。
+        // 若 skill 用 overwrite(new Set(spec.tools))而非 union,会丢掉预激活的 Grep。
+        deferredTools({
+          deferred: ["WebFetch", "Grep"],
+          alwaysListed: ["Grep", tool.name],
+        }),
+        hook,
+      ],
+    });
+    await session.run("go");
+
+    const turn2 = namesOf(fake.getCalls()[1]!.tools);
+    // union:WebFetch 新激活 + Grep 预激活仍在(overwrite 会丢 Grep)。
+    expect(turn2).toEqual(expect.arrayContaining(["WebFetch", "Grep"]));
+    fake.teardown();
+  });
+});
+
+describe("skills: skill tool is a barrier", () => {
+  it("declares isConcurrencySafe === false (writes shared ctx.state activation set)", () => {
+    const { tool } = skills(SPECS);
+    expect(tool.isConcurrencySafe!({})).toBe(false);
+  });
+});
+
+describe("skills: custom toolName", () => {
+  it("honors opts.toolName in both tool.name and the catalog invoke hint", async () => {
+    const { hook, tool } = skills(SPECS, { toolName: "loadSkill" });
+    expect(tool.name).toBe("loadSkill");
+    const fake = createFakeModel([
+      { content: [{ type: "text", text: "ok" }], stopReason: "stop" },
+    ]);
+    const session = new AgentSession({ model: fake, tools: [tool], hooks: [hook] });
+    await session.run("go");
+    expect(fake.getCalls()[0]!.systemPrompt).toContain("`loadSkill`");
     fake.teardown();
   });
 });

--- a/packages/plugins/src/__tests__/skills.test.ts
+++ b/packages/plugins/src/__tests__/skills.test.ts
@@ -1,0 +1,216 @@
+/**
+ * skills —— 渐进式技能加载测试（issue #68 / O2）。
+ *
+ * 经 testing.ts fake-model 的 getCalls()——它捕获每次 Context.systemPrompt / Context.tools，
+ * 据此断言 catalog 进 system prompt（仅 name+description）、invoke 注入 body、非法 name throw、
+ * 工具激活复用 O1 激活集、opt-in 与 0.2.x 字节级一致、构造期 fail-loud。
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  AgentSession,
+  Type,
+  type HarnessTool,
+} from "@harness-pi/core";
+import { createFakeModel } from "@harness-pi/core/testing";
+import { skills } from "../skills.js";
+import { deferredTools } from "../deferred-tools.js";
+
+function trivialTool(name: string): HarnessTool {
+  return {
+    name,
+    description: `${name} tool`,
+    parameters: Type.Object({}),
+    isConcurrencySafe: () => true,
+    async execute() {
+      return { content: [{ type: "text", text: `${name} ran` }] };
+    },
+  };
+}
+
+function namesOf(
+  tools: ReadonlyArray<{ name: string }> | undefined,
+): string[] {
+  return (tools ?? []).map((t) => t.name);
+}
+
+const SPECS = [
+  {
+    name: "review-pr",
+    description: "Use when asked to review a pull request.",
+    body: "REVIEW BODY: read the diff, check correctness, summarize findings.",
+  },
+  {
+    name: "deep-research",
+    description: "Use for multi-source fact-checked research.",
+    body: "RESEARCH BODY: fan out searches, verify claims, cite sources.",
+  },
+];
+
+describe("skills: catalog in system prompt (a)", () => {
+  it("appends each skill's name + description, never the body", async () => {
+    const fake = createFakeModel([
+      { content: [{ type: "text", text: "ok" }], stopReason: "stop" },
+    ]);
+    const { hook, tool } = skills(SPECS);
+    const session = new AgentSession({
+      model: fake,
+      systemPrompt: "You are an agent.",
+      tools: [tool],
+      hooks: [hook],
+    });
+    await session.run("go");
+
+    const sys = fake.getCalls()[0]!.systemPrompt;
+    expect(sys).toContain("## Available skills");
+    for (const s of SPECS) {
+      expect(sys).toContain(s.name);
+      expect(sys).toContain(s.description);
+      // body 绝不进 catalog。
+      expect(sys).not.toContain(s.body);
+    }
+    // 原有 system prompt 保留。
+    expect(sys).toContain("You are an agent.");
+    fake.teardown();
+  });
+});
+
+describe("skills: invoke injects body (b)", () => {
+  it("skill({name}) returns the spec body as toolResult content", async () => {
+    const { hook, tool } = skills(SPECS);
+    const fake = createFakeModel([
+      {
+        content: [
+          { type: "toolCall", name: "skill", arguments: { name: "review-pr" } },
+        ],
+      },
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [tool],
+      hooks: [hook],
+    });
+    await session.run("go");
+
+    const tr = session.messages.find((m) => m.role === "toolResult") as
+      | { content: { text?: string }[]; isError?: boolean }
+      | undefined;
+    expect(tr).toBeDefined();
+    expect(tr!.isError).not.toBe(true);
+    const text = tr!.content.map((b) => b.text ?? "").join("");
+    expect(text).toContain("REVIEW BODY");
+    fake.teardown();
+  });
+});
+
+describe("skills: unknown name (c)", () => {
+  it("throws -> kernel wraps as isError toolResult mentioning 'unknown skill'", async () => {
+    const { hook, tool } = skills(SPECS);
+    const fake = createFakeModel([
+      {
+        content: [
+          { type: "toolCall", name: "skill", arguments: { name: "nope" } },
+        ],
+      },
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [tool],
+      hooks: [hook],
+    });
+    await session.run("go");
+
+    const tr = session.messages.find((m) => m.role === "toolResult") as
+      | { content: { text?: string }[]; isError?: boolean }
+      | undefined;
+    expect(tr).toBeDefined();
+    expect(tr!.isError).toBe(true);
+    const text = tr!.content.map((b) => b.text ?? "").join("");
+    expect(text).toContain("unknown skill");
+    fake.teardown();
+  });
+});
+
+describe("skills: tool activation reuses O1 activation set (d)", () => {
+  it("invoking a skill with tools activates them in the deferred listing next turn", async () => {
+    const { hook, tool } = skills([
+      {
+        name: "fetcher",
+        description: "Use to fetch web pages.",
+        body: "FETCH BODY",
+        tools: ["WebFetch"],
+      },
+    ]);
+    const fake = createFakeModel([
+      // turn-1：调 skill 激活 WebFetch（不收尾，继续循环）。
+      {
+        content: [
+          { type: "toolCall", name: "skill", arguments: { name: "fetcher" } },
+        ],
+      },
+      // turn-2：收尾。
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [trivialTool("WebFetch"), tool],
+      hooks: [
+        deferredTools({ deferred: ["WebFetch"], alwaysListed: [tool.name] }),
+        hook,
+      ],
+    });
+    await session.run("go");
+
+    const turn1 = namesOf(fake.getCalls()[0]!.tools);
+    const turn2 = namesOf(fake.getCalls()[1]!.tools);
+    // turn-1：WebFetch 仍 deferred、不可见。
+    expect(turn1).not.toContain("WebFetch");
+    // turn-2：skill 激活后下一 turn 出现在 listing（证明复用 O1 激活集）。
+    expect(turn2).toContain("WebFetch");
+
+    // toolResult 文案标注激活的工具。
+    const tr = session.messages.find((m) => m.role === "toolResult") as
+      | { content: { text?: string }[] }
+      | undefined;
+    const text = tr!.content.map((b) => b.text ?? "").join("");
+    expect(text).toContain("FETCH BODY");
+    expect(text).toContain("activated tools: WebFetch");
+    fake.teardown();
+  });
+});
+
+describe("skills: opt-in byte-equal (e)", () => {
+  it("without the skills hook, system prompt has no 'Available skills'", async () => {
+    const fake = createFakeModel([
+      { content: [{ type: "text", text: "ok" }], stopReason: "stop" },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      systemPrompt: "You are an agent.",
+      tools: [],
+      hooks: [],
+    });
+    await session.run("go");
+
+    expect(fake.getCalls()[0]!.systemPrompt).toBe("You are an agent.");
+    expect(fake.getCalls()[0]!.systemPrompt).not.toContain("Available skills");
+    fake.teardown();
+  });
+});
+
+describe("skills: construction-time fail-loud (f)", () => {
+  it("empty specs throws", () => {
+    expect(() => skills([])).toThrow();
+  });
+
+  it("duplicate skill name throws", () => {
+    expect(() =>
+      skills([
+        { name: "dup", description: "a", body: "A" },
+        { name: "dup", description: "b", body: "B" },
+      ]),
+    ).toThrow(/duplicate skill name/);
+  });
+});

--- a/packages/plugins/src/auto-compaction.ts
+++ b/packages/plugins/src/auto-compaction.ts
@@ -207,6 +207,42 @@ export const defaultTokenCounter: TokenCounter = {
 };
 
 /**
+ * 混合 token 计量（issue #13 / C5）：取 messages 里**最近一条带真 `Usage` 的 assistant** 作基线
+ * （`input + cacheRead + cacheWrite + output` —— 那一刻真实的 prompt+output 体积，**已含 tools/systemPrompt**），
+ * 只对其后的消息走字符估算补尾（{@link estimateTokensByChars}，messages-only，**不再加 tools/systemPrompt**：
+ * 它们已计在真基线里，再加会双重计）。有真 usage 时基线精确——修掉 D0 实测的残差（messages-only 低估
+ * ~7x；X1 加回 tools/sys 后仍 ~2x，因 chat 模板/tool schema 自有格式比 char/4 重）。
+ *
+ * 无可用真 usage 时退回 {@link estimateRequestTokens}（X1，含 tools/systemPrompt）：(a) turn-0 还没 assistant；
+ * (b) assistant `usage` 全 0（fake-model / provider 未回 usage）—— 视为「无真值」而非「真的 0」。这保证不挂真
+ * provider 时（如 fake-model 测试）行为与 {@link defaultTokenCounter} 完全一致。
+ *
+ * **不满足 additivity 契约**（基线随「最近 assistant」跳变、非逐条可加）——故**别**用作 microcompact 的增量
+ * counter；它专给 autoCompaction（每 turn 全量 estimate、无增量假设）做更准的触发判据。
+ */
+export const hybridTokenCounter: TokenCounter = {
+  estimate(input: RequestTokenInput): number {
+    const msgs = input.messages;
+    for (let i = msgs.length - 1; i >= 0; i--) {
+      const m = msgs[i];
+      if (m === undefined || m.role !== "assistant") continue;
+      const u = m.usage;
+      // 判别「有无真值」**故意只看 input+output、忽略 cache**：fake-model / 未回 usage 的标志是
+      // input==output==0(testing.ts zeroUsage);真 assistant 输出内容必有 output>0。别把判别改成含
+      // cacheRead/cacheWrite —— 否则纯缓存命中(理论上 input=output=0、cacheRead>0)会被误判为真值,
+      // 且会让 fake 全 0 的 parity 假设变脆。continue(非 break):越过零-usage 继续往前找最近真值。
+      if (!u || u.input + u.output <= 0) continue;
+      // 基线 = 那一刻真实 prompt+output footprint(= pi-ai 自己的 totalTokens;input 已排除 cached,故 +cache)。
+      const baseline = u.input + u.cacheRead + u.cacheWrite + u.output;
+      // 补尾只数后缀消息字符(messages-only)。注:未加后缀的每消息 framing(~4tok/条),故对后缀略偏低估;
+      // 后缀在 turn 间有界(就最近几条)、基线主导且精确,这点偏差对「宁高勿低」的触发阈值可忽略。
+      return baseline + estimateTokensByChars(msgs.slice(i + 1));
+    }
+    return estimateRequestTokens(input);
+  },
+};
+
+/**
  * 构造一个 autoCompaction hook。三条**使用须知**（issue #13，违反会得到悄无声息的错误压缩）：
  *
  * 1. **Hook 顺序**：本插件从 `transformMessagesBeforeLlm` 收到的 `messages`（≈ `session.messages`）估算
@@ -243,7 +279,8 @@ export function autoCompaction(opts: AutoCompactionOptions): Hook {
   if (opts.safetyBuffer !== undefined && opts.safetyBuffer < 0) {
     throw new Error("autoCompaction: safetyBuffer must be >= 0");
   }
-  const counter = opts.tokenCounter ?? defaultTokenCounter;
+  // 默认走混合计量（C5）：有真 usage 用真基线（更准、修 D0 残差），无真 usage（turn-0 / fake）退回 X1。
+  const counter = opts.tokenCounter ?? hybridTokenCounter;
   const safetyBuffer = opts.safetyBuffer ?? 0;
   // 百分比路径阈值是构造期常量；窗口路径阈值依赖 ctx.config.model.contextWindow，须每请求算。
   const percentThreshold =

--- a/packages/plugins/src/auto-compaction.ts
+++ b/packages/plugins/src/auto-compaction.ts
@@ -278,9 +278,11 @@ export function autoCompaction(opts: AutoCompactionOptions): Hook {
       if (threshold === undefined) return undefined;
 
       // 未到 token 阈值 → 原样。tools / systemPrompt 由 ctx.config 提供，计入每请求随发的固定开销（X1）。
+      // deferredTools 在场时，本 turn 实际随发的是激活子集（deferred.activeListing），按它估更准；
+      // 无 deferredTools 则退回 ctx.config.tools 全集（0.2.x 行为）。
       const estimated = counter.estimate({
         messages,
-        tools: ctx.config.tools,
+        tools: ctx.state.get("deferred.activeListing") ?? ctx.config.tools,
         systemPrompt: ctx.config.systemPrompt,
       });
       if (estimated <= threshold) return undefined;

--- a/packages/plugins/src/controllers/compact-resume-from-boundary.ts
+++ b/packages/plugins/src/controllers/compact-resume-from-boundary.ts
@@ -1,0 +1,99 @@
+/**
+ * compactResumeFromBoundary —— compactRestartFresh 的兄弟（docs/09 §4.2），同样建在内核
+ * `onContextOverflow` → `compactOnOverflow()` abort 之上，但**恢复方式相反**：
+ *
+ *   - `compactRestartFresh`：overflow 时 abort + **fresh 重跑同一 prompt**，丢掉整段越界 ReAct trace。
+ *     便宜，但每次都从零开始——压缩成果（trace 里已做的工作）全部作废。
+ *   - `compactResumeFromBoundary`（本控制器）：overflow 时 abort 后，把当下 live messages **总结成一条
+ *     覆盖全量的 summary**、写一条 `compaction_boundary` entry，再 `AgentSession.resume()` 从 boundary
+ *     **续跑**（`continue()`）。**保留压缩后的成果**——summary 把越界 trace 浓缩成一条，从这条接着干。
+ *
+ * 二者都复用 `compactOnOverflow`（Hook）+ `isCompactionRestart`（谓词），区别仅在 abort 之后怎么恢复。
+ *
+ * 为什么不像 fresh 那样可能死循环：boundary **覆盖它之前的全部前缀**，resume 重建出的 messages 就是
+ * `[summary]` 一条——最大压缩。只要 summarize 真把内容压短，每次 resume 的起点都比上次小，进展有保证；
+ * 不像 fresh「重跑同一 prompt」在 **初始 prompt 本身过大** 时会反复同样越界。
+ *
+ * ⚠️ 诚实边界：
+ *   - **需要 `store`**：boundary 必须落盘，`resume()` 从 store 重建。compactRestartFresh 不需 store。
+ *   - **`maxRestarts` 耗尽**：若持续 overflow（如单条 summary 仍超窗），控制器在耗尽后返回**最后一次的
+ *     aborted summary**（不假装恢复成功）。
+ *   - **signal 只透传给 `run`/`continue`**：其余 run 选项不穿透（与 compactRestartFresh 一致）。
+ *   - **domain-free**：`summarize` 由调用方提供（可调 LLM），控制器/内核都不内置 LLM 调用。
+ *   - **`summarize` 抛错**：`run()` 直接 reject（fail-loud，caller 自负 summarize 错误）。因 summarize 在
+ *     `appendEntry` 之前调用，抛错时**不留半成品 orphan boundary**——store 不损坏。
+ */
+
+import { AgentSession, type AgentSessionOptions, type Message, type RunSummary, type SessionStore } from "@harness-pi/core";
+import { isCompactionRestart } from "./compact-restart-fresh.js";
+
+export interface CompactResumeFromBoundaryOptions {
+  /** 落盘 store（resume 从它读重建）。必需。 */
+  store: SessionStore;
+  /** session id（首跑 + resume 同一 lineage 用同一个）。必需。 */
+  sessionId: string;
+  /**
+   * 造首个 session + resume 都用的会话选项（model/tools/hooks/...）。
+   * **务必在 hooks 里装 `compactOnOverflow()`** —— 否则 overflow 不会变成 compaction abort、控制器无从感知。
+   */
+  sessionOptions: Omit<
+    AgentSessionOptions,
+    "store" | "sessionId" | "initialMessages" | "resumedMessageCount"
+  >;
+  /**
+   * 把 abort 时的 live messages 总结成一条覆盖全量的 summary message。可 async（调 LLM）。domain-free。
+   */
+  summarize: (messages: ReadonlyArray<Message>) => Message | Promise<Message>;
+  /** 最大重启次数（不含首跑），默认 3。 */
+  maxRestarts?: number;
+}
+
+export interface CompactResumeResult extends RunSummary {
+  /** 实际 resume-continue 次数。 */
+  restarts: number;
+}
+
+const DEFAULT_MAX_RESTARTS = 3;
+
+export class CompactResumeFromBoundary {
+  constructor(private readonly opts: CompactResumeFromBoundaryOptions) {
+    if ((opts.maxRestarts ?? DEFAULT_MAX_RESTARTS) < 0) {
+      throw new Error("CompactResumeFromBoundary: maxRestarts must be >= 0");
+    }
+  }
+
+  /**
+   * 跑 prompt；overflow-abort 则写 boundary（summary 覆盖全量）→ resume → continue 续跑，直到非
+   * compaction abort 或 maxRestarts 耗尽。耗尽返回最后一次的 aborted summary（不假装恢复）。
+   * 注意：只代理 `signal` 给每次 `run`/`continue`，其余 run 选项不穿透（与 compactRestartFresh 同）。
+   */
+  async run(
+    prompt: string,
+    opts?: { signal?: AbortSignal },
+  ): Promise<CompactResumeResult> {
+    const { store, sessionId, sessionOptions, summarize } = this.opts;
+    const max = this.opts.maxRestarts ?? DEFAULT_MAX_RESTARTS;
+    const runOpts = opts?.signal ? { signal: opts.signal } : {};
+
+    let session = new AgentSession({ ...sessionOptions, store, sessionId });
+    let summary = await session.run(prompt, runOpts);
+    let restarts = 0;
+
+    while (
+      summary.reason === "aborted" &&
+      isCompactionRestart(summary.abortReason) &&
+      restarts < max &&
+      !opts?.signal?.aborted
+    ) {
+      restarts++;
+      // 把越界 trace 总结成一条覆盖全量的 summary，写 boundary（覆盖它之前的全部前缀）。
+      const boundary = await summarize(session.messages);
+      await store.appendEntry(sessionId, { kind: "compaction_boundary", summary: boundary });
+      // 从 boundary resume：重建出的 messages 就是 [summary] 一条，从这条 continue 续跑。
+      session = await AgentSession.resume(store, sessionId, sessionOptions);
+      summary = await session.continue(runOpts);
+    }
+
+    return { ...summary, restarts };
+  }
+}

--- a/packages/plugins/src/controllers/index.ts
+++ b/packages/plugins/src/controllers/index.ts
@@ -48,6 +48,12 @@ export type {
   CompactRestartResult,
 } from "./compact-restart-fresh.js";
 
+export { CompactResumeFromBoundary } from "./compact-resume-from-boundary.js";
+export type {
+  CompactResumeFromBoundaryOptions,
+  CompactResumeResult,
+} from "./compact-resume-from-boundary.js";
+
 export { subAgentTool, routedSubAgentTool } from "./sub-agent-tool.js";
 export type {
   SubAgentToolOptions,

--- a/packages/plugins/src/deferred-tools.ts
+++ b/packages/plugins/src/deferred-tools.ts
@@ -1,0 +1,71 @@
+/**
+ * deferredTools —— listing-only 的工具延迟暴露（issue #66 / O1）。
+ *
+ * 把一部分工具标成 "deferred"：默认**不进 LLM 看到的 tool listing**，直到被激活
+ * （典型由 {@link toolSearch} 工具命中后写入激活集）才在**下一 turn** 出现在 listing 里。
+ * 纯 listing 收窄 —— **不碰 execution**：deferred 工具始终在 `session.tools` 全集里，
+ * 一旦被调用，executor 照常 findToolByName / validateToolCall / 过权限闸。
+ *
+ * 激活集载体：`ctx.state` 的 `"deferred.activated"`（`Set<string>`），由 onSessionStart
+ * seed 成 `alwaysListed`。当前 turn 实际 listing 的子集顺手写进 `"deferred.activeListing"`，
+ * 给 autoCompaction 的 token 估算读（有 deferred 就估激活子集，没有退回全集）。
+ *
+ * **必须排在 autoCompaction 之前**（用 `requires` 声明）——否则 autoCompaction 读不到
+ * 本 turn 写入的 `deferred.activeListing`。
+ */
+
+import type { Hook, Tool } from "@harness-pi/core";
+
+/* ── 在 core 的 HookStateRegistry 上 augment 本 plugin 用到的 key ── */
+declare module "@harness-pi/core" {
+  interface HookStateRegistry {
+    "deferred.activated": Set<string>;
+    "deferred.activeListing": Tool[];
+  }
+}
+
+// `as const` 保留字面类型，让 TypedStateMap 走 typed overload 而不是 string fallback
+const KEY_ACTIVATED = "deferred.activated" as const;
+const KEY_LISTING = "deferred.activeListing" as const;
+
+export interface DeferredToolsOptions {
+  /**
+   * 哪些工具是 deferred：字符串数组（按名命中）或谓词（`(name) => boolean`）。
+   * deferred 工具默认不进 listing，激活后才可见。
+   */
+  deferred: string[] | ((name: string) => boolean);
+  /**
+   * 即便是 deferred 也**始终列出**的工具名（seed 进激活集）。典型：toolSearch 自己，
+   * 以及希望首 turn 就可见的常用工具。
+   */
+  alwaysListed?: string[];
+}
+
+export function deferredTools(opts: DeferredToolsOptions): Hook {
+  const isDeferred = (name: string): boolean =>
+    typeof opts.deferred === "function"
+      ? opts.deferred(name)
+      : opts.deferred.includes(name);
+
+  return {
+    name: "deferredTools",
+    // 软依赖：autoCompaction 的 token 估算会读 deferred.activeListing（激活子集），缺它也能独立工作。
+    // 两者都挂时，deferredTools 应排在 autoCompaction **之前**注册，让估算口径与本 turn listing 对齐。
+    // 用 prefers（不发 warning，opt-in 行为不受影响），与 tokenBudget→cost-tracker 同例。
+    prefers: ["autoCompaction"],
+
+    onSessionStart(_input, ctx) {
+      ctx.state.set(KEY_ACTIVATED, new Set(opts.alwaysListed ?? []));
+    },
+
+    transformToolsBeforeLlm(tools, ctx) {
+      const activated = ctx.state.get(KEY_ACTIVATED) ?? new Set<string>();
+      const result = tools.filter(
+        (t) => !isDeferred(t.name) || activated.has(t.name),
+      );
+      // 当前 turn 实际 listing 的子集 —— 给 autoCompaction 估算读（激活子集而非全集）。
+      ctx.state.set(KEY_LISTING, result);
+      return result;
+    },
+  };
+}

--- a/packages/plugins/src/deferred-tools.ts
+++ b/packages/plugins/src/deferred-tools.ts
@@ -10,8 +10,11 @@
  * seed 成 `alwaysListed`。当前 turn 实际 listing 的子集顺手写进 `"deferred.activeListing"`，
  * 给 autoCompaction 的 token 估算读（有 deferred 就估激活子集，没有退回全集）。
  *
- * **必须排在 autoCompaction 之前**（用 `requires` 声明）——否则 autoCompaction 读不到
- * 本 turn 写入的 `deferred.activeListing`。
+ * **估算联动有结构性的一 turn 滞后，与 hook 注册顺序无关**：autoCompaction 在
+ * `transformMessagesBeforeLlm` 读 `deferred.activeListing`，本 hook 在 `transformToolsBeforeLlm`
+ * 写它——内核固定 messages-pipe 先于 tools-pipe（且二者不同 method，重排注册顺序也改不了），
+ * 故 autoCompaction 读到的是**上一 turn**写入的激活子集；turn-0 读到 undefined → 退回全集
+ * （保守高估，安全侧：宁早压勿晚）。对压缩阈值无害，无需也无法靠排序消除。
  */
 
 import type { Hook, Tool } from "@harness-pi/core";
@@ -49,10 +52,8 @@ export function deferredTools(opts: DeferredToolsOptions): Hook {
 
   return {
     name: "deferredTools",
-    // 软依赖：autoCompaction 的 token 估算会读 deferred.activeListing（激活子集），缺它也能独立工作。
-    // 两者都挂时，deferredTools 应排在 autoCompaction **之前**注册，让估算口径与本 turn listing 对齐。
-    // 用 prefers（不发 warning，opt-in 行为不受影响），与 tokenBudget→cost-tracker 同例。
-    prefers: ["autoCompaction"],
+    // 不声明对 autoCompaction 的依赖：二者在不同 pipe method（tools vs messages），注册顺序对其
+    // 交互无影响（见文件头「结构性一 turn 滞后」）。autoCompaction 缺席时也独立工作（opt-in）。
 
     onSessionStart(_input, ctx) {
       ctx.state.set(KEY_ACTIVATED, new Set(opts.alwaysListed ?? []));

--- a/packages/plugins/src/deferred-tools.ts
+++ b/packages/plugins/src/deferred-tools.ts
@@ -27,8 +27,10 @@ declare module "@harness-pi/core" {
   }
 }
 
-// `as const` 保留字面类型，让 TypedStateMap 走 typed overload 而不是 string fallback
-const KEY_ACTIVATED = "deferred.activated" as const;
+// `as const` 保留字面类型，让 TypedStateMap 走 typed overload 而不是 string fallback。
+// `KEY_ACTIVATED` 导出供 toolSearch / skills 复用同一激活集（单一 key 真相源，
+// 别在别处重复 declare module augmentation）。
+export const KEY_ACTIVATED = "deferred.activated" as const;
 const KEY_LISTING = "deferred.activeListing" as const;
 
 export interface DeferredToolsOptions {

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -49,6 +49,7 @@ export {
   estimateTokensByChars,
   estimateRequestTokens,
   defaultTokenCounter,
+  hybridTokenCounter,
 } from "./auto-compaction.js";
 export type {
   AutoCompactionOptions,

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -113,3 +113,9 @@ export type { TokenBudgetOptions } from "./token-budget.js";
 
 export { repeatedCallGuard } from "./repeated-call-guard.js";
 export type { RepeatedCallGuardOptions } from "./repeated-call-guard.js";
+
+export { deferredTools } from "./deferred-tools.js";
+export type { DeferredToolsOptions } from "./deferred-tools.js";
+
+export { toolSearch } from "./tool-search.js";
+export type { ToolSearchOptions } from "./tool-search.js";

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -119,3 +119,6 @@ export type { DeferredToolsOptions } from "./deferred-tools.js";
 
 export { toolSearch } from "./tool-search.js";
 export type { ToolSearchOptions } from "./tool-search.js";
+
+export { skills } from "./skills.js";
+export type { SkillSpec, SkillsOptions } from "./skills.js";

--- a/packages/plugins/src/skills.ts
+++ b/packages/plugins/src/skills.ts
@@ -1,0 +1,102 @@
+/**
+ * skills —— 渐进式技能加载（issue #68 / O2）。
+ *
+ * 把一组 "skill"（一段命名的 prompt 全文 + 可选要激活的工具）做成 catalog + 加载工具：
+ * - **发现**：`hook` 在 system prompt 末尾追加一段简洁 catalog（仅 name + description，
+ *   **绝不含 body**），随 system prompt 每 turn 已发、无额外注入成本。模型据此挑技能。
+ * - **加载**：`skill` 工具按名取回该 skill 的 body 全文作 toolResult 注入；若 skill 声明了
+ *   `tools`，把它们写进 O1 的 `"deferred.activated"` 激活集，**下一 turn** 才在 listing 里出现
+ *   （仅当也挂了 {@link deferredTools} 且这些工具被 deferred 时才有视觉效果——O1/O2 共享同一 seam）。
+ *
+ * domain-free：`SkillSpec` 不绑任何具体领域，纯 name/description/body/tools。
+ * opt-in：不挂 skills 时行为与 0.2.x 一致（system prompt 不含 "Available skills"）。
+ */
+
+import { Type } from "@harness-pi/core";
+import type {
+  HarnessTool,
+  Hook,
+  HookContext,
+  ToolExecResult,
+} from "@harness-pi/core";
+import { KEY_ACTIVATED } from "./deferred-tools.js";
+
+export interface SkillSpec {
+  /** 技能名，调 `skill` 工具时按此名取回。catalog 内唯一。 */
+  name: string;
+  /** 进 catalog 给模型选用的简短描述（whenToUse 性质）。 */
+  description: string;
+  /** invoke 时注入的全文 prompt —— 只在被调用时进 toolResult，**绝不进 catalog**。 */
+  body: string;
+  /** 可选：invoke 时激活的工具名（复用 O1 的 deferred.activated 激活集）。 */
+  tools?: string[];
+}
+
+export interface SkillsOptions {
+  /** `skill` 工具名 —— 默认 `"skill"`。 */
+  toolName?: string;
+}
+
+export function skills(
+  specs: SkillSpec[],
+  opts: SkillsOptions = {},
+): { hook: Hook; tool: HarnessTool } {
+  // 构造期 fail-loud：空集 / 重名直接抛，别等运行时静默退化。
+  if (specs.length === 0) {
+    throw new Error("skills(): specs must be non-empty");
+  }
+  const byName = new Map<string, SkillSpec>();
+  for (const spec of specs) {
+    if (byName.has(spec.name)) {
+      throw new Error(`skills(): duplicate skill name "${spec.name}"`);
+    }
+    byName.set(spec.name, spec);
+  }
+
+  const toolName = opts.toolName ?? "skill";
+
+  const catalog =
+    `\n\n## Available skills\n` +
+    `Invoke the \`${toolName}\` tool with a skill name to load its full instructions.\n` +
+    specs.map((s) => `- ${s.name}: ${s.description}`).join("\n");
+
+  const hook: Hook = {
+    name: "skills",
+    transformSystemPromptBeforeLlm(systemPrompt) {
+      // catalog 只含 name + description，绝不含 body。
+      return systemPrompt + catalog;
+    },
+  };
+
+  const tool: HarnessTool = {
+    name: toolName,
+    description:
+      "Load a skill's full instructions by name. " +
+      "Available skill names are listed under '## Available skills' in the system prompt.",
+    parameters: Type.Object({
+      name: Type.String({ description: "Name of the skill to load." }),
+    }),
+    // 可能写 ctx.state（激活集），且注入语义应顺序化 —— 屏障型。
+    isConcurrencySafe: () => false,
+    async execute(args, ctx: HookContext): Promise<ToolExecResult> {
+      const name = args.name as string;
+      const spec = byName.get(name);
+      if (!spec) {
+        const available = [...byName.keys()].join(", ");
+        throw new Error(`unknown skill "${name}" (available: ${available})`);
+      }
+
+      if (spec.tools?.length) {
+        const cur = ctx.state.get(KEY_ACTIVATED) ?? new Set<string>();
+        ctx.state.set(KEY_ACTIVATED, new Set([...cur, ...spec.tools]));
+      }
+
+      const note = spec.tools?.length
+        ? `\n\n(activated tools: ${spec.tools.join(", ")} — available next turn.)`
+        : "";
+      return { content: [{ type: "text", text: spec.body + note }] };
+    },
+  };
+
+  return { hook, tool };
+}

--- a/packages/plugins/src/skills.ts
+++ b/packages/plugins/src/skills.ts
@@ -10,6 +10,10 @@
  *
  * domain-free：`SkillSpec` 不绑任何具体领域，纯 name/description/body/tools。
  * opt-in：不挂 skills 时行为与 0.2.x 一致（system prompt 不含 "Available skills"）。
+ *
+ * 注意（已知小限制，非本插件引入）：catalog 经 `transformSystemPromptBeforeLlm` 追加在 **pipe 之后**，
+ * 而 `SessionConfigView.systemPrompt`（token-budget / autoCompaction 读的）暴露的是 **pipe 前**的 base，
+ * 故 catalog 的字节不计入 token 估算。catalog 仅 name+description、体积小，影响可忽略。
  */
 
 import { Type } from "@harness-pi/core";

--- a/packages/plugins/src/token-budget.ts
+++ b/packages/plugins/src/token-budget.ts
@@ -18,14 +18,14 @@ declare module "@harness-pi/core" {
 export interface TokenBudgetOptions {
   /** session 总 token 预算。null = 不限。 */
   budget: number | null;
-  /** 当前累计超 budget × completionThreshold 时停止 nudge（默认 0.9）。 */
+  /** 累计超 budget × completionThreshold 时,每 turn 的 remaining 提示升级为「该收尾」urgency（默认 0.9）。 */
   completionThreshold?: number;
   /** Diminishing returns 阈值。连续 N turn delta < 这个值视为收敛（默认 500）。 */
   diminishingThreshold?: number;
-  /** 触发 diminishing 判定前最少 continuation 次数（默认 3）。 */
+  /** 触发 diminishing 判定前最少 turn 数（默认 3）。 */
   diminishingMinNudges?: number;
-  /** 触发 nudge 的文案。 */
-  nudgeMessage?: (pct: number, turnTokens: number, budget: number) => string;
+  /** 每 turn 注入的 remaining 提示文案。`usedTokens` 是**累计**已用 token（非单 turn）。 */
+  nudgeMessage?: (pct: number, usedTokens: number, budget: number) => string;
 }
 
 interface BudgetTracker {
@@ -41,10 +41,11 @@ const KEY = "token-budget.tracker" as const;
 
 function defaultNudge(
   pct: number,
-  turnTokens: number,
+  usedTokens: number,
   budget: number,
 ): string {
-  return `You've used ${turnTokens.toLocaleString()} / ${budget.toLocaleString()} tokens (${pct}%). Continue if more useful work remains; otherwise summarize and stop.`;
+  const remaining = Math.max(0, budget - usedTokens);
+  return `Token budget: ${usedTokens.toLocaleString()} / ${budget.toLocaleString()} tokens used (${pct}%), ${remaining.toLocaleString()} remaining. Plan remaining work to fit the budget; summarize and stop if little remains.`;
 }
 
 function readCumulativeTokens(ctx: HookContext): number {
@@ -87,6 +88,24 @@ export function tokenBudget(opts: TokenBudgetOptions): Hook {
       tr.fallbackOutput += input.msg.usage.output ?? 0;
     },
 
+    // X4（issue #43）：每 turn 开始注入「剩余预算」结构化提示——**持续反馈**(不只停时)，让模型据此
+    // 规划剩余工作。补上原先 0.9~1.0 临界区无反馈的缺口。additionalContext 一次性消费语义正好匹配
+    // 「每 call 注入」；走通用 prompt 注入，不依赖 provider beta（实仓核验 pi-ai 无 task_budget）。
+    onTurnStart(_input, ctx): HookResult | void {
+      if (opts.budget == null || opts.budget <= 0) return;
+      const totalTokens = readCumulativeTokens(ctx);
+      const pct = Math.round((totalTokens / opts.budget) * 100);
+      // 越过 completionThreshold 进入临界区 → reminder 升级为「该收尾」紧急提示（补原先 0.9~1.0 无反馈的缺口）。
+      const urgent = totalTokens >= opts.budget * completionThreshold;
+      const body =
+        nudgeMsg(pct, totalTokens, opts.budget) +
+        (urgent ? " You are near the budget limit — wrap up and stop soon." : "");
+      return {
+        additionalContext: `<system-reminder>${body}</system-reminder>`,
+      };
+    },
+
+    // turn 收尾只做**停止决策**（预算耗尽 / diminishing 收敛）——持续 remaining 反馈已移到 onTurnStart。
     onTurnEnd(_input, ctx): HookResult | void {
       if (opts.budget == null || opts.budget <= 0) return;
 
@@ -94,7 +113,6 @@ export function tokenBudget(opts: TokenBudgetOptions): Hook {
       if (!tr) return;
 
       const totalTokens = readCumulativeTokens(ctx);
-      const pct = Math.round((totalTokens / opts.budget) * 100);
       const delta = totalTokens - tr.lastTotalTokens;
 
       const isDiminishing =
@@ -116,16 +134,8 @@ export function tokenBudget(opts: TokenBudgetOptions): Hook {
         };
       }
 
-      if (totalTokens < opts.budget * completionThreshold) {
-        tr.nudgeCount++;
-        tr.lastDeltaTokens = delta;
-        tr.lastTotalTokens = totalTokens;
-        return {
-          additionalContext: `<system-reminder>${nudgeMsg(pct, totalTokens, opts.budget)}</system-reminder>`,
-        };
-      }
-
-      // 已到完成阈值但未爆——不强停，让 LLM 自然收尾
+      // 每 turn 推进收敛跟踪（nudgeCount 现作「已观察 turn 数」，喂 diminishing 判定）。
+      tr.nudgeCount++;
       tr.lastDeltaTokens = delta;
       tr.lastTotalTokens = totalTokens;
       return;

--- a/packages/plugins/src/tool-search.ts
+++ b/packages/plugins/src/tool-search.ts
@@ -1,0 +1,109 @@
+/**
+ * toolSearch —— 激活 deferred 工具的普通 first-party 工具（issue #66 / O1）。
+ *
+ * 配合 {@link deferredTools} 用：deferred 工具默认不在 LLM 看到的 listing 里，模型调
+ * toolSearch（按名 `select` 或 `keyword` 本地模糊匹配）把命中的工具写进 `ctx.state` 的
+ * `"deferred.activated"` 激活集，**下一 turn** 它们才出现在 listing 里。
+ *
+ * 全本地、零 provider 依赖：数据源是 `ctx.config.tools`（session.tools 全集的冻结视图），
+ * keyword 在工具 name + description 上做最简包含匹配。
+ *
+ * 屏障型（`isConcurrencySafe: () => false`）：写 `ctx.state` 同一 key，绝不与同 turn 其他工具并行。
+ */
+
+import { Type } from "@harness-pi/core";
+import type { HarnessTool, HookContext, ToolExecResult } from "@harness-pi/core";
+
+const KEY_ACTIVATED = "deferred.activated" as const;
+
+export interface ToolSearchOptions {
+  /**
+   * 工具名 —— 默认 `"toolSearch"`。挂 deferredTools 时把这个名字放进 `alwaysListed`，
+   * 保证它首 turn 就可见。
+   */
+  name?: string;
+}
+
+export function toolSearch(opts: ToolSearchOptions = {}): HarnessTool {
+  const name = opts.name ?? "toolSearch";
+  return {
+    name,
+    description:
+      "Activate deferred tools so they become available next turn. " +
+      "Pass `select` (exact tool names) and/or `keyword` (fuzzy match against tool name + description). " +
+      "Returns the activated tools' schemas. Activation = visibility, not authorization.",
+    parameters: Type.Object({
+      select: Type.Optional(
+        Type.Array(Type.String(), {
+          description: "Exact tool names to activate.",
+        }),
+      ),
+      keyword: Type.Optional(
+        Type.String({
+          description:
+            "Keyword to fuzzy-match against tool name + description; matched tools are activated.",
+        }),
+      ),
+    }),
+    // 写 ctx.state 同一激活集 key —— 屏障型，绝不与同 turn 其他工具并行。
+    isConcurrencySafe: () => false,
+    async execute(args, ctx: HookContext): Promise<ToolExecResult> {
+      const select = (args.select as string[] | undefined) ?? [];
+      const keyword = (args.keyword as string | undefined)?.trim();
+
+      const catalog = ctx.config.tools;
+      const hits = new Set<string>();
+
+      // select：按名精确命中（仅命中确实存在的工具）。
+      const names = new Set(catalog.map((t) => t.name));
+      for (const s of select) {
+        if (names.has(s)) hits.add(s);
+      }
+
+      // keyword：在 name + description 上做最简本地包含匹配（大小写不敏感）。
+      if (keyword) {
+        const kw = keyword.toLowerCase();
+        for (const t of catalog) {
+          const hay = `${t.name} ${t.description}`.toLowerCase();
+          if (hay.includes(kw)) hits.add(t.name);
+        }
+      }
+
+      if (hits.size === 0) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `No tools matched select=${JSON.stringify(
+                select,
+              )} keyword=${JSON.stringify(keyword ?? null)}.`,
+            },
+          ],
+        };
+      }
+
+      const cur = ctx.state.get(KEY_ACTIVATED) ?? new Set<string>();
+      ctx.state.set(KEY_ACTIVATED, new Set([...cur, ...hits]));
+
+      const activatedNames = [...hits];
+      const schemas = catalog
+        .filter((t) => hits.has(t.name))
+        .map((t) => ({
+          name: t.name,
+          description: t.description,
+          parameters: t.parameters,
+        }));
+
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `activated: ${activatedNames.join(", ")} — available next turn.\n` +
+              JSON.stringify(schemas, null, 2),
+          },
+        ],
+      };
+    },
+  };
+}

--- a/packages/plugins/src/tool-search.ts
+++ b/packages/plugins/src/tool-search.ts
@@ -13,8 +13,7 @@
 
 import { Type } from "@harness-pi/core";
 import type { HarnessTool, HookContext, ToolExecResult } from "@harness-pi/core";
-
-const KEY_ACTIVATED = "deferred.activated" as const;
+import { KEY_ACTIVATED } from "./deferred-tools.js";
 
 export interface ToolSearchOptions {
   /**

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-pi/tools",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "First-party coding tools for harness-pi agents",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
**v0.2.4**(patch)。自 v0.2.3 以来 5 个 PR,全部过 review-gate(inline-diff 多轮)+ CI 绿。

## 内容
| | PR | |
|---|---|---|
| O1 | #67 | **deferredTools + 内置 toolSearch**(0.3.0 最大内核改动:新增对称 `transformToolsBeforeLlm` pipe;工具按需激活) |
| O2 | #69 | **skill 插件**(命名 prompt 包,catalog 进 system prompt / invoke 注入 body;复用 O1 seam,零内核) |
| C5 | #71 | **混合 token 计量**(真 usage 基线 + 字符补尾,修 D0 实测 2.18x 残差;autoCompaction 默认采用) |
| X4 | #73 | **token-budget 每 turn 持续注入 remaining** + 临界 urgency(补 0.9~1.0 反馈缺口) |
| C3 | #75 | **CompactResumeFromBoundary**(overflow→写 boundary→resume 续跑,保留压缩成果;compactRestartFresh 的兄弟) |

**Wave B 至此全部完成**(S1/S2/C1/C2 在 v0.2.2;X1/X2/C5/C3 + Sub-Agent S3 在 v0.2.3/v0.2.4)。

## ⚠️ CHANGELOG / 迁移注意
- **加性内核**:新增 `Hook.transformToolsBeforeLlm` pipe(裸 `Tool[]`,listing-only,不影响 execution);`SessionConfigView` 此前已扩(v0.2.3)。不启用 deferredTools 时行为与旧版一致。
- **autoCompaction 默认 counter** 改 `hybridTokenCounter`(有真 usage 时更准;无真 usage 退回 X1 estimateRequestTokens = 旧默认 → fake/turn-0 行为不变)。
- **token-budget**:反馈从 onTurnEnd 条件 nudge 改为 onTurnStart 每 turn 注入 remaining;`completionThreshold` 语义从「停 nudge」→「urgency 升级阈值」;`nudgeMessage` 形参语义=累计 used tokens。`budget=null/0` 仍 noop。
- 新增 plugins 导出:`deferredTools`/`toolSearch`/`skills`/`hybridTokenCounter`/`CompactResumeFromBoundary`(+ 类型)。

## 验证
全仓 `pnpm -r build/typecheck/test` 全绿(core 286 / plugins 345 / tools 59 / adapters 61+18skip / coding-agent 240 / examples 3)。每个 PR 经确定性 inline-diff review-gate 3/3 PASS(domain-free / tools-frozen / execution-listing 解耦等不变量逐条对照真 source 核验)。