### PR TITLE
feat(plugins): Wave C zero-kernel enhancements — S4 + O3 + C4

### DIFF
--- a/packages/plugins/src/__tests__/gap-explorer.test.ts
+++ b/packages/plugins/src/__tests__/gap-explorer.test.ts
@@ -8,6 +8,7 @@ import { createFakeModel, createTestContext } from "@harness-pi/core/testing";
 import {
   subAgentTool,
   routedSubAgentTool,
+  SubAgentRegistry,
   GapExplorer,
   type Gap,
   type ExplorerFinding,
@@ -37,6 +38,49 @@ describe("subAgentTool", () => {
     const details = result.details as { subAgent?: { reason?: string; turns?: number } } | undefined;
     expect(details?.subAgent?.reason).toBe("done");
     expect(details?.subAgent?.turns).toBe(1);
+    subFake.teardown();
+  });
+
+  it("delivers the sub-agent sessionId + usage in details (typed delivery, S4)", async () => {
+    const subFake = createFakeModel([
+      { content: [{ type: "text", text: "ans" }], stopReason: "stop", usage: { input: 7, output: 4 } },
+    ]);
+    let subId = "";
+    const tool = subAgentTool({
+      sessionFactory: () => {
+        const s = new AgentSession({ model: subFake, tools: [] });
+        subId = s.id;
+        return s;
+      },
+    });
+    const { ctx } = createTestContext();
+    const result = await tool.execute({ task: "do X" }, ctx, new AbortController().signal);
+    const details = result.details as
+      | { subAgent?: { sessionId?: string; usage?: { input?: number; output?: number } } }
+      | undefined;
+    expect(details?.subAgent?.sessionId).toBe(subId);
+    expect(details?.subAgent?.usage?.input).toBe(7);
+    expect(details?.subAgent?.usage?.output).toBe(4);
+    subFake.teardown();
+  });
+
+  it("does NOT retain the sub-agent when no registry is wired (0.2.4 regression)", async () => {
+    // 默认（不接 onSpawn）→ 子 session 跑完即弃。建一个 registry 但**不接到** tool 上：spawn 后 registry 仍为空，
+    // 续聊该 id 报「未保留」。证明启用新能力前行为与现状一致：句柄不外泄、不被保留。
+    const subFake = createFakeModel([{ content: [{ type: "text", text: "ok" }], stopReason: "stop" }]);
+    const registry = new SubAgentRegistry();
+    let subId = "";
+    const tool = subAgentTool({
+      sessionFactory: () => {
+        const s = new AgentSession({ model: subFake, tools: [] });
+        subId = s.id;
+        return s;
+      },
+      // 故意不传 onSpawn —— 复刻 0.2.4 默认配置。
+    });
+    await tool.execute({ task: "t" }, createTestContext().ctx, new AbortController().signal);
+    expect(registry.size).toBe(0);
+    await expect(registry.continueSubAgent(subId, "more")).rejects.toThrow(/no retained sub-agent/);
     subFake.teardown();
   });
 

--- a/packages/plugins/src/__tests__/post-compact-file-reread.test.ts
+++ b/packages/plugins/src/__tests__/post-compact-file-reread.test.ts
@@ -225,4 +225,53 @@ describe("postCompactFileReread", () => {
     expect(sawFresh).toBe(true);
     fake.teardown();
   });
+
+  it("regression: compaction marks reread ONLY on re-summarize turns, not every over-threshold turn", async () => {
+    // 锁住 blocker 回归：messages 是 append-only 原始 _messages，一旦越阈值就**永久**在阈值之上。
+    // 若 marker 每个越界 turn 都置位（旧 bug：set 在重算分支外），postCompactFileReread 会每 turn 重读重注入，
+    // 把刚省下的 token 又灌回去。正确契约：marker 只在「本 turn 真跑了一次新总结」时置位。
+    let summarizeCalls = 0;
+    const hook = compactSummarize({
+      maxMessages: 4,
+      keepRecent: 2,
+      resummarizeEvery: 3, // 想覆盖的前缀每增长 ≥3 条才重算
+      summarize: () => {
+        summarizeCalls++;
+        return "RECAP";
+      },
+    });
+    const mkMsgs = (n: number) =>
+      Array.from({ length: n }, (_, i) => createUserMessage(`m${i}`));
+    const map = new Map<string, unknown>();
+    const ctx = {
+      turnIdx: 0,
+      state: {
+        get: (k: string) => map.get(k),
+        set: (k: string, v: unknown) => void map.set(k, v),
+        has: (k: string) => map.has(k),
+        delete: (k: string) => map.delete(k),
+      },
+    } as unknown as HookContext;
+    const transform = hook.transformMessagesBeforeLlm!;
+
+    // turn A：6 条（>4），cache 空 → 重算 → 置标记。
+    await transform(mkMsgs(6), ctx);
+    expect(summarizeCalls).toBe(1);
+    expect(map.has(POST_COMPACT_PENDING_KEY)).toBe(true);
+    map.delete(POST_COMPACT_PENDING_KEY); // 模拟 reread 在下一 turn 消费即清
+
+    // turn B：7 条（仍 >4，targetCover=5；5-4=1 < 3）→ cache 命中、不重算 → **不**置标记。
+    await transform(mkMsgs(7), ctx);
+    expect(summarizeCalls).toBe(1);
+    expect(map.has(POST_COMPACT_PENDING_KEY)).toBe(false); // 关键：cache-hit 越界 turn 不触发 reread
+
+    // turn C：8 条（targetCover=6；6-4=2 < 3）→ 仍 cache 命中、不置标记。
+    await transform(mkMsgs(8), ctx);
+    expect(map.has(POST_COMPACT_PENDING_KEY)).toBe(false);
+
+    // turn D：10 条（targetCover=8；8-4=4 ≥ 3）→ 重算 → 重新置标记。
+    await transform(mkMsgs(10), ctx);
+    expect(summarizeCalls).toBe(2);
+    expect(map.has(POST_COMPACT_PENDING_KEY)).toBe(true);
+  });
 });

--- a/packages/plugins/src/__tests__/post-compact-file-reread.test.ts
+++ b/packages/plugins/src/__tests__/post-compact-file-reread.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from "vitest";
+import { AgentSession, createUserMessage } from "@harness-pi/core";
+import type { HookContext, Message } from "@harness-pi/core";
+import { createFakeModel } from "@harness-pi/core/testing";
+import {
+  postCompactFileReread,
+  POST_COMPACT_PENDING_KEY,
+} from "../post-compact-file-reread.js";
+import { compactSummarize } from "../compact-summarize.js";
+
+/** assistant message carrying a single tool call (read/edit/write 等)。 */
+function toolCallMsg(name: string, args: Record<string, unknown>): Message {
+  return {
+    role: "assistant",
+    content: [{ type: "toolCall", id: `c-${name}-${JSON.stringify(args)}`, name, arguments: args }],
+    api: "x" as never,
+    provider: "p",
+    model: "m",
+    usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+    stopReason: "toolUse",
+    timestamp: 0,
+  };
+}
+
+/**
+ * 最小 fake HookContext，只实现 postCompactFileReread 实际用到的面：state / messages / log。
+ * 不碰 core 的 createTestContext（它把 messages 钉死成 []），但用真实的 Map 语义。
+ */
+function fakeCtx(messages: Message[], opts: { pending?: number } = {}): HookContext {
+  const map = new Map<string, unknown>();
+  if (opts.pending !== undefined) map.set(POST_COMPACT_PENDING_KEY, opts.pending);
+  return {
+    sessionId: "test",
+    turnIdx: 1,
+    messages,
+    state: {
+      get: (k: string) => map.get(k),
+      set: (k: string, v: unknown) => void map.set(k, v),
+      has: (k: string) => map.has(k),
+      delete: (k: string) => map.delete(k),
+      get size() {
+        return map.size;
+      },
+      clear: () => map.clear(),
+    },
+    log: { debug() {}, info() {}, warn() {}, error() {} },
+  } as unknown as HookContext;
+}
+
+describe("postCompactFileReread", () => {
+  it("does nothing when no compaction is pending (regression: default off / no flag → zero injection)", async () => {
+    let providerCalls = 0;
+    const hook = postCompactFileReread({
+      fileContentProvider: async () => {
+        providerCalls++;
+        return "X";
+      },
+    });
+    const ctx = fakeCtx([toolCallMsg("read", { path: "/a.ts" })]); // 有路径但无 pending 标记
+    const out = await hook.onTurnStart!({ turnIdx: 1 }, ctx);
+
+    expect(out).toBeUndefined();
+    expect(providerCalls).toBe(0); // 没压缩 → 根本不解析
+  });
+
+  it("resolves referenced paths and injects their current content after compaction", async () => {
+    const fs: Record<string, string> = { "/a.ts": "AAA", "/b.ts": "BBB" };
+    const hook = postCompactFileReread({
+      fileContentProvider: async (p) => fs[p] ?? null,
+    });
+    const ctx = fakeCtx(
+      [toolCallMsg("read", { path: "/a.ts" }), toolCallMsg("edit", { path: "/b.ts", oldText: "x", newText: "y" })],
+      { pending: 0 },
+    );
+    const out = await hook.onTurnStart!({ turnIdx: 1 }, ctx);
+
+    expect(out).toBeDefined();
+    const text = (out as { additionalContext: string }).additionalContext;
+    expect(text).toContain('/a.ts');
+    expect(text).toContain("AAA");
+    expect(text).toContain('/b.ts');
+    expect(text).toContain("BBB");
+    // 消费即清：标记被删，下一 turn 不再注入。
+    expect(ctx.state.has(POST_COMPACT_PENDING_KEY)).toBe(false);
+  });
+
+  it("clears the pending flag so a second turn injects nothing", async () => {
+    const hook = postCompactFileReread({ fileContentProvider: async () => "C" });
+    const ctx = fakeCtx([toolCallMsg("read", { path: "/a.ts" })], { pending: 0 });
+
+    const first = await hook.onTurnStart!({ turnIdx: 1 }, ctx);
+    expect(first).toBeDefined();
+    const second = await hook.onTurnStart!({ turnIdx: 2 }, ctx);
+    expect(second).toBeUndefined(); // 标记已被消费
+  });
+
+  it("skips a file when the provider returns null", async () => {
+    const hook = postCompactFileReread({
+      fileContentProvider: async (p) => (p === "/keep.ts" ? "KEPT" : null),
+    });
+    const ctx = fakeCtx(
+      [toolCallMsg("read", { path: "/gone.ts" }), toolCallMsg("read", { path: "/keep.ts" })],
+      { pending: 0 },
+    );
+    const out = await hook.onTurnStart!({ turnIdx: 1 }, ctx);
+    const text = (out as { additionalContext: string }).additionalContext;
+    expect(text).toContain("KEPT");
+    expect(text).not.toContain("/gone.ts");
+  });
+
+  it("returns nothing when every referenced file resolves to null", async () => {
+    const hook = postCompactFileReread({ fileContentProvider: async () => null });
+    const ctx = fakeCtx([toolCallMsg("read", { path: "/a.ts" })], { pending: 0 });
+    expect(await hook.onTurnStart!({ turnIdx: 1 }, ctx)).toBeUndefined();
+  });
+
+  it("bounds the number of files to maxFiles (most-recently-referenced first)", async () => {
+    const calls: string[] = [];
+    const hook = postCompactFileReread({
+      maxFiles: 2,
+      fileContentProvider: async (p) => {
+        calls.push(p);
+        return p;
+      },
+    });
+    // 引用顺序 a,b,c → 倒序收集 = c,b,a → maxFiles 2 取 c,b。
+    const ctx = fakeCtx(
+      [
+        toolCallMsg("read", { path: "/a.ts" }),
+        toolCallMsg("read", { path: "/b.ts" }),
+        toolCallMsg("read", { path: "/c.ts" }),
+      ],
+      { pending: 0 },
+    );
+    const out = await hook.onTurnStart!({ turnIdx: 1 }, ctx);
+    const text = (out as { additionalContext: string }).additionalContext;
+    expect(calls.sort()).toEqual(["/b.ts", "/c.ts"]); // 只解析了最近两个
+    expect(text).not.toContain("/a.ts");
+  });
+
+  it("truncates each file to maxBytes and labels the truncation", async () => {
+    const hook = postCompactFileReread({
+      maxBytes: 10,
+      fileContentProvider: async () => "0123456789ABCDEF", // 16 bytes
+    });
+    const ctx = fakeCtx([toolCallMsg("read", { path: "/big.ts" })], { pending: 0 });
+    const out = await hook.onTurnStart!({ turnIdx: 1 }, ctx);
+    const text = (out as { additionalContext: string }).additionalContext;
+    expect(text).toContain("0123456789");
+    expect(text).not.toContain("ABCDEF"); // 超出 10 字节被切
+    expect(text).toContain("truncated to 10 bytes");
+  });
+
+  it("dedups repeated references to the same path", async () => {
+    let calls = 0;
+    const hook = postCompactFileReread({
+      fileContentProvider: async () => {
+        calls++;
+        return "X";
+      },
+    });
+    const ctx = fakeCtx(
+      [toolCallMsg("read", { path: "/a.ts" }), toolCallMsg("edit", { path: "/a.ts", oldText: "x", newText: "y" })],
+      { pending: 0 },
+    );
+    await hook.onTurnStart!({ turnIdx: 1 }, ctx);
+    expect(calls).toBe(1); // 同一路径只解析一次
+  });
+
+  it("ignores tool calls not in toolNames and missing path args", async () => {
+    let calls = 0;
+    const hook = postCompactFileReread({
+      fileContentProvider: async () => {
+        calls++;
+        return "X";
+      },
+    });
+    const ctx = fakeCtx(
+      [
+        toolCallMsg("bash", { command: "ls" }), // 非文件工具
+        toolCallMsg("read", { offset: 1 }), // read 但没 path
+      ],
+      { pending: 0 },
+    );
+    const out = await hook.onTurnStart!({ turnIdx: 1 }, ctx);
+    expect(out).toBeUndefined();
+    expect(calls).toBe(0);
+  });
+
+  it("rejects invalid bounds at construction", () => {
+    expect(() => postCompactFileReread({ fileContentProvider: async () => "", maxFiles: 0 })).toThrow(/maxFiles/);
+    expect(() => postCompactFileReread({ fileContentProvider: async () => "", maxBytes: 0 })).toThrow(/maxBytes/);
+  });
+
+  it("end-to-end: compaction sets the flag, reread injects current file content on the next turn", async () => {
+    // turn0/turn1：模型连发 read /f.ts toolCall（保持 loop 存活）；turn1 的 LLM call 时消息数 > maxMessages
+    // → compaction 改写 view + set flag；turn2 的 onTurnStart：reread 注入 /f.ts 的"当前"内容，模型本轮 view 应见到它。
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", id: "t1", name: "read", arguments: { path: "/f.ts" } }], stopReason: "toolUse" },
+      { content: [{ type: "toolCall", id: "t2", name: "read", arguments: { path: "/f.ts" } }], stopReason: "toolUse" },
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const readTool = {
+      name: "read",
+      label: "read",
+      description: "read a file",
+      parameters: { type: "object", properties: { path: { type: "string" } } } as never,
+      execute: async () => ({ content: [{ type: "text" as const, text: "OLD_CONTENT" }] }),
+    };
+    const session = new AgentSession({
+      model: fake,
+      tools: [readTool as never],
+      initialMessages: [createUserMessage("p1"), createUserMessage("p2"), createUserMessage("p3")],
+      hooks: [
+        compactSummarize({ maxMessages: 4, keepRecent: 2, summarize: () => "RECAP" }),
+        postCompactFileReread({ fileContentProvider: async (p) => (p === "/f.ts" ? "FRESH_CONTENT" : null) }),
+      ],
+    });
+    await session.run("go");
+
+    // 找一帧 view 含 FRESH_CONTENT（reread 注入的 attachment）。
+    const sawFresh = fake
+      .getCalls()
+      .some((c) => c.messages.some((m) => JSON.stringify(m).includes("FRESH_CONTENT")));
+    expect(sawFresh).toBe(true);
+    fake.teardown();
+  });
+});

--- a/packages/plugins/src/__tests__/sub-agent-registry.test.ts
+++ b/packages/plugins/src/__tests__/sub-agent-registry.test.ts
@@ -85,6 +85,74 @@ describe("SubAgentRegistry — continue handle", () => {
     fakes.forEach((f) => f.teardown());
   });
 
+  it("keeps the most-recently-continued entry under LRU (not FIFO)", async () => {
+    // maxRetained=2，但 a 在 b 之后被续聊 → a 的 recency 刷新到 b 之上。再 spawn c 触发驱逐时，LRU 该逐的是
+    // **最久未用**的 b，而非最早 spawn 的 a。把「LRU≠FIFO」钉死：若实现退化成按插入序逐，本测试会红。
+    const now = { v: 1_000 };
+    vi.spyOn(Date, "now").mockImplementation(() => now.v);
+    const fakes = [0, 1, 2].map(() =>
+      createFakeModel([{ content: [{ type: "text", text: "ok" }], stopReason: "stop" }]),
+    );
+    let i = 0;
+    const registry = new SubAgentRegistry({ maxRetained: 2 });
+    const tool = subAgentTool({
+      sessionFactory: () => new AgentSession({ model: fakes[i++]!, tools: [] }),
+      onSpawn: registry.retain,
+    });
+    const { ctx } = createTestContext();
+    const sig = new AbortController().signal;
+    const idOf = (r: { details?: unknown }) =>
+      (r.details as { subAgent: { sessionId: string } }).subAgent.sessionId;
+
+    now.v = 1_000;
+    const a = idOf(await tool.execute({ task: "a" }, ctx, sig));
+    now.v = 1_001;
+    const b = idOf(await tool.execute({ task: "b" }, ctx, sig));
+    // 续聊 a（@1002）→ 把 a 的 lastUsedMs 刷新到 b 之上。
+    now.v = 1_002;
+    fakes[0]!.push({ content: [{ type: "text", text: "a2" }], stopReason: "stop" });
+    await registry.continueSubAgent(a, "again");
+    // spawn c（@1003）→ 超上限驱逐 LRU = b（1001，最久未用），a（1002）幸免。
+    now.v = 1_003;
+    await tool.execute({ task: "c" }, ctx, sig);
+    expect(registry.size).toBe(2);
+    await expect(registry.continueSubAgent(b, "x")).rejects.toThrow(/no retained sub-agent/);
+    // a 因被续聊过 recency 最新 → 仍可续。
+    fakes[0]!.push({ content: [{ type: "text", text: "a3" }], stopReason: "stop" });
+    expect(blockText((await registry.continueSubAgent(a, "x")).content)).toContain("a3");
+    fakes.forEach((f) => f.teardown());
+  });
+
+  it("sweeps out TTL-expired entries on a new retain (retain-path TTL)", async () => {
+    // retain 路径也扫 TTL：新 spawn 进来时把已过期的旧句柄清掉，而非留到下次 continue 才发现。
+    const now = { v: 1_000 };
+    vi.spyOn(Date, "now").mockImplementation(() => now.v);
+    const fakes = [0, 1].map(() =>
+      createFakeModel([{ content: [{ type: "text", text: "ok" }], stopReason: "stop" }]),
+    );
+    let i = 0;
+    const registry = new SubAgentRegistry({ ttlMs: 100 });
+    const tool = subAgentTool({
+      sessionFactory: () => new AgentSession({ model: fakes[i++]!, tools: [] }),
+      onSpawn: registry.retain,
+    });
+    const { ctx } = createTestContext();
+    const sig = new AbortController().signal;
+    const idOf = (r: { details?: unknown }) =>
+      (r.details as { subAgent: { sessionId: string } }).subAgent.sessionId;
+
+    const s1 = idOf(await tool.execute({ task: "s1" }, ctx, sig));
+    expect(registry.size).toBe(1);
+    // 时钟越过 ttl 后再 spawn s2 → retain 的 TTL 扫描把 s1 清掉。
+    now.v += 101;
+    const s2 = idOf(await tool.execute({ task: "s2" }, ctx, sig));
+    expect(registry.size).toBe(1); // 只剩 s2
+    await expect(registry.continueSubAgent(s1, "x")).rejects.toThrow(/no retained sub-agent/);
+    fakes[1]!.push({ content: [{ type: "text", text: "s2b" }], stopReason: "stop" });
+    expect(blockText((await registry.continueSubAgent(s2, "x")).content)).toContain("s2b");
+    fakes.forEach((f) => f.teardown());
+  });
+
   it("evicts entries that have outlived ttlMs", async () => {
     const now = { v: 1_000 };
     vi.spyOn(Date, "now").mockImplementation(() => now.v);

--- a/packages/plugins/src/__tests__/sub-agent-registry.test.ts
+++ b/packages/plugins/src/__tests__/sub-agent-registry.test.ts
@@ -1,0 +1,137 @@
+/**
+ * S4 — SubAgentRegistry：subAgent 续聊句柄的 bounded registry 行为测试。
+ *
+ * 全部经公共接口断言可观测行为：用 core `testing.ts` 的 fake-model + 真 `AgentSession` 当 sessionFactory，
+ * 由 `subAgentTool({ onSpawn: registry.retain })` 驱动 spawn，再用 `registry.continueSubAgent` 续聊。
+ * TTL/LRU 这类时间相关用 `vi.spyOn(Date, "now")` 注入确定性时钟（registry 用 Date.now() 计时），
+ * 不靠真实 sleep → 无时序竞争。
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { AgentSession } from "@harness-pi/core";
+import { createFakeModel, createTestContext } from "@harness-pi/core/testing";
+import { subAgentTool, SubAgentRegistry } from "../controllers/index.js";
+
+function blockText(content: unknown): string {
+  return Array.isArray(content)
+    ? content.map((b) => ("text" in b ? (b as { text: string }).text : "")).join("")
+    : String(content ?? "");
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("SubAgentRegistry — continue handle", () => {
+  it("resumes a retained sub-agent and the continuation sees prior context", async () => {
+    // 子 fake：首轮回 "first"，续聊回 "second"。续聊时该子 session 的 messages 必含首轮 user prompt + 首轮回答，
+    // 证明续聊看到了之前的上下文（不是全新会话）。
+    const subFake = createFakeModel([
+      { content: [{ type: "text", text: "first" }], stopReason: "stop" },
+      { content: [{ type: "text", text: "second" }], stopReason: "stop" },
+    ]);
+    const registry = new SubAgentRegistry();
+    const tool = subAgentTool({
+      sessionFactory: () => new AgentSession({ model: subFake, tools: [] }),
+      onSpawn: registry.retain,
+    });
+    const { ctx } = createTestContext();
+    const spawn = await tool.execute({ task: "do the first thing" }, ctx, new AbortController().signal);
+    const details = spawn.details as { subAgent?: { sessionId?: string } };
+    const id = details.subAgent!.sessionId!;
+    expect(registry.size).toBe(1);
+
+    const cont = await registry.continueSubAgent(id, "now the second thing");
+    expect(blockText(cont.content)).toContain("second");
+    // 续聊结果 shape 与 spawn 同形：details.subAgent 含同一 sessionId。
+    const contDetails = cont.details as { subAgent?: { sessionId?: string } };
+    expect(contDetails.subAgent?.sessionId).toBe(id);
+
+    // 续聊时 fake 收到的最后一个 context 应包含首轮的 user prompt + 首轮 assistant 回答 → 看见了之前上下文。
+    const lastCtx = subFake.getCalls().at(-1)!;
+    const ctxText = JSON.stringify(lastCtx.messages);
+    expect(ctxText).toContain("do the first thing");
+    expect(ctxText).toContain("first");
+    expect(ctxText).toContain("now the second thing");
+    subFake.teardown();
+  });
+
+  it("evicts the LRU entry once maxRetained is exceeded", async () => {
+    // maxRetained=2：spawn 3 个子 session（每个独立 fake/session）。第 3 个进来时超上限 → 驱逐最久未用的（第 1 个）。
+    const fakes = [0, 1, 2].map(() =>
+      createFakeModel([{ content: [{ type: "text", text: "ok" }], stopReason: "stop" }]),
+    );
+    let i = 0;
+    const registry = new SubAgentRegistry({ maxRetained: 2 });
+    const tool = subAgentTool({
+      sessionFactory: () => new AgentSession({ model: fakes[i++]!, tools: [] }),
+      onSpawn: registry.retain,
+    });
+    const { ctx } = createTestContext();
+    const sig = new AbortController().signal;
+    const ids: string[] = [];
+    for (const task of ["a", "b", "c"]) {
+      const r = await tool.execute({ task }, ctx, sig);
+      ids.push((r.details as { subAgent: { sessionId: string } }).subAgent.sessionId);
+    }
+    expect(registry.size).toBe(2);
+    // 第 1 个（最久未用）被 LRU 驱逐 → 续聊报错；第 2、3 个仍在。
+    await expect(registry.continueSubAgent(ids[0]!, "x")).rejects.toThrow(/no retained sub-agent/);
+    // 给后两个补一条续聊脚本再验证它们仍可续。
+    fakes[1]!.push({ content: [{ type: "text", text: "b2" }], stopReason: "stop" });
+    fakes[2]!.push({ content: [{ type: "text", text: "c2" }], stopReason: "stop" });
+    expect(blockText((await registry.continueSubAgent(ids[1]!, "x")).content)).toContain("b2");
+    expect(blockText((await registry.continueSubAgent(ids[2]!, "x")).content)).toContain("c2");
+    fakes.forEach((f) => f.teardown());
+  });
+
+  it("evicts entries that have outlived ttlMs", async () => {
+    const now = { v: 1_000 };
+    vi.spyOn(Date, "now").mockImplementation(() => now.v);
+    const subFake = createFakeModel([{ content: [{ type: "text", text: "ok" }], stopReason: "stop" }]);
+    const registry = new SubAgentRegistry({ ttlMs: 100 });
+    const tool = subAgentTool({
+      sessionFactory: () => new AgentSession({ model: subFake, tools: [] }),
+      onSpawn: registry.retain,
+    });
+    const { ctx } = createTestContext();
+    const r = await tool.execute({ task: "t" }, ctx, new AbortController().signal);
+    const id = (r.details as { subAgent: { sessionId: string } }).subAgent.sessionId;
+    expect(registry.size).toBe(1);
+
+    // 时钟推进超过 ttl → 下一次 continue 前的 TTL 扫描把它驱逐 → 报「未保留」。
+    now.v += 101;
+    await expect(registry.continueSubAgent(id, "x")).rejects.toThrow(/no retained sub-agent/);
+    expect(registry.size).toBe(0);
+    subFake.teardown();
+  });
+
+  it("clears all retained sessions when the parent signal aborts (no leak)", async () => {
+    const subFake = createFakeModel([
+      { content: [{ type: "text", text: "1" }], stopReason: "stop" },
+      { content: [{ type: "text", text: "2" }], stopReason: "stop" },
+    ]);
+    const parent = new AbortController();
+    const registry = new SubAgentRegistry({ parentSignal: parent.signal });
+    const tool = subAgentTool({
+      sessionFactory: () => new AgentSession({ model: subFake, tools: [] }),
+      onSpawn: registry.retain,
+    });
+    const { ctx } = createTestContext();
+    const r = await tool.execute({ task: "a" }, ctx, new AbortController().signal);
+    const id = (r.details as { subAgent: { sessionId: string } }).subAgent.sessionId;
+    expect(registry.size).toBe(1);
+
+    parent.abort();
+    expect(registry.size).toBe(0); // 全清空 → 句柄不在 abort 后泄漏
+    await expect(registry.continueSubAgent(id, "b")).rejects.toThrow(/no retained sub-agent/);
+    subFake.teardown();
+  });
+
+  it("throws a clear error for an unknown / never-retained id", async () => {
+    const registry = new SubAgentRegistry();
+    await expect(registry.continueSubAgent("nope", "x")).rejects.toThrow(
+      /no retained sub-agent for id "nope"/,
+    );
+  });
+});

--- a/packages/plugins/src/__tests__/summary-template.test.ts
+++ b/packages/plugins/src/__tests__/summary-template.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { createUserMessage } from "@harness-pi/core";
+import { createTestContext } from "@harness-pi/core/testing";
+import type { Message } from "@earendil-works/pi-ai";
+import {
+  defaultSummarize,
+  renderSummaryPrompt,
+  DEFAULT_SUMMARY_TEMPLATE,
+} from "../summary-template.js";
+
+const NINE_SECTIONS = [
+  "Primary Request and Intent",
+  "Key Concepts",
+  "Files and Resources",
+  "Errors and Fixes",
+  "Problem Solving",
+  "All User Messages",
+  "Pending Tasks",
+  "Current Work",
+  "Next Step",
+];
+
+describe("defaultSummarize / summary template", () => {
+  it("renders all 9 sections into the prompt", async () => {
+    let seen = "";
+    const summarize = defaultSummarize({
+      complete: async (p) => {
+        seen = p;
+        return "SUMMARY";
+      },
+    });
+    const { ctx } = createTestContext();
+    const out = await summarize([createUserMessage("hello")], ctx);
+
+    expect(out).toBe("SUMMARY");
+    for (const [i, label] of NINE_SECTIONS.entries()) {
+      expect(seen).toContain(`${i + 1}. ${label}`);
+    }
+  });
+
+  it("embeds early message content into the transcript", async () => {
+    let seen = "";
+    const summarize = defaultSummarize({
+      complete: async (p) => {
+        seen = p;
+        return "S";
+      },
+    });
+    const assistant: Message = {
+      role: "assistant",
+      content: [{ type: "text", text: "ASSISTANT_SAID_THIS" }],
+      api: "x" as never,
+      provider: "p",
+      model: "m",
+      usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+      stopReason: "stop",
+      timestamp: 0,
+    };
+    const { ctx } = createTestContext();
+    await summarize([createUserMessage("USER_ASKED_THIS"), assistant], ctx);
+
+    expect(seen).toContain("USER_ASKED_THIS");
+    expect(seen).toContain("ASSISTANT_SAID_THIS");
+    expect(seen).toContain("user: USER_ASKED_THIS");
+    expect(seen).toContain("assistant: ASSISTANT_SAID_THIS");
+  });
+
+  it("includes tool call args and tool result names in the transcript", async () => {
+    let seen = "";
+    const summarize = defaultSummarize({ complete: async (p) => ((seen = p), "S") });
+    const assistant: Message = {
+      role: "assistant",
+      content: [{ type: "toolCall", id: "c1", name: "read", arguments: { path: "/etc/hosts" } }],
+      api: "x" as never,
+      provider: "p",
+      model: "m",
+      usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+      stopReason: "toolUse",
+      timestamp: 0,
+    };
+    const toolResult: Message = {
+      role: "toolResult",
+      toolCallId: "c1",
+      toolName: "read",
+      content: [{ type: "text", text: "FILE_BODY" }],
+      isError: false,
+      timestamp: 0,
+    };
+    const { ctx } = createTestContext();
+    await summarize([assistant, toolResult], ctx);
+
+    expect(seen).toContain("read");
+    expect(seen).toContain("/etc/hosts");
+    expect(seen).toContain("toolResult(read): FILE_BODY");
+  });
+
+  it("a custom template overrides the default and still receives the transcript", async () => {
+    let seen = "";
+    const summarize = defaultSummarize({
+      complete: async (p) => ((seen = p), "S"),
+      template: "ONLY_THIS {transcript} END",
+    });
+    const { ctx } = createTestContext();
+    await summarize([createUserMessage("payload")], ctx);
+
+    expect(seen).toContain("ONLY_THIS");
+    expect(seen).toContain("payload");
+    expect(seen).not.toContain("Primary Request and Intent"); // 默认 9 段未出现
+    expect(seen).toBe("ONLY_THIS user: payload END");
+  });
+
+  it("renderSummaryPrompt defaults to the 9-section template", () => {
+    const out = renderSummaryPrompt([createUserMessage("x")]);
+    expect(out).toBe(DEFAULT_SUMMARY_TEMPLATE.replace("{transcript}", "user: x"));
+  });
+});

--- a/packages/plugins/src/__tests__/turn-end-guard.test.ts
+++ b/packages/plugins/src/__tests__/turn-end-guard.test.ts
@@ -33,6 +33,21 @@ describe("turnEndGuard", () => {
     ).toThrow();
   });
 
+  it("sets a generous default hook timeout (event-class 100ms is too short for I/O checks)", () => {
+    // onContinuationCheck 是 event 类、dispatcher 默认仅 100ms；check 做 I/O 必然超时被静默丢弃 → 闸失效。
+    // 故返回 Hook 自设宽 timeout（默认 30s），可经 timeoutMs 覆盖。
+    expect(turnEndGuard({ check: () => ({ ok: true }) }).timeout).toBe(30_000);
+    expect(
+      turnEndGuard({ check: () => ({ ok: true }), timeoutMs: 5_000 }).timeout,
+    ).toBe(5_000);
+  });
+
+  it("throws if timeoutMs <= 0", () => {
+    expect(() =>
+      turnEndGuard({ check: () => ({ ok: true }), timeoutMs: 0 }),
+    ).toThrow();
+  });
+
   it("blocks stop: persists blocking message + forces a retry, then passes", async () => {
     // 两条 assistant 回复：第一条「以为做完了」，第二条是看到阻断消息后的「修好了」。
     const model = createFakeModel([
@@ -182,9 +197,10 @@ describe("turnEndGuard", () => {
     expect(injected).toHaveLength(1);
   });
 
-  it("retry budget resets after a pass (independent stop events within one run)", async () => {
-    // 序列：done → check fail（强制）→ fixed → check pass（放行）。
-    // 用 state 重置语义保证一次 pass 后预算回满（这里只验证 pass 后能正常停，不串味）。
+  it("passes cleanly when check is satisfied on the retry (single fail→force→pass cycle)", async () => {
+    // 序列：done → check fail（强制一轮）→ fixed → check pass（放行）。maxRetries=1 下走完一个
+    // fail→force→pass 周期后干净停止。（注：一次 pass 即终止本 run，故「pass 后预算回满」无法在单 run 内
+    // 再触发一次 fail 来观测——那条 reset 分支与 onSessionStart 的重置在 continue() 场景才各自有意义。）
     const model = createFakeModel([
       { content: [{ type: "text", text: "v1" }] },
       { content: [{ type: "text", text: "v2" }] },

--- a/packages/plugins/src/__tests__/turn-end-guard.test.ts
+++ b/packages/plugins/src/__tests__/turn-end-guard.test.ts
@@ -1,0 +1,211 @@
+/**
+ * turnEndGuard 单测 —— 跑真实 AgentSession + fake LLM，验证 stopHook 式质量闸。
+ *
+ * 覆盖：
+ *   1. 校验失败 → 持久阻断消息进 session.messages + 强制再跑一轮 → 修好后通过 → 正常停止
+ *   2. maxRetries 到上限后放行停止，不无限空转
+ *   3. 回归：不挂 turnEndGuard 时续跑行为与基线一致（无续跑、continuations=0）
+ *   4. 多个 onContinuationCheck hook 共存时合并语义正确（continue:true 不被沉默 hook 覆盖）
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  AgentSession,
+  type Hook,
+  type HookContext,
+  type Message,
+} from "@harness-pi/core";
+import { createFakeModel } from "@harness-pi/core/testing";
+import { turnEndGuard } from "../index.js";
+
+function userText(m: Message): string {
+  if (m.role !== "user") return "";
+  if (typeof m.content === "string") return m.content;
+  return m.content
+    .map((b) => (b.type === "text" ? b.text : ""))
+    .join("");
+}
+
+describe("turnEndGuard", () => {
+  it("throws if maxRetries <= 0", () => {
+    expect(() =>
+      turnEndGuard({ check: () => ({ ok: true }), maxRetries: 0 }),
+    ).toThrow();
+  });
+
+  it("blocks stop: persists blocking message + forces a retry, then passes", async () => {
+    // 两条 assistant 回复：第一条「以为做完了」，第二条是看到阻断消息后的「修好了」。
+    const model = createFakeModel([
+      { content: [{ type: "text", text: "done (attempt 1)" }] },
+      { content: [{ type: "text", text: "fixed (attempt 2)" }] },
+    ]);
+
+    // check 第一次 fail、第二次 pass。
+    let calls = 0;
+    const check = vi.fn((_ctx: HookContext) => {
+      calls++;
+      return calls === 1
+        ? { ok: false, message: "tests failed: 1 red. fix before stopping." }
+        : { ok: true };
+    });
+
+    const session = new AgentSession({
+      model,
+      tools: [],
+      hooks: [turnEndGuard({ check })],
+    });
+    const summary = await session.run("go");
+
+    // 校验跑了两次（fail → 续跑 → pass）。
+    expect(check).toHaveBeenCalledTimes(2);
+    // session 正常停止（不是 max_continuations）。
+    expect(summary.reason).toBe("done");
+    // 续跑恰好 1 次。
+    expect(summary.continuations).toBe(1);
+
+    // 阻断消息**持久**注入 session.messages（user role），下次 LLM call 可见。
+    const injected = session.messages.filter((m) =>
+      userText(m).includes("tests failed: 1 red"),
+    );
+    expect(injected).toHaveLength(1);
+
+    // 模型在第二轮确实看到了阻断消息（fake provider 记录的 context）。
+    const lastCtx = model.getCalls().at(-1)!;
+    const sawBlock = lastCtx.messages.some((m) =>
+      userText(m as Message).includes("tests failed: 1 red"),
+    );
+    expect(sawBlock).toBe(true);
+  });
+
+  it("uses fallback blocking message when check omits message", async () => {
+    const model = createFakeModel([
+      { content: [{ type: "text", text: "a" }] },
+      { content: [{ type: "text", text: "b" }] },
+    ]);
+    let calls = 0;
+    const session = new AgentSession({
+      model,
+      tools: [],
+      hooks: [
+        turnEndGuard({
+          check: () => {
+            calls++;
+            return calls === 1 ? { ok: false } : { ok: true };
+          },
+        }),
+      ],
+    });
+    await session.run("go");
+    const injected = session.messages.filter((m) =>
+      userText(m).includes("turn-end-guard:"),
+    );
+    expect(injected).toHaveLength(1);
+  });
+
+  it("stops forcing after maxRetries exhausted (allows stop, no infinite spin)", async () => {
+    // check 永远 fail。
+    const model = createFakeModel([]); // fake 自动补 "[no more scripted responses]"
+    const check = vi.fn(() => ({ ok: false, message: "still red" }));
+
+    const session = new AgentSession({
+      model,
+      tools: [],
+      // maxRetries=2 远小于内核 maxContinuations，确保是插件侧兜底先生效。
+      hooks: [turnEndGuard({ check, maxRetries: 2 })],
+      maxContinuations: 10,
+    });
+    const summary = await session.run("go");
+
+    // check 被调 maxRetries+1 次：2 次强制续跑 + 第 3 次发现预算用尽放行。
+    expect(check).toHaveBeenCalledTimes(3);
+    // 插件放行停止（done），不是内核 max_continuations 兜底。
+    expect(summary.reason).toBe("done");
+    expect(summary.continuations).toBe(2);
+
+    // 注入了 2 条阻断消息（每次强制各一条）。
+    const injected = session.messages.filter((m) =>
+      userText(m).includes("still red"),
+    );
+    expect(injected).toHaveLength(2);
+  });
+
+  it("regression: without turnEndGuard, no continuation happens", async () => {
+    const model = createFakeModel([
+      { content: [{ type: "text", text: "done" }] },
+    ]);
+    const session = new AgentSession({
+      model,
+      tools: [],
+      hooks: [],
+    });
+    const summary = await session.run("go");
+    expect(summary.reason).toBe("done");
+    expect(summary.continuations).toBe(0);
+  });
+
+  it("coexists with another onContinuationCheck hook (continue:true not masked)", async () => {
+    const model = createFakeModel([
+      { content: [{ type: "text", text: "done 1" }] },
+      { content: [{ type: "text", text: "fixed 2" }] },
+    ]);
+
+    // 一个沉默的 onContinuationCheck hook（不返回 continue），不应屏蔽 turnEndGuard 的强制续跑。
+    const silent: Hook = {
+      name: "silent-cc",
+      onContinuationCheck() {
+        return { additionalContext: "fyi" };
+      },
+    };
+
+    let calls = 0;
+    const session = new AgentSession({
+      model,
+      tools: [],
+      hooks: [
+        silent,
+        turnEndGuard({
+          check: () => {
+            calls++;
+            return calls === 1 ? { ok: false, message: "blocked" } : { ok: true };
+          },
+        }),
+      ],
+    });
+    const summary = await session.run("go");
+
+    // mergeResults：沉默 hook 的 additionalContext 不算决断，turnEndGuard 的 continue:true 仍生效。
+    expect(summary.continuations).toBe(1);
+    expect(summary.reason).toBe("done");
+    const injected = session.messages.filter((m) =>
+      userText(m).includes("blocked"),
+    );
+    expect(injected).toHaveLength(1);
+  });
+
+  it("retry budget resets after a pass (independent stop events within one run)", async () => {
+    // 序列：done → check fail（强制）→ fixed → check pass（放行）。
+    // 用 state 重置语义保证一次 pass 后预算回满（这里只验证 pass 后能正常停，不串味）。
+    const model = createFakeModel([
+      { content: [{ type: "text", text: "v1" }] },
+      { content: [{ type: "text", text: "v2" }] },
+    ]);
+    let calls = 0;
+    const session = new AgentSession({
+      model,
+      tools: [],
+      hooks: [
+        turnEndGuard({
+          check: () => {
+            calls++;
+            return calls === 1 ? { ok: false, message: "x" } : { ok: true };
+          },
+          maxRetries: 1,
+        }),
+      ],
+    });
+    const summary = await session.run("go");
+    // maxRetries=1：第一次 fail 强制一轮（用尽预算前还差），第二次 pass 放行。
+    expect(summary.reason).toBe("done");
+    expect(summary.continuations).toBe(1);
+  });
+});

--- a/packages/plugins/src/auto-compaction.ts
+++ b/packages/plugins/src/auto-compaction.ts
@@ -25,6 +25,7 @@
 import type { Hook, HookContext } from "@harness-pi/core";
 import { createUserMessage } from "@harness-pi/core";
 import type { Message, Tool } from "@earendil-works/pi-ai";
+import { POST_COMPACT_PENDING_KEY } from "./post-compact-file-reread.js";
 
 export interface AutoCompactionOptions {
   /**
@@ -333,10 +334,11 @@ export function autoCompaction(opts: AutoCompactionOptions): Hook {
         // 赋值在 await 之后，抛错时 cache 不被脏写。
         const text = await opts.summarize(messages.slice(0, targetCover), ctx);
         cache = { coveredCount: targetCover, text };
+        // 仅在**本 turn 真跑了一次新总结**时标记，供 postCompactFileReread 下一 turn 重读关键文件
+        // （opt-in，缺该插件无副作用）。**不可**放在分支外：messages 是 append-only 原始 _messages，
+        // 一旦越阈值就永久在阈值之上，分支外 set 会让每个越界 turn 都重置标记 → 重读每 turn 重复注入。
+        ctx.state.set(POST_COMPACT_PENDING_KEY, ctx.turnIdx);
       }
-
-      // 标记「本 turn 发生了压缩」，供 postCompactFileReread 在下一 turn 重读关键文件（opt-in，缺该插件无副作用）。
-      ctx.state.set("post-compact-file-reread.pending", ctx.turnIdx);
 
       const summaryMsg = createUserMessage(wrap(cache.text, cache.coveredCount));
       return [summaryMsg, ...messages.slice(cache.coveredCount)];

--- a/packages/plugins/src/auto-compaction.ts
+++ b/packages/plugins/src/auto-compaction.ts
@@ -335,6 +335,9 @@ export function autoCompaction(opts: AutoCompactionOptions): Hook {
         cache = { coveredCount: targetCover, text };
       }
 
+      // 标记「本 turn 发生了压缩」，供 postCompactFileReread 在下一 turn 重读关键文件（opt-in，缺该插件无副作用）。
+      ctx.state.set("post-compact-file-reread.pending", ctx.turnIdx);
+
       const summaryMsg = createUserMessage(wrap(cache.text, cache.coveredCount));
       return [summaryMsg, ...messages.slice(cache.coveredCount)];
     },

--- a/packages/plugins/src/compact-summarize.ts
+++ b/packages/plugins/src/compact-summarize.ts
@@ -19,6 +19,7 @@
 import type { Hook, HookContext } from "@harness-pi/core";
 import { createUserMessage } from "@harness-pi/core";
 import type { Message } from "@earendil-works/pi-ai";
+import { POST_COMPACT_PENDING_KEY } from "./post-compact-file-reread.js";
 
 export interface CompactSummarizeOptions {
   /** 触发阈值：messages 条数 > maxMessages 才压缩。须 > keepRecent。 */
@@ -77,13 +78,14 @@ export function compactSummarize(opts: CompactSummarizeOptions): Hook {
         // 关键：赋值在 await 之后，抛错时 cache 不被脏写，下次成功调用从头算。
         const text = await opts.summarize(messages.slice(0, targetCover), ctx);
         cache = { coveredCount: targetCover, text };
+        // 仅在**本 turn 真跑了一次新总结**时标记，供 postCompactFileReread 下一 turn 重读关键文件
+        // （opt-in，缺该插件无副作用）。**不可**放在分支外：messages 是 append-only 原始 _messages，
+        // 一旦越阈值就永久在阈值之上，分支外 set 会让每个越界 turn 都重置标记 → 重读每 turn 重复注入。
+        ctx.state.set(POST_COMPACT_PENDING_KEY, ctx.turnIdx);
       }
 
       // summary 用 role:"user" 承载（一条"用户从没发过的回顾 turn"）——对齐 Claude Code 的 compaction
       // 惯例，且 pi-ai 无独立 system role；不用 attachment 是因为它要稳定占据前缀、参与 cache。
-      // 标记「本 turn 发生了压缩」，供 postCompactFileReread 在下一 turn 重读关键文件（opt-in，缺该插件无副作用）。
-      ctx.state.set("post-compact-file-reread.pending", ctx.turnIdx);
-
       const summaryMsg = createUserMessage(wrap(cache.text, cache.coveredCount));
       // view = [summary(覆盖前 coveredCount 条)] + 其后全部原样（含未重算的早期 + recent tail）。
       // 无缝无重叠：slice 起点正是 coveredCount。stable-state 下 tail 在两次重算间从 keepRecent

--- a/packages/plugins/src/compact-summarize.ts
+++ b/packages/plugins/src/compact-summarize.ts
@@ -81,6 +81,9 @@ export function compactSummarize(opts: CompactSummarizeOptions): Hook {
 
       // summary 用 role:"user" 承载（一条"用户从没发过的回顾 turn"）——对齐 Claude Code 的 compaction
       // 惯例，且 pi-ai 无独立 system role；不用 attachment 是因为它要稳定占据前缀、参与 cache。
+      // 标记「本 turn 发生了压缩」，供 postCompactFileReread 在下一 turn 重读关键文件（opt-in，缺该插件无副作用）。
+      ctx.state.set("post-compact-file-reread.pending", ctx.turnIdx);
+
       const summaryMsg = createUserMessage(wrap(cache.text, cache.coveredCount));
       // view = [summary(覆盖前 coveredCount 条)] + 其后全部原样（含未重算的早期 + recent tail）。
       // 无缝无重叠：slice 起点正是 coveredCount。stable-state 下 tail 在两次重算间从 keepRecent

--- a/packages/plugins/src/controllers/index.ts
+++ b/packages/plugins/src/controllers/index.ts
@@ -54,12 +54,15 @@ export type {
   CompactResumeResult,
 } from "./compact-resume-from-boundary.js";
 
-export { subAgentTool, routedSubAgentTool } from "./sub-agent-tool.js";
+export { subAgentTool, routedSubAgentTool, subAgentResult } from "./sub-agent-tool.js";
 export type {
   SubAgentToolOptions,
   AgentSpec,
   RoutedSubAgentToolOptions,
 } from "./sub-agent-tool.js";
+
+export { SubAgentRegistry } from "./sub-agent-registry.js";
+export type { SubAgentRegistryOptions } from "./sub-agent-registry.js";
 
 export { persistCompactionBoundary } from "./persist-compaction-boundary.js";
 export type { PersistCompactionBoundaryOptions } from "./persist-compaction-boundary.js";

--- a/packages/plugins/src/controllers/sub-agent-registry.ts
+++ b/packages/plugins/src/controllers/sub-agent-registry.ts
@@ -1,0 +1,134 @@
+/**
+ * subAgent 续聊句柄 —— 一个 **bounded** registry：把已 spawn 的子 session 按 id 留住，让父能按 id 续聊（S4 / 0.3.0）。
+ *
+ * **资源安全是头等约束**：cc 曾因 sub-agent 句柄无界保留爆 36.8GB 内存。故本 registry 三道闸：
+ *   - **硬上限** `maxRetained`（默认 16）：超上限按 **LRU** 驱逐最久未用的；
+ *   - **TTL** `ttlMs`（默认 5 分钟）：每次 retain/continue 前先扫掉过期项；
+ *   - **父 abort 清空**：父 signal abort → 清空全部（子 session 不再可续，让 GC 回收）。
+ *
+ * **opt-in**：默认 `subAgentTool` 不接 registry（子 session 跑完即弃，0.2.4 逐字节一致）。只有调用方把
+ * `registry.retain` 接到 `subAgentTool({ onSpawn })` 上，子 session 才被留住。
+ *
+ * **domain-free**：registry 不认识任何业务；它只持有 AgentSession 句柄 + 调内核已有的 `session.run(...)`。
+ */
+
+import type { AgentSession, ToolExecResult } from "@harness-pi/core";
+import { subAgentResult } from "./sub-agent-tool.js";
+
+/** 一个被留住的子 session 句柄 + 它最后一次被用到的时刻（LRU/TTL 判据）。 */
+interface RetainedEntry {
+  session: AgentSession;
+  lastUsedMs: number;
+}
+
+export interface SubAgentRegistryOptions {
+  /** 最多留住多少个子 session（**硬上限**，超出按 LRU 驱逐）。默认 16。 */
+  maxRetained?: number;
+  /** 留存存活时长（毫秒）；超过未用即被驱逐。默认 5 分钟。 */
+  ttlMs?: number;
+  /**
+   * 父 session 的 abort signal。一旦 abort → 清空全部留存（子 session 不再可续）。
+   * 不传则不绑定（调用方需自行管理生命周期 / 显式 `clear()`）。
+   */
+  parentSignal?: AbortSignal;
+}
+
+const DEFAULT_MAX_RETAINED = 16;
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * Bounded sub-agent 续聊 registry。典型用法：
+ *
+ * ```ts
+ * const registry = new SubAgentRegistry({ parentSignal: ctx.signal });
+ * const tool = subAgentTool({ sessionFactory, onSpawn: registry.retain });
+ * // 父模型先 spawn（details.subAgent.sessionId 拿到 id），之后：
+ * const result = await registry.continueSubAgent(id, "再补一句", { signal });
+ * ```
+ */
+export class SubAgentRegistry {
+  private readonly _maxRetained: number;
+  private readonly _ttlMs: number;
+  private readonly _entries = new Map<string, RetainedEntry>();
+
+  constructor(opts: SubAgentRegistryOptions = {}) {
+    this._maxRetained = opts.maxRetained ?? DEFAULT_MAX_RETAINED;
+    this._ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS;
+    // 父 abort → 清空全部（资源安全：句柄不在 abort 后泄漏）。once 即可，abort 不可逆。
+    opts.parentSignal?.addEventListener("abort", () => this.clear(), { once: true });
+  }
+
+  /** 当前留存数量（测试 / 观测用）。 */
+  get size(): number {
+    return this._entries.size;
+  }
+
+  /**
+   * retain 回调：接到 `subAgentTool({ onSpawn })` 上，把 spawn 出的子 session 留住。
+   * 箭头属性（非方法）→ 解构传递时 `this` 不丢。retain 时先扫 TTL 过期项，再按 LRU 收口到上限内。
+   */
+  readonly retain = (session: AgentSession): void => {
+    const now = Date.now();
+    this._evictExpired(now);
+    // 重复 retain 同一 id：刷新 lastUsedMs（视为「刚用过」），不重复占名额。
+    this._entries.set(session.id, { session, lastUsedMs: now });
+    this._evictOverflow();
+  };
+
+  /**
+   * 按 id 续聊一个已留住的子 session：调内核已有的 `session.run(message)`（追加新 user prompt 跑到结束，
+   * 保留此前上下文）→ 返回与 `spawnSubAgent` **同形状**的 ToolExecResult（text + details 含 sessionId + usage）。
+   *
+   * id 不存在 / 已被驱逐（LRU/TTL/abort）→ 抛清晰 error（不静默返回空）。
+   */
+  async continueSubAgent(
+    id: string,
+    message: string,
+    runOpts?: { signal?: AbortSignal },
+  ): Promise<ToolExecResult> {
+    const now = Date.now();
+    this._evictExpired(now);
+    const entry = this._entries.get(id);
+    if (!entry) {
+      throw new Error(
+        `SubAgentRegistry: no retained sub-agent for id "${id}" ` +
+          `(unknown, or evicted by TTL/LRU/parent-abort)`,
+      );
+    }
+    entry.lastUsedMs = now;
+    const summary = await entry.session.run(message, runOpts);
+    // 续聊后再刷新一次：run 可能耗时较长，按「用完」的时刻记 lastUsedMs，LRU 更准。
+    entry.lastUsedMs = Date.now();
+    return subAgentResult(entry.session, summary);
+  }
+
+  /** 清空全部留存（父 abort 时自动调；也可手动调）。 */
+  clear(): void {
+    this._entries.clear();
+  }
+
+  /** 扫掉所有超过 TTL 的项。 */
+  private _evictExpired(now: number): void {
+    for (const [id, entry] of this._entries) {
+      if (now - entry.lastUsedMs >= this._ttlMs) {
+        this._entries.delete(id);
+      }
+    }
+  }
+
+  /** 超上限则按 LRU（lastUsedMs 最小）逐个驱逐，直到收口到上限内。 */
+  private _evictOverflow(): void {
+    while (this._entries.size > this._maxRetained) {
+      let lruId: string | undefined;
+      let lruMs = Infinity;
+      for (const [id, entry] of this._entries) {
+        if (entry.lastUsedMs < lruMs) {
+          lruMs = entry.lastUsedMs;
+          lruId = id;
+        }
+      }
+      if (lruId === undefined) break;
+      this._entries.delete(lruId);
+    }
+  }
+}

--- a/packages/plugins/src/controllers/sub-agent-registry.ts
+++ b/packages/plugins/src/controllers/sub-agent-registry.ts
@@ -80,6 +80,9 @@ export class SubAgentRegistry {
    * 保留此前上下文）→ 返回与 `spawnSubAgent` **同形状**的 ToolExecResult（text + details 含 sessionId + usage）。
    *
    * id 不存在 / 已被驱逐（LRU/TTL/abort）→ 抛清晰 error（不静默返回空）。
+   *
+   * **不可重入**：同一 id 的上一次 `run` 未结束时再续聊会让内核抛「already in progress」（子 session 互斥）。
+   * 调用方须串行续聊同一子 agent（不同 id 之间并发无碍）。
    */
   async continueSubAgent(
     id: string,

--- a/packages/plugins/src/controllers/sub-agent-tool.ts
+++ b/packages/plugins/src/controllers/sub-agent-tool.ts
@@ -9,7 +9,7 @@
  * `sessionFactory` 里。父 session 的 abort signal 透传给 sub-agent（协作式取消）。
  */
 
-import type { AgentSession, Hook, HarnessTool, HookContext, Message, ToolExecResult } from "@harness-pi/core";
+import type { AgentSession, Hook, HarnessTool, HookContext, Message, RunSummary, ToolExecResult } from "@harness-pi/core";
 import { Type } from "@earendil-works/pi-ai";
 
 /**
@@ -40,6 +40,11 @@ export interface SubAgentToolOptions {
    * 正交：一纵一横，互不干扰。
    */
   maxDepth?: number;
+  /**
+   * **opt-in 续聊接缝（S4）**：每 spawn 完一个子 session（跑完首轮）就回调一次，让调用方留住句柄以便按 id
+   * 续聊（典型：传 `SubAgentRegistry.retain`）。**默认不传 → 子 session 跑完即弃（0.2.4 逐字节一致）**。
+   */
+  onSpawn?: (session: AgentSession) => void;
 }
 
 /** 取一条 message 的纯文本（content 可能是 string 或 block 数组）。 */
@@ -53,15 +58,42 @@ function messageText(m: Message | undefined): string {
 }
 
 /**
+ * 共享：把一次子 session run/continue 的终态整形成回灌父模型的 ToolExecResult。
+ * spawn 路径与续聊路径（SubAgentRegistry.continueSubAgent）都走这里 → 两边 shape **逐字段一致**。
+ *
+ * content = 子最后一条 assistant 的纯文本（回灌父模型）；details.subAgent = 结构化终态（trace/metrics 用），
+ * 含 `sessionId`（S4：父据此对该子 agent 续聊）+ 现有 reason/turns/usage/stopReason。
+ */
+export function subAgentResult(sub: AgentSession, summary: RunSummary): ToolExecResult {
+  const text = messageText(summary.lastMessage) || "(sub-agent produced no text output)";
+  return {
+    content: [{ type: "text", text }],
+    details: {
+      subAgent: {
+        sessionId: sub.id,
+        reason: summary.reason,
+        turns: summary.turns,
+        usage: summary.usage,
+        ...(summary.stopReason ? { stopReason: summary.stopReason } : {}),
+      },
+    },
+  };
+}
+
+/**
  * 共享：spawn 一个 sub-agent session 并整形结果。单 factory 版与 routed 版（#59）都走这里——
  * 纵向深度透传（给子挂 onSessionStart hook 把深度设为 父+1）、父 signal 透传、子终态回灌全在此收口。
  * 横向/纵向闸由调用方在调用前各自判（错误文案各自独立），故本函数只管「确实要 spawn 时」的动作。
+ *
+ * `onSpawn`（opt-in）：spawn 完一拿到终态就回调，让调用方（如 SubAgentRegistry）把子 session 留住以便续聊。
+ * 不传则子 session 跑完即弃（0.2.4 行为）。在 run 之后调 → 句柄已带完整首轮上下文。
  */
 async function spawnSubAgent(
   sub: AgentSession,
   task: string,
   depth: number,
   signal: AbortSignal,
+  onSpawn?: (session: AgentSession) => void,
 ): Promise<ToolExecResult> {
   // 纵向深度透传：给子 session 挂一个 onSessionStart hook，把子 ctx.state 的深度设为 当前+1。
   // 子 session 自己的（routed）subAgentTool（若有）execute 时就读到递增后的深度——多分支各自从父继承，
@@ -76,20 +108,9 @@ async function spawnSubAgent(
   sub.use(depthInjector);
   // 父 signal 透传 → sub-agent 可被父的 abort 协作式取消。
   const summary = await sub.run(task, { signal });
-  const text = messageText(summary.lastMessage) || "(sub-agent produced no text output)";
-
-  // 把子代理终态放进 details（trace/metrics 用），content 回灌父模型。
-  return {
-    content: [{ type: "text", text }],
-    details: {
-      subAgent: {
-        reason: summary.reason,
-        turns: summary.turns,
-        usage: summary.usage,
-        ...(summary.stopReason ? { stopReason: summary.stopReason } : {}),
-      },
-    },
-  };
+  // opt-in 续聊：把跑完首轮的子 session 留住（默认不传 → 跑完即弃）。
+  onSpawn?.(sub);
+  return subAgentResult(sub, summary);
 }
 
 export function subAgentTool(opts: SubAgentToolOptions): HarnessTool {
@@ -127,7 +148,7 @@ export function subAgentTool(opts: SubAgentToolOptions): HarnessTool {
       spawned++;
 
       const sub = opts.sessionFactory(task, ctx);
-      return spawnSubAgent(sub, task, depth, signal);
+      return spawnSubAgent(sub, task, depth, signal, opts.onSpawn);
     },
   };
 }
@@ -165,6 +186,11 @@ export interface RoutedSubAgentToolOptions {
   maxSubAgents?: number;
   /** 跨层递归**纵向**深度闸（#45），语义同单 factory 版。默认 2。 */
   maxDepth?: number;
+  /**
+   * **opt-in 续聊接缝（S4）**：语义同单 factory 版——每 spawn 完一个子 session 就回调一次（跨所有 type）。
+   * 默认不传 → 子 session 跑完即弃。
+   */
+  onSpawn?: (session: AgentSession) => void;
 }
 
 /**
@@ -244,7 +270,7 @@ export function routedSubAgentTool(opts: RoutedSubAgentToolOptions): HarnessTool
       spawned++;
 
       const sub = spec.sessionFactory(task, ctx);
-      return spawnSubAgent(sub, task, depth, signal);
+      return spawnSubAgent(sub, task, depth, signal, opts.onSpawn);
     },
   };
 }

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -51,6 +51,19 @@ export type {
 } from "./turn-end-guard.js";
 
 export {
+  defaultSummarize,
+  renderSummaryPrompt,
+  DEFAULT_SUMMARY_TEMPLATE,
+} from "./summary-template.js";
+export type { DefaultSummarizeOptions } from "./summary-template.js";
+
+export {
+  postCompactFileReread,
+  POST_COMPACT_PENDING_KEY,
+} from "./post-compact-file-reread.js";
+export type { PostCompactFileRereadOptions } from "./post-compact-file-reread.js";
+
+export {
   autoCompaction,
   estimateTokensByChars,
   estimateRequestTokens,

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -44,6 +44,12 @@ export type { LeaseDecisionOptions } from "./lease-decision.js";
 export { compactSummarize } from "./compact-summarize.js";
 export type { CompactSummarizeOptions } from "./compact-summarize.js";
 
+export { turnEndGuard } from "./turn-end-guard.js";
+export type {
+  TurnEndGuardOptions,
+  TurnEndGuardResult,
+} from "./turn-end-guard.js";
+
 export {
   autoCompaction,
   estimateTokensByChars,

--- a/packages/plugins/src/post-compact-file-reread.ts
+++ b/packages/plugins/src/post-compact-file-reread.ts
@@ -119,7 +119,8 @@ export function postCompactFileReread(
         let body = content;
         let truncated = "";
         if (Buffer.byteLength(body, "utf8") > maxBytes) {
-          // 按字节上界截断（slice 到 maxBytes 字节内的最长合法 UTF-8 前缀）。
+          // 按字节上界截断到 maxBytes。注意：在多字节 UTF-8 字符中间切会让末尾出现一个替换字符
+          // （U+FFFD）——注入内容是给模型看的 advisory，可接受；故不保证截断点落在码点边界。
           body = Buffer.from(body, "utf8").subarray(0, maxBytes).toString("utf8");
           truncated = `\n[truncated to ${maxBytes} bytes]`;
         }

--- a/packages/plugins/src/post-compact-file-reread.ts
+++ b/packages/plugins/src/post-compact-file-reread.ts
@@ -1,0 +1,137 @@
+/**
+ * postCompactFileReread —— 压缩后文件重读（C4，docs/09 §4.2）。**opt-in、默认关**。
+ *
+ * **问题**：compactSummarize / autoCompaction 把早期消息（含 `read` 的完整文件输出）压成一条 summary
+ * 后，模型 view 里只剩对文件的**摘要描述**，丢了**逐字内容**；若文件在此期间又被 edit/write 改过，summary
+ * 还可能**过时**。下一轮模型据此推理就是看着陈旧/有损的文件状态。
+ *
+ * **做法**：压缩发生的**下一个 turn 开始**时，从最近消息里收集被 read/edit/write 引用过的文件路径，用调用方
+ * 注入的 `fileContentProvider` 取**当前**内容，经 `additionalContext`（transient attachment）注入——让模型在
+ * 压缩后立刻重新看到关键文件的现状。**bounded**：`maxFiles` + 每文件 `maxBytes`，避免把刚省下的 token 又灌回去。
+ *
+ * **与压缩插件的协作（顺序契约）**：
+ *   - 压缩插件在 `transformMessagesBeforeLlm` 里产生 compacted view 时，会 `ctx.state.set` 一个待重读标记
+ *     （`post-compact-file-reread.pending` = 压缩发生的 turnIdx）。本插件在**下一个** `onTurnStart` 读到该标记 →
+ *     注入一次 → 清标记。故**每次压缩只重读一次**，不会每 turn 重复注入。
+ *   - core 不知道 `read` 工具长什么样 → 路径解析（`fileContentProvider`）由调用方注入；返回 `null` = 跳过该文件
+ *     （已删除 / 越权 / 不该重读）。
+ *   - 与压缩插件**搭配使用**：单挂本插件而不挂任何压缩插件时，标记永不被 set，本插件**零注入**（纯 no-op）。
+ */
+
+import type { Hook, HookContext, Message } from "@harness-pi/core";
+
+/* ── 在 core 的 HookStateRegistry 上 augment 压缩↔重读之间的协作 key ── */
+declare module "@harness-pi/core" {
+  interface HookStateRegistry {
+    /** 压缩插件 set = 「本 turn 发生了压缩」的 turnIdx；postCompactFileReread 在下一 turn 消费并清除。 */
+    "post-compact-file-reread.pending": number;
+  }
+}
+
+/** 压缩↔重读协作 state key（导出供压缩插件 set、测试断言）。 */
+export const POST_COMPACT_PENDING_KEY = "post-compact-file-reread.pending";
+
+export interface PostCompactFileRereadOptions {
+  /**
+   * 路径 → 当前内容解析器（调用方注入；core 不知道 `read` 的实现）。返回 `null` = 跳过该文件
+   * （已删除 / 越权 / 不重读）。可 async。
+   */
+  fileContentProvider: (path: string) => Promise<string | null>;
+  /** 最多重读几个文件（取最近被引用的）。默认 5，须 ≥ 1。 */
+  maxFiles?: number;
+  /** 每个文件最多注入多少字节（超出截断并标注）。默认 8192，须 ≥ 1。 */
+  maxBytes?: number;
+  /**
+   * 视为「文件操作」、其 `path` 参数要被收集的工具名。默认 `["read", "edit", "write"]`（first-party tools）。
+   * 自定义工具集时覆盖。
+   */
+  toolNames?: string[];
+  /** tool 参数里承载文件路径的字段名。默认 `"path"`（first-party tools 用 `path`）。 */
+  pathArg?: string;
+}
+
+/**
+ * 从消息序列里收集被文件工具引用过的路径，**保留最近引用优先**、去重。
+ * 扫 assistant 消息里的 toolCall（`name ∈ toolNames` 且 `arguments[pathArg]` 是非空 string）。
+ * 倒序遍历 → 最近引用的文件排前面，配合 `maxFiles` 截断时保留「最相关」的那批。
+ */
+function collectPaths(
+  messages: ReadonlyArray<Message>,
+  toolNames: ReadonlySet<string>,
+  pathArg: string,
+): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m === undefined || m.role !== "assistant" || typeof m.content === "string")
+      continue;
+    for (const b of m.content) {
+      if (b.type !== "toolCall" || !toolNames.has(b.name)) continue;
+      const p = b.arguments[pathArg];
+      if (typeof p !== "string" || p.length === 0 || seen.has(p)) continue;
+      seen.add(p);
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+export function postCompactFileReread(
+  opts: PostCompactFileRereadOptions,
+): Hook {
+  const maxFiles = opts.maxFiles ?? 5;
+  if (maxFiles < 1) {
+    throw new Error("postCompactFileReread: maxFiles must be >= 1");
+  }
+  const maxBytes = opts.maxBytes ?? 8192;
+  if (maxBytes < 1) {
+    throw new Error("postCompactFileReread: maxBytes must be >= 1");
+  }
+  const toolNames = new Set(opts.toolNames ?? ["read", "edit", "write"]);
+  const pathArg = opts.pathArg ?? "path";
+
+  return {
+    name: "postCompactFileReread",
+
+    async onTurnStart(_input, ctx: HookContext) {
+      // 仅在「上一 turn 发生了压缩」时重读一次。无标记（没挂压缩插件 / 本 turn 没压缩）→ 纯 no-op。
+      if (!ctx.state.has(POST_COMPACT_PENDING_KEY)) return;
+      ctx.state.delete(POST_COMPACT_PENDING_KEY); // 消费即清，避免每 turn 重复注入
+
+      const paths = collectPaths(ctx.messages, toolNames, pathArg).slice(0, maxFiles);
+      if (paths.length === 0) return;
+
+      const blocks: string[] = [];
+      for (const p of paths) {
+        // provider 抛错不该拖垮整个 turn——记一笔、跳过该文件（其余文件照常重读）。
+        let content: string | null;
+        try {
+          content = await opts.fileContentProvider(p);
+        } catch (err) {
+          ctx.log.warn("postCompactFileReread: provider failed", {
+            path: p,
+            err: err instanceof Error ? err.message : String(err),
+          });
+          continue;
+        }
+        if (content === null) continue; // null = 跳过该文件
+        let body = content;
+        let truncated = "";
+        if (Buffer.byteLength(body, "utf8") > maxBytes) {
+          // 按字节上界截断（slice 到 maxBytes 字节内的最长合法 UTF-8 前缀）。
+          body = Buffer.from(body, "utf8").subarray(0, maxBytes).toString("utf8");
+          truncated = `\n[truncated to ${maxBytes} bytes]`;
+        }
+        blocks.push(`<file path="${p}">\n${body}${truncated}\n</file>`);
+      }
+      if (blocks.length === 0) return;
+
+      return {
+        additionalContext: `Current contents of files referenced before compaction (re-read so you see their up-to-date state):\n${blocks.join(
+          "\n",
+        )}`,
+      };
+    },
+  };
+}

--- a/packages/plugins/src/summary-template.ts
+++ b/packages/plugins/src/summary-template.ts
@@ -1,0 +1,86 @@
+/**
+ * summary-template —— 可覆盖的 9 段 summary 模板 + `defaultSummarize` 工厂（C4，docs/09 §4.2）。
+ *
+ * `compactSummarize` / `autoCompaction` 的 `summarize` 契约是「把一批早期消息总结成一段文本」，但**怎么
+ * 总结**留给调用方。本文件提供一个**默认实现**：借鉴 Claude Code compaction 的「9 段结构化回顾」模板，
+ * 但**完全 domain-free**（不硬编任何业务），让模型把早期对话压成高保真的结构化 summary。
+ *
+ * **接缝**：summarize 跑在 `transformMessagesBeforeLlm` 内、需要再调一次 LLM，但 `HookContext` 不暴露
+ * 「调 LLM」的能力（内核刻意不把 model 句柄塞进 ctx）。故工厂要求调用方注入一个最薄的
+ * `complete: (prompt) => Promise<string>`——它把 prompt 发给某个 model、拿回纯文本。调用方用 pi-ai
+ * 的 `complete()` / 自己的 model wrapper 实现它（plugins 层不依赖 pi-ai 的 complete API，保持 seam 干净）。
+ */
+
+import type { HookContext } from "@harness-pi/core";
+import type { Message } from "@earendil-works/pi-ai";
+
+/**
+ * 默认 9 段 summary 模板（domain-free）。`{transcript}` 是唯一占位符，渲染时替换成早期消息文本。
+ * 借鉴 Claude Code compaction 的结构化回顾，但去掉一切业务/工具专属措辞——只要求模型按 9 段组织。
+ */
+export const DEFAULT_SUMMARY_TEMPLATE = `You are compacting an earlier portion of a conversation into a structured summary so the work can continue without losing context. Read the transcript below and produce a summary organized into these 9 numbered sections. Be specific and faithful; do not invent details, and preserve exact names, paths, and identifiers.
+
+1. Primary Request and Intent: What the user originally asked for and what they are ultimately trying to achieve.
+2. Key Concepts: The important technical concepts, terms, and ideas that came up.
+3. Files and Resources: The specific files, directories, URLs, or other resources referenced or modified, and why each matters.
+4. Errors and Fixes: Any errors, failures, or problems encountered and how each was (or was not) resolved.
+5. Problem Solving: The reasoning, approaches, and decisions made while working through the task.
+6. All User Messages: A faithful list of every message the user sent (paraphrased but complete), so their guidance is not lost.
+7. Pending Tasks: Work that was explicitly requested but is not yet done.
+8. Current Work: What was being worked on at the very end of this transcript.
+9. Next Step: The single most logical next step to continue the work.
+
+<transcript>
+{transcript}
+</transcript>`;
+
+/** 把一条 message 渲染成 transcript 里的一行（role: text）。toolResult 也带上工具名，便于模型对账。 */
+function renderMessage(m: Message): string {
+  const text =
+    typeof m.content === "string"
+      ? m.content
+      : m.content
+          .map((b) => {
+            if ("text" in b && typeof b.text === "string") return b.text;
+            if (b.type === "toolCall")
+              return `[toolCall ${b.name} ${JSON.stringify(b.arguments)}]`;
+            if (b.type === "image") return "[image]";
+            return JSON.stringify(b);
+          })
+          .join("");
+  if (m.role === "toolResult") return `toolResult(${m.toolName}): ${text}`;
+  return `${m.role}: ${text}`;
+}
+
+/** 把一批早期消息渲染进模板的 `{transcript}` 占位符，得到最终 prompt。导出供测试/调用方复用。 */
+export function renderSummaryPrompt(
+  earlyMessages: Message[],
+  template: string = DEFAULT_SUMMARY_TEMPLATE,
+): string {
+  const transcript = earlyMessages.map(renderMessage).join("\n");
+  return template.replace("{transcript}", transcript);
+}
+
+export interface DefaultSummarizeOptions {
+  /**
+   * 把一段 prompt 发给某个 model、拿回纯文本的最薄 seam（调用方注入；可调真 LLM）。
+   * plugins 层不依赖 pi-ai 的 complete API，调用方用 pi-ai `complete()` / 自己的 wrapper 实现它。
+   */
+  complete: (prompt: string) => Promise<string>;
+  /** 覆盖默认 9 段模板。须含 `{transcript}` 占位符（否则早期消息不会被注入）。 */
+  template?: string;
+}
+
+/**
+ * 工厂：返回一个**兼容 `CompactSummarizeOptions.summarize` / `AutoCompactionOptions.summarize`** 的函数。
+ * 内部把 earlyMessages 渲染进 9 段 prompt（或 `opts.template` 覆盖的模板），再调注入的 `complete` 拿回 summary。
+ */
+export function defaultSummarize(
+  opts: DefaultSummarizeOptions,
+): (earlyMessages: Message[], ctx: HookContext) => Promise<string> {
+  const template = opts.template ?? DEFAULT_SUMMARY_TEMPLATE;
+  return async (earlyMessages: Message[]) => {
+    const prompt = renderSummaryPrompt(earlyMessages, template);
+    return opts.complete(prompt);
+  };
+}

--- a/packages/plugins/src/turn-end-guard.ts
+++ b/packages/plugins/src/turn-end-guard.ts
@@ -28,6 +28,11 @@
  * `false` 也不会取消已 `appendMessage` 的持久阻断消息（那是即时副作用）。`appendMessage` 不经 merge、直接
  * push 进 session.messages，故多个 turnEndGuard / 其它注入 hook 共存时各自的消息都会落上，互不抢占。
  *
+ * **超时**：`onContinuationCheck` 是 **event 类** hook，dispatcher 默认 per-hook timeout 仅 100ms；而本插件的
+ * `check` 通常做 I/O（跑测试 / lint / 调 LLM）必然超 100ms，一旦超时其 `{continue:true}` 会被 `_invokeSafe`
+ * 静默丢弃 → 质量闸形同虚设。故返回的 Hook **自设较宽的 `timeout`**（默认 30s，对齐 `onAfterFlush` 对
+ * 「可调 LLM 的 hook 应放宽 timeout」的同款约定），调用方可经 `timeoutMs` 覆盖。
+ *
  * **domain-free**：插件不认识「测试」「lint」这类业务；`check` 全由调用方注入，`message` 是要回灌给模型的
  * 阻断说明（如 "测试未过：<输出>，修复后再停"）。
  */
@@ -67,11 +72,17 @@ export interface TurnEndGuardOptions {
    * 与内核 `maxContinuations` 互补，避免后者很大时空转。计数随一次 `ok:true` 重置。
    */
   maxRetries?: number;
+  /**
+   * 返回 Hook 的 per-hook timeout（毫秒，默认 30000）。`onContinuationCheck` 是 event 类、dispatcher
+   * 默认仅 100ms，而 `check` 通常做 I/O 必然超时被静默丢弃 → 闸失效。故放宽默认；`check` 更慢时调大。
+   */
+  timeoutMs?: number;
 }
 
 const KEY = "turn-end-guard.retries" as const;
 
 const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_BLOCK_MESSAGE =
   "turn-end-guard: quality check did not pass; please fix the issue before stopping.";
 
@@ -80,9 +91,15 @@ export function turnEndGuard(opts: TurnEndGuardOptions): Hook {
   if (maxRetries <= 0) {
     throw new Error("turnEndGuard: maxRetries must be > 0");
   }
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  if (timeoutMs <= 0) {
+    throw new Error("turnEndGuard: timeoutMs must be > 0");
+  }
 
   return {
     name: "turn-end-guard",
+    // event 类默认 100ms 远不够 check 做 I/O——放宽，否则超时丢弃 {continue:true} → 闸静默失效。
+    timeout: timeoutMs,
 
     onSessionStart(_input, ctx) {
       // 每次 run/continue 重置，避免续跑串味（对齐 emptyRunGuard）。

--- a/packages/plugins/src/turn-end-guard.ts
+++ b/packages/plugins/src/turn-end-guard.ts
@@ -1,0 +1,123 @@
+/**
+ * Turn-end quality guard —— stopHook 式「想停时先过一道闸」。纯插件、零内核改动。
+ *
+ * 对齐 Claude Code stopHook 的 `preventContinuation + blockingError`：session 走到 would-be-done
+ * （`reason==="done"` 且还有续跑预算）时，内核 fire `onContinuationCheck`；本插件在这里跑一个
+ * 调用方注入的 `check`：
+ *   - **不过**（`ok:false`）→ 用 `ctx.appendMessage(createUserMessage(message))` 注入一条**持久**阻断
+ *     消息（进 session.messages、下次 LLM call 可见——对齐 cc 的 isMeta blocking user message，比 transient
+ *     `additionalContext` 更忠实，模型在后续轮始终看得到「为什么没让你停」），**并** return `{ continue: true }`
+ *     强制再跑一轮让模型修。
+ *   - **过**（`ok:true`）→ return 空（放行，session 正常停止）。
+ *
+ * 这就覆盖了 cc stopHook 的核心语义，**不动内核一行**——`onContinuationCheck` 是唯一能「强制再来一轮」
+ * 的 hook（`onTurnEnd` 只能 `continue:false` 中止、不能强制续跑）。
+ *
+ * **防死循环：两层兜底。**
+ *   - 内核侧：`maxContinuations`（AgentSessionOptions，默认 5）是续跑硬上限，超出内核以
+ *     `reason:"max_continuations"` 收尾——这是最终安全网。
+ *   - 插件侧：`maxRetries`（默认 3）。连续强制 `maxRetries` 次后 `check` 仍不过，本插件**停止强制**
+ *     （return 空 → 放行停止），避免在 `maxContinuations` 被调得很大时空转。选「放行停止」而非
+ *     `ctx.abort`：插件 domain-free，不替调用方决定「修不好就是错误」；session 以正常 `done` 收尾，调用方
+ *     可在 onSessionEnd 自行判定。计数随 `ok:true` 重置（一次通过后重新给满预算）。
+ *
+ * **与其它 `onContinuationCheck` hook 的合并交互**（见 dispatcher.ts `mergeResults`）：`onContinuationCheck`
+ * 走 **event 并行 + merge** 路径。`continue` 的合并是「`false` 优先、否则任一 `true` 即 `true`」——本插件
+ * 返回 `continue:true` 不会被别的 hook 的「沉默/`true`」覆盖，能可靠强制续跑；唯一能压过它的是别的 hook
+ * 显式 `continue:false`，但 `mergeResults` 对 event 路径的 `false` 只在调用点用于「是否续跑」判定，且
+ * `false` 也不会取消已 `appendMessage` 的持久阻断消息（那是即时副作用）。`appendMessage` 不经 merge、直接
+ * push 进 session.messages，故多个 turnEndGuard / 其它注入 hook 共存时各自的消息都会落上，互不抢占。
+ *
+ * **domain-free**：插件不认识「测试」「lint」这类业务；`check` 全由调用方注入，`message` 是要回灌给模型的
+ * 阻断说明（如 "测试未过：<输出>，修复后再停"）。
+ */
+
+import {
+  createUserMessage,
+  type ContinuationCheckInput,
+  type Hook,
+  type HookContext,
+  type HookResult,
+} from "@harness-pi/core";
+
+declare module "@harness-pi/core" {
+  interface HookStateRegistry {
+    "turn-end-guard.retries": number;
+  }
+}
+
+/**
+ * `check` 的返回。`ok:true` 放行停止；`ok:false` 时 `message` 是要持久回灌给模型的阻断说明
+ * （缺省给一句兜底文案）。
+ */
+export interface TurnEndGuardResult {
+  ok: boolean;
+  /** `ok:false` 时回灌给模型的阻断消息。省略则用兜底文案。 */
+  message?: string;
+}
+
+export interface TurnEndGuardOptions {
+  /**
+   * 质量闸校验。session 想停时跑一次：`ok:false` → 注入 `message` + 强制再跑一轮让模型修；
+   * `ok:true` → 放行停止。`ctx` 给到 messages / state / config 等只读视图。
+   */
+  check: (ctx: HookContext) => Promise<TurnEndGuardResult> | TurnEndGuardResult;
+  /**
+   * 插件自身的连续强制上限（默认 3）。连续失败到此上限后停止强制、放行停止——
+   * 与内核 `maxContinuations` 互补，避免后者很大时空转。计数随一次 `ok:true` 重置。
+   */
+  maxRetries?: number;
+}
+
+const KEY = "turn-end-guard.retries" as const;
+
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_BLOCK_MESSAGE =
+  "turn-end-guard: quality check did not pass; please fix the issue before stopping.";
+
+export function turnEndGuard(opts: TurnEndGuardOptions): Hook {
+  const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
+  if (maxRetries <= 0) {
+    throw new Error("turnEndGuard: maxRetries must be > 0");
+  }
+
+  return {
+    name: "turn-end-guard",
+
+    onSessionStart(_input, ctx) {
+      // 每次 run/continue 重置，避免续跑串味（对齐 emptyRunGuard）。
+      ctx.state.set(KEY, 0);
+    },
+
+    async onContinuationCheck(
+      _input: ContinuationCheckInput,
+      ctx: HookContext,
+    ): Promise<HookResult | void> {
+      const result = await opts.check(ctx);
+
+      if (result.ok) {
+        // 过闸：放行停止，并重置预算（下次 run 内再想停时重新给满 maxRetries）。
+        ctx.state.set(KEY, 0);
+        return;
+      }
+
+      // 不过闸。先看插件侧预算是否用尽。
+      const used = ctx.state.get(KEY) ?? 0;
+      if (used >= maxRetries) {
+        // 连续强制到上限仍不过：停止强制，放行停止（不 abort——domain-free，让调用方在
+        // onSessionEnd 自行判定）。重置计数，避免 continue/resume 串味。
+        ctx.state.set(KEY, 0);
+        ctx.log.warn(
+          `turn-end-guard: maxRetries (${maxRetries}) exhausted, allowing stop`,
+        );
+        return;
+      }
+
+      // 注入持久阻断消息（进 session.messages、下次 LLM call 可见），并强制再跑一轮。
+      const message = result.message ?? DEFAULT_BLOCK_MESSAGE;
+      ctx.appendMessage(createUserMessage(message));
+      ctx.state.set(KEY, used + 1);
+      return { continue: true };
+    },
+  };
+}


### PR DESCRIPTION
0.3.0 "Wave C" 增强,三个**零内核**插件特性打包(各一 commit + 一个 review-hardening commit)。`packages/core` 一行未动。

## 特性

- **S4 — subAgent typed 交付 + bounded 续聊句柄**:`spawnSubAgent` 的 `details.subAgent` 现含 `sessionId`;新 `SubAgentRegistry`(opt-in via `subAgentTool({ onSpawn })`)按 id 留住子 session 供续聊,三道资源闸 `maxRetained`(16) LRU + `ttlMs`(5min) + 父 abort 清空(对标 cc 36.8GB 内存失控教训)。续聊用 `session.run(message)`(内核 `continue()` 不接受新 prompt)。
- **O3 — turnEndGuard 质量闸**(stopHook 式,零内核):挂 `onContinuationCheck`(唯一能强制续跑的 hook),`check` 不过 → `ctx.appendMessage(持久阻断消息)` + `{continue:true}` 强制再跑一轮;过 → 放行。`maxRetries`(默认3) + 内核 `maxContinuations` 双层防死循环。**推翻 PRD 对 O3「小改 core」的估计**——现有 `onContinuationCheck` + `appendMessage` 原语已完整覆盖 cc 的 `preventContinuation + blockingError`。
- **C4 — 9 段 summary 模板 + 压缩后文件重读**:导出可覆盖的 `DEFAULT_SUMMARY_TEMPLATE` + `defaultSummarize({complete})` 工厂(兼容 `compactSummarize`/`autoCompaction` 的 summarize 契约);新 `postCompactFileReread`(opt-in,onTurnStart 消费压缩插件 set 的 `POST_COMPACT_PENDING_KEY` 标记,经 `fileContentProvider` 回调重注入当前文件内容,bounded `maxFiles`/`maxBytes`)。

## Review-gate(code/test/linus 三闸)

linus 闸抓到两个 code/test 闸漏掉的真 bug,已修 + 加回归测试:
- **C4 blocker**:`postCompactFileReread` 原会**每个越界 turn** 重读重注入(`transformMessagesBeforeLlm` 收 append-only `_messages`,越阈值后永久越阈;标记每 turn 无条件 set)。修:标记 set **移进重算分支**,只在真发生一次新总结时置位 + 多 turn 回归测试锁住契约(原 e2e 只断言「≥1 次注入」故漏掉)。
- **O3 major**:`onContinuationCheck` 是 event 类(默认 100ms timeout),`check` 做 I/O 必超时 → `{continue:true}` 静默丢弃 → 闸失效。修:返回 Hook 设 `timeout`(默认 30s) + 暴露 `timeoutMs`,对齐 `onAfterFlush` 先例。

复审(linus)PASS:两 finding 独立核验已解决,无新 blocker/major。

## 验证

- `pnpm -r build && pnpm -r typecheck` 全绿;`pnpm --filter @harness-pi/plugins test` **380 passed**(+5:2 S4 不变量 / 2 O3 timeout / 1 C4 blocker 回归)。
- 每特性有 opt-in 回归断言:不启用时与 0.2.4 逐字节一致。
- 零内核改动;domain-free(业务全走注入回调)。

> O4(memdir)、O5(子 agent 生命周期 event)按设计核验结果 defer 到 0.3.1(O5 的内核成本高于预估且 P3;O4 lark-bot MVP 已够用)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)