### PR TITLE
feat(core): O5 — sub-agent lifecycle events (onSubagentStart/End)

### DIFF
--- a/packages/core/src/__tests__/dispatcher.test.ts
+++ b/packages/core/src/__tests__/dispatcher.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, vi } from "vitest";
 import { HookDispatcher, mergeResults, defaultTimeoutFor } from "../dispatcher.js";
-import type { Hook, HookContext, MergedHookResult } from "../index.js";
+import type { Hook, HookContext } from "../index.js";
 import { createTestContext } from "../testing.js";
 
 function fakeCtx(): HookContext {
@@ -423,18 +423,19 @@ describe("HookDispatcher subagent events (O5)", () => {
     ]);
   });
 
-  it("subagent events are observe-only: a thrown hook does not break dispatch (returns merged)", async () => {
+  it("subagent events are observe-only: a thrown hook does not break dispatch nor mask sibling hooks", async () => {
+    let okRan = false;
     const hooks: Hook[] = [
       { name: "thrower", internal: true, onSubagentStart: () => { throw new Error("boom"); } },
-      { name: "ok", onSubagentStart: () => {} },
+      { name: "ok", onSubagentStart: () => { okRan = true; } },
     ];
     const d = new HookDispatcher(hooks);
-    // fire-and-observe：返回 MergedHookResult，调用方忽略；throw 被 fail-open 吞掉，不冒泡。
-    const out = await d.fireEvent(
+    // fire-and-observe：throw 被 fail-open 吞掉、不冒泡（await 不抛即证），且不挡住同批未 throw 的 hook。
+    await d.fireEvent(
       "onSubagentStart",
       { agentId: "s", task: "t", depth: 1 },
       fakeCtx(),
     );
-    expect(out.continue).toBeUndefined();
+    expect(okRan).toBe(true); // thrower 的 throw 没阻断 ok hook（并行 observe + fail-open）
   });
 });

--- a/packages/core/src/__tests__/dispatcher.test.ts
+++ b/packages/core/src/__tests__/dispatcher.test.ts
@@ -389,3 +389,52 @@ describe("mergeResults", () => {
     expect(out.systemMessages).toEqual([]);
   });
 });
+
+describe("HookDispatcher subagent events (O5)", () => {
+  it("fireEvent('onSubagentStart') dispatches to matched hooks with the input", async () => {
+    const seen: Array<{ agentId: string; task: string; depth: number }> = [];
+    const hooks: Hook[] = [
+      { name: "probe", onSubagentStart: (input) => { seen.push(input); } },
+      { name: "noop", onTurnEnd: () => {} }, // 不实现 onSubagentStart → 不被调
+    ];
+    const d = new HookDispatcher(hooks);
+    await d.fireEvent(
+      "onSubagentStart",
+      { agentId: "sub-1", task: "do x", depth: 1 },
+      fakeCtx(),
+    );
+    expect(seen).toEqual([{ agentId: "sub-1", task: "do x", depth: 1 }]);
+  });
+
+  it("fireEvent('onSubagentEnd') dispatches terminal state to matched hooks", async () => {
+    const seen: any[] = [];
+    const hooks: Hook[] = [
+      { name: "probe", onSubagentEnd: (input) => { seen.push(input); } },
+    ];
+    const d = new HookDispatcher(hooks);
+    const usage = { input: 1, output: 2 } as any;
+    await d.fireEvent(
+      "onSubagentEnd",
+      { agentId: "sub-1", task: "do x", depth: 1, reason: "done", turns: 3, usage, summaryText: "result" },
+      fakeCtx(),
+    );
+    expect(seen).toEqual([
+      { agentId: "sub-1", task: "do x", depth: 1, reason: "done", turns: 3, usage, summaryText: "result" },
+    ]);
+  });
+
+  it("subagent events are observe-only: a thrown hook does not break dispatch (returns merged)", async () => {
+    const hooks: Hook[] = [
+      { name: "thrower", internal: true, onSubagentStart: () => { throw new Error("boom"); } },
+      { name: "ok", onSubagentStart: () => {} },
+    ];
+    const d = new HookDispatcher(hooks);
+    // fire-and-observe：返回 MergedHookResult，调用方忽略；throw 被 fail-open 吞掉，不冒泡。
+    const out = await d.fireEvent(
+      "onSubagentStart",
+      { agentId: "s", task: "t", depth: 1 },
+      fakeCtx(),
+    );
+    expect(out.continue).toBeUndefined();
+  });
+});

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -18,6 +18,8 @@ import type {
   HookContext,
   HookLogger,
   LogLevel,
+  OnSubagentEndInput,
+  OnSubagentStartInput,
   SessionConfigView,
   StateValueFor,
   TypedStateMap,
@@ -68,6 +70,13 @@ export interface HookContextDeps {
   onAbort: (reason: string) => void;
   /** emit 回调（可选；默认 noop）。 */
   onEmit?: (event: { type: string; [k: string]: unknown }) => void;
+  /**
+   * O5：kernel-wired 回调，把 `onSubagentStart` 事件派发到本 session 的 hook。缺省 = no-op
+   * （即未由 session.ts 接线、或脱离 session 的裸 ctx → `fireSubagentStart` 静默无操作）。
+   */
+  onSubagentStart?: (input: OnSubagentStartInput) => Promise<void>;
+  /** O5：同上，派发 `onSubagentEnd`。 */
+  onSubagentEnd?: (input: OnSubagentEndInput) => Promise<void>;
 }
 
 /**
@@ -205,5 +214,14 @@ export class HookContextImpl implements HookContext {
 
   emit(event: { type: string; [k: string]: unknown }): void {
     this.deps.onEmit?.(event);
+  }
+
+  async fireSubagentStart(input: OnSubagentStartInput): Promise<void> {
+    // deps 缺省（未由 session.ts 接线）时 = no-op。
+    await this.deps.onSubagentStart?.(input);
+  }
+
+  async fireSubagentEnd(input: OnSubagentEndInput): Promise<void> {
+    await this.deps.onSubagentEnd?.(input);
   }
 }

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -30,6 +30,8 @@ import type {
   MergedHookResult,
   OnAfterFlushInput,
   OnAfterFlushResult,
+  OnSubagentEndInput,
+  OnSubagentStartInput,
   PostToolUseInput,
   PreToolUseInput,
   SessionEndInput,
@@ -63,6 +65,8 @@ const EVENT_METHODS = new Set([
   "onContextOverflow",
   "onPostToolUse",
   "onError",
+  "onSubagentStart",
+  "onSubagentEnd",
 ] as const);
 
 const DECISION_METHODS = new Set([
@@ -124,6 +128,8 @@ export interface EventInputMap {
   onLlmEnd: LlmEndInput;
   onContextOverflow: ContextOverflowInput;
   onPostToolUse: PostToolUseInput;
+  onSubagentStart: OnSubagentStartInput;
+  onSubagentEnd: OnSubagentEndInput;
 }
 
 export interface DecisionInputMap {

--- a/packages/core/src/hook.ts
+++ b/packages/core/src/hook.ts
@@ -15,8 +15,11 @@ import type {
   Message,
   Tool,
   ToolCall,
+  Usage,
 } from "@earendil-works/pi-ai";
 import type { HarnessTool } from "./types.js";
+// type-only import：编译期擦除，不构成与 session.ts 的运行时循环依赖。
+import type { RunSummary } from "./session.js";
 
 /* ──────────────────── Tool 执行结果 ──────────────────── */
 
@@ -191,6 +194,38 @@ export interface ErrorInput {
   err: Error;
   call?: ToolCall;
   hookName?: string;
+}
+
+/**
+ * 子 agent **spawn 前**的观测信号（O5）。只有经 subAgentTool / routedSubAgentTool 造的子才会 fire——
+ * 它们在 tool 内调 `ctx.fireSubagentStart(...)` 把事件派发到**父** session 的 hook。让 metrics / sessionLog
+ * 等现有 plugin 统一观测子 agent 生命周期，无需各自插桩 sessionFactory。
+ */
+export interface OnSubagentStartInput {
+  /** 子 session 的 id（= `AgentSession.id`）。 */
+  agentId: string;
+  /** 派给子 agent 的任务文本。 */
+  task: string;
+  /** 子 agent 的递归深度（父深度 + 1，与 subAgent.depth 透传一致）。 */
+  depth: number;
+}
+
+/**
+ * 子 agent **跑完后**的观测信号（O5），带终态。配对 `OnSubagentStartInput`：start 先于 end。
+ * 字段取自子 session 的 `RunSummary` 终态 + 回灌父模型的文本。
+ */
+export interface OnSubagentEndInput {
+  agentId: string;
+  task: string;
+  depth: number;
+  /** 子 session 的终态判别（与 `RunSummary.reason` 同一枚举）。 */
+  reason: RunSummary["reason"];
+  /** 子 session 跑过的 turn 数。 */
+  turns: number;
+  /** 子 session 累计 token usage（含 cost）。 */
+  usage: Usage;
+  /** 子最后一条 assistant 的纯文本（回灌父模型的内容）；无文本输出则缺省。 */
+  summaryText?: string;
 }
 
 /* ──────────────────── 统一返回 envelope ──────────────────── */
@@ -370,6 +405,19 @@ export interface HookContext {
 
   /** 内部 emit（用于 kernel ↔ plugin 互通；极少用）。 */
   emit(event: { type: string; [k: string]: unknown }): void;
+
+  /**
+   * 把 `onSubagentStart` 事件派发到**本（父）session** 的 hook（O5）。供 controller 在 tool 内、spawn
+   * 子 agent 前调用——子在 `depth + 1`。**只有经 subAgentTool / routedSubAgentTool 造的子才会 fire**；
+   * forkSession / workPool / 直接 `new AgentSession` 的子不 fire（无父 ctx 在 scope）。
+   */
+  fireSubagentStart(input: OnSubagentStartInput): Promise<void>;
+
+  /**
+   * 把 `onSubagentEnd` 事件派发到**本（父）session** 的 hook（O5）。供 controller 在子 agent 跑完、
+   * 拿到终态后调用。作用域边界同 `fireSubagentStart`。
+   */
+  fireSubagentEnd(input: OnSubagentEndInput): Promise<void>;
 }
 
 /* ──────────────────── Hook 接口 ──────────────────── */
@@ -497,6 +545,22 @@ export interface Hook {
     ctx: HookContext,
   ): HookResult | void | Promise<HookResult | void>;
   onError?(input: ErrorInput, ctx: HookContext): void | Promise<void>;
+  /**
+   * 子 agent **spawn 前**观测点（O5）。fire-and-observe（像 onError，**返回被忽略**，无控制流）。
+   * 只对经 subAgentTool / routedSubAgentTool 造的子 fire；其它来源的子 session 不触发。
+   */
+  onSubagentStart?(
+    input: OnSubagentStartInput,
+    ctx: HookContext,
+  ): void | Promise<void>;
+  /**
+   * 子 agent **跑完后**观测点（O5），带终态。fire-and-observe（**返回被忽略**）。
+   * 与 onSubagentStart 配对、作用域相同。
+   */
+  onSubagentEnd?(
+    input: OnSubagentEndInput,
+    ctx: HookContext,
+  ): void | Promise<void>;
 
   // ─────────── Decision (sequential short-circuit) ───────────
   onPreToolUse?(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,8 @@ export type {
   ContextOverflowInput,
   OnAfterFlushInput,
   OnAfterFlushResult,
+  OnSubagentStartInput,
+  OnSubagentEndInput,
   PreToolUseInput,
   PostToolUseInput,
   UserPromptSubmitInput,

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -356,6 +356,15 @@ export class AgentSession {
       config: configView,
       onAppendMessage: (msg) => this._messages.push(msg),
       onAbort: (reason) => this._abortCtrl.abort(new Error(reason)),
+      // O5：把 controller 在 tool 内调的 fireSubagentStart/End 派发到本 session 的 hook。
+      // 闭包读 this._ctx 在调用时已构造完毕（fire* 只在 run 中、tool 内触发，无循环依赖）。
+      // 观测事件：fireEvent 返回 MergedHookResult 一律忽略（无控制流）。
+      onSubagentStart: async (input) => {
+        await this._dispatcher.fireEvent("onSubagentStart", input, this._ctx);
+      },
+      onSubagentEnd: async (input) => {
+        await this._dispatcher.fireEvent("onSubagentEnd", input, this._ctx);
+      },
     };
     if (opts.logSink) ctxDeps.logSink = opts.logSink;
     this._ctx = new HookContextImpl(ctxDeps);

--- a/packages/plugins/src/__tests__/sub-agent-events.test.ts
+++ b/packages/plugins/src/__tests__/sub-agent-events.test.ts
@@ -152,6 +152,75 @@ describe("subAgent lifecycle events (O5)", () => {
     subFake.teardown();
   });
 
+  it("observe-only end-to-end: a throwing onSubagent hook breaks neither the parent run nor sibling hooks", async () => {
+    // 端到端背书核心主张「现有 plugin 在父 session 上统一观测子生命周期」：一个在 onSubagentStart/End 里
+    // throw 的 hook 不该中断父 run、不该挡住同批其它 hook、不该丢子结果（fireEvent 并行 observe + fail-open）。
+    const probe = makeProbe();
+    const thrower: Hook = {
+      name: "thrower",
+      onSubagentStart() {
+        throw new Error("boom-start");
+      },
+      onSubagentEnd() {
+        throw new Error("boom-end");
+      },
+    };
+    const subFake = createFakeModel([
+      { content: [{ type: "text", text: "child" }], stopReason: "stop" },
+    ]);
+    const tool = subAgentTool({
+      sessionFactory: () => new AgentSession({ model: subFake, tools: [] }),
+    });
+    const parentFake = createFakeModel([
+      { content: [{ type: "toolCall", name: "subAgent", arguments: { task: "t" } }] },
+      { content: [{ type: "text", text: "parent done" }], stopReason: "stop" },
+    ]);
+    // thrower 排在 probe 之前 → 它 throw 不该挡住 probe 收事件。
+    const parent = new AgentSession({ model: parentFake, tools: [tool], hooks: [thrower, probe.hook] });
+    const summary = await parent.run("go"); // 不抛
+    expect(summary.reason).toBe("done"); // 父正常收尾
+    expect(probe.events.map((e) => e.kind)).toEqual(["start", "end"]); // sibling 仍收到两事件
+    // 子结果仍正常回灌父。
+    const tr = parent.messages.find((m) => m.role === "toolResult") as { content: unknown } | undefined;
+    const text = Array.isArray(tr!.content)
+      ? tr!.content.map((b) => ("text" in b ? (b as { text: string }).text : "")).join("")
+      : "";
+    expect(text).toBe("child");
+    parentFake.teardown();
+    subFake.teardown();
+  });
+
+  it("transports a non-done reason (max_turns) faithfully to onSubagentEnd", async () => {
+    // reason 是 summary.reason 直透；非 done 分支也得如实传到父 hook。让子撞 maxTurns=1 → reason=max_turns。
+    const probe = makeProbe();
+    const noopTool = {
+      name: "noop",
+      description: "noop",
+      parameters: { type: "object", properties: {} } as never,
+      execute: async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
+    };
+    // 子每轮都发 toolCall（想继续），maxTurns=1 → 子以 max_turns 收尾。
+    const subFake = createFakeModel([
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }], stopReason: "toolUse" },
+      { content: [{ type: "toolCall", name: "noop", arguments: {} }], stopReason: "toolUse" },
+    ]);
+    const tool = subAgentTool({
+      sessionFactory: () => new AgentSession({ model: subFake, tools: [noopTool as never], maxTurns: 1 }),
+    });
+    const parentFake = createFakeModel([
+      { content: [{ type: "toolCall", name: "subAgent", arguments: { task: "t" } }] },
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const parent = new AgentSession({ model: parentFake, tools: [tool], hooks: [probe.hook] });
+    await parent.run("go");
+
+    expect(probe.events.map((e) => e.kind)).toEqual(["start", "end"]); // start 仍先于 end
+    const end = probe.events[1]!.input as OnSubagentEndInput;
+    expect(end.reason).toBe("max_turns"); // 非 done reason 如实直透
+    parentFake.teardown();
+    subFake.teardown();
+  });
+
   it("regression: a session that never spawns a sub fires neither event", async () => {
     const probe = makeProbe();
     // 父只回一句话收尾，从不调 subAgent。

--- a/packages/plugins/src/__tests__/sub-agent-events.test.ts
+++ b/packages/plugins/src/__tests__/sub-agent-events.test.ts
@@ -1,0 +1,198 @@
+/**
+ * O5 — 子 agent 生命周期 event（onSubagentStart / onSubagentEnd）。
+ *
+ * 全部经公共接口断言可观测行为：真**父** AgentSession（fake-model 脚本：调一次 subAgent 工具 → 收尾）
+ * + 一个监听 onSubagentStart/End 的探针 hook 挂在父 session 上 + subAgentTool / routedSubAgentTool 造子。
+ * 子 session 用独立 fake-model。父 loop 执行工具时把**父** ctx 传进 execute → 工具内 ctx.fireSubagent*
+ * 把事件派回父 session 的探针 hook。
+ *
+ * 回归：不 spawn 子的 session 永不 fire；未挂探针 hook 时 subAgentTool 行为与 0.3.0 逐字节一致。
+ */
+
+import { describe, it, expect } from "vitest";
+import { AgentSession, type Hook, type OnSubagentStartInput, type OnSubagentEndInput } from "@harness-pi/core";
+import { createFakeModel } from "@harness-pi/core/testing";
+import { subAgentTool, routedSubAgentTool } from "../controllers/index.js";
+
+interface ProbeEvent {
+  kind: "start" | "end";
+  input: OnSubagentStartInput | OnSubagentEndInput;
+}
+
+/** 收集 onSubagentStart/End 的探针 hook（保留 fire 顺序）。 */
+function makeProbe(): { hook: Hook; events: ProbeEvent[] } {
+  const events: ProbeEvent[] = [];
+  return {
+    events,
+    hook: {
+      name: "subagent-probe",
+      onSubagentStart(input) {
+        events.push({ kind: "start", input });
+      },
+      onSubagentEnd(input) {
+        events.push({ kind: "end", input });
+      },
+    },
+  };
+}
+
+describe("subAgent lifecycle events (O5)", () => {
+  it("fires onSubagentStart before the sub runs and onSubagentEnd after, with correct fields", async () => {
+    const probe = makeProbe();
+    // 子 fake：单轮返回 "child-answer"，1 turn done。
+    const subFake = createFakeModel([
+      { content: [{ type: "text", text: "child-answer" }], stopReason: "stop", usage: { input: 5, output: 7 } },
+    ]);
+    let subId = "";
+    // sessionFactory 在 spawn 时被调；记下子 id 以核对事件里的 agentId。
+    const tool = subAgentTool({
+      sessionFactory: () => {
+        const s = new AgentSession({ model: subFake, tools: [] });
+        subId = s.id;
+        return s;
+      },
+    });
+    // 父 fake：调一次 subAgent 工具 → 收尾。
+    const parentFake = createFakeModel([
+      { content: [{ type: "toolCall", name: "subAgent", arguments: { task: "delegate this" } }] },
+      { content: [{ type: "text", text: "parent done" }], stopReason: "stop" },
+    ]);
+    const parent = new AgentSession({ model: parentFake, tools: [tool], hooks: [probe.hook] });
+    await parent.run("go");
+
+    // 两个事件都 fire，start 先于 end。
+    expect(probe.events.map((e) => e.kind)).toEqual(["start", "end"]);
+
+    const start = probe.events[0]!.input as OnSubagentStartInput;
+    expect(start.agentId).toBe(subId);
+    expect(start.task).toBe("delegate this");
+    expect(start.depth).toBe(1); // 顶层(0) → 子(1)
+
+    const end = probe.events[1]!.input as OnSubagentEndInput;
+    expect(end.agentId).toBe(subId);
+    expect(end.task).toBe("delegate this");
+    expect(end.depth).toBe(1);
+    expect(end.reason).toBe("done");
+    expect(end.turns).toBe(1);
+    expect(end.usage.input).toBe(5);
+    expect(end.usage.output).toBe(7);
+    expect(end.summaryText).toBe("child-answer");
+
+    parentFake.teardown();
+    subFake.teardown();
+  });
+
+  it("fires onSubagentStart strictly before the sub session has run", async () => {
+    // 用一个会在 sub.run 期间观测「start 是否已 fire」的子 hook：子的 onSessionStart 跑时，父的 start 必已 fire。
+    const probe = makeProbe();
+    let startFiredWhenSubStarted = false;
+    const subFake = createFakeModel([
+      { content: [{ type: "text", text: "x" }], stopReason: "stop" },
+    ]);
+    const tool = subAgentTool({
+      sessionFactory: () => {
+        const s = new AgentSession({ model: subFake, tools: [] });
+        s.use({
+          name: "observe-start-order",
+          onSessionStart() {
+            // 子 session 一启动，父的 onSubagentStart 必已 fire（fireSubagentStart 在 sub.run 之前 await）。
+            startFiredWhenSubStarted = probe.events.some((e) => e.kind === "start");
+          },
+        });
+        return s;
+      },
+    });
+    const parentFake = createFakeModel([
+      { content: [{ type: "toolCall", name: "subAgent", arguments: { task: "t" } }] },
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const parent = new AgentSession({ model: parentFake, tools: [tool], hooks: [probe.hook] });
+    await parent.run("go");
+    expect(startFiredWhenSubStarted).toBe(true);
+    parentFake.teardown();
+    subFake.teardown();
+  });
+
+  it("routedSubAgentTool fires the same lifecycle events", async () => {
+    const probe = makeProbe();
+    const subFake = createFakeModel([
+      { content: [{ type: "text", text: "routed-answer" }], stopReason: "stop" },
+    ]);
+    let subId = "";
+    const tool = routedSubAgentTool({
+      specs: [
+        {
+          type: "worker",
+          whenToUse: "for any work",
+          sessionFactory: () => {
+            const s = new AgentSession({ model: subFake, tools: [] });
+            subId = s.id;
+            return s;
+          },
+        },
+      ],
+    });
+    const parentFake = createFakeModel([
+      { content: [{ type: "toolCall", name: "subAgent", arguments: { agent_type: "worker", task: "routed task" } }] },
+      { content: [{ type: "text", text: "parent done" }], stopReason: "stop" },
+    ]);
+    const parent = new AgentSession({ model: parentFake, tools: [tool], hooks: [probe.hook] });
+    await parent.run("go");
+
+    expect(probe.events.map((e) => e.kind)).toEqual(["start", "end"]);
+    const start = probe.events[0]!.input as OnSubagentStartInput;
+    expect(start.agentId).toBe(subId);
+    expect(start.task).toBe("routed task");
+    expect(start.depth).toBe(1);
+    const end = probe.events[1]!.input as OnSubagentEndInput;
+    expect(end.agentId).toBe(subId);
+    expect(end.summaryText).toBe("routed-answer");
+
+    parentFake.teardown();
+    subFake.teardown();
+  });
+
+  it("regression: a session that never spawns a sub fires neither event", async () => {
+    const probe = makeProbe();
+    // 父只回一句话收尾，从不调 subAgent。
+    const parentFake = createFakeModel([
+      { content: [{ type: "text", text: "no delegation" }], stopReason: "stop" },
+    ]);
+    const tool = subAgentTool({
+      sessionFactory: () => new AgentSession({ model: createFakeModel([]), tools: [] }),
+    });
+    const parent = new AgentSession({ model: parentFake, tools: [tool], hooks: [probe.hook] });
+    await parent.run("go");
+    expect(probe.events).toEqual([]);
+    parentFake.teardown();
+  });
+
+  it("regression: without a probe hook, subAgentTool behaves byte-for-byte as 0.3.0", async () => {
+    // 没挂任何 onSubagentStart/End hook → fire* 走 no-op 路径，工具结果 shape 不变。
+    const subFake = createFakeModel([
+      { content: [{ type: "text", text: "child" }], stopReason: "stop", usage: { input: 1, output: 2 } },
+    ]);
+    const tool = subAgentTool({
+      sessionFactory: () => new AgentSession({ model: subFake, tools: [] }),
+    });
+    const parentFake = createFakeModel([
+      { content: [{ type: "toolCall", name: "subAgent", arguments: { task: "t" } }] },
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const parent = new AgentSession({ model: parentFake, tools: [tool] }); // 无 hooks
+    await parent.run("go");
+    const tr = parent.messages.find((m) => m.role === "toolResult") as
+      | { content: unknown; details?: unknown }
+      | undefined;
+    expect(tr).toBeDefined();
+    const text = Array.isArray(tr!.content)
+      ? tr!.content.map((b) => ("text" in b ? (b as { text: string }).text : "")).join("")
+      : "";
+    expect(text).toBe("child"); // 回灌父模型的文本 = 子最后一条 assistant
+    const details = tr!.details as { subAgent?: { reason?: string; turns?: number } };
+    expect(details.subAgent?.reason).toBe("done");
+    expect(details.subAgent?.turns).toBe(1);
+    parentFake.teardown();
+    subFake.teardown();
+  });
+});

--- a/packages/plugins/src/controllers/sub-agent-tool.ts
+++ b/packages/plugins/src/controllers/sub-agent-tool.ts
@@ -115,11 +115,17 @@ async function spawnSubAgent(
   // O5：spawn 前 fire onSubagentStart（子在 depth+1）。
   await ctx.fireSubagentStart({ agentId: sub.id, task, depth: depth + 1 });
   // 父 signal 透传 → sub-agent 可被父的 abort 协作式取消。
+  // start↔end 配对依赖 `sub.run()` **永不 throw**：内核 turn loop 把所有终态（done/aborted/error/
+  // max_turns）转成 RunSummary 返回（仅 re-entrancy guard 会 throw，而这里每次造全新 sub 跑一次、不可能命中）。
+  // 若将来 run() 改成某些路径 throw，下面的 fireSubagentEnd 会被跳过、留下没配对 end 的 start——届时需补 try/finally。
   const summary = await sub.run(task, { signal });
   // opt-in 续聊：把跑完首轮的子 session 留住（默认不传 → 跑完即弃）。
   onSpawn?.(sub);
   const result = subAgentResult(sub, summary);
-  // O5：跑完后 fire onSubagentEnd（带终态）。summaryText 复用回灌父模型的同一份文本。
+  // O5：跑完后 fire onSubagentEnd（带终态）。summaryText 复用回灌父模型的同一份文本；无文本则省略该字段
+  // （对齐 OnSubagentEndInput.summaryText「无文本输出则缺省」的契约）。注意 error 终态下 lastMessage 语义
+  // 同 RunSummary.lastMessage——可能是上一成功 turn 的陈旧文本，消费者应配合 reason 判读。
+  const summaryText = messageText(summary.lastMessage);
   await ctx.fireSubagentEnd({
     agentId: sub.id,
     task,
@@ -127,7 +133,7 @@ async function spawnSubAgent(
     reason: summary.reason,
     turns: summary.turns,
     usage: summary.usage,
-    summaryText: messageText(summary.lastMessage),
+    ...(summaryText ? { summaryText } : {}),
   });
   return result;
 }

--- a/packages/plugins/src/controllers/sub-agent-tool.ts
+++ b/packages/plugins/src/controllers/sub-agent-tool.ts
@@ -85,6 +85,11 @@ export function subAgentResult(sub: AgentSession, summary: RunSummary): ToolExec
  * 纵向深度透传（给子挂 onSessionStart hook 把深度设为 父+1）、父 signal 透传、子终态回灌全在此收口。
  * 横向/纵向闸由调用方在调用前各自判（错误文案各自独立），故本函数只管「确实要 spawn 时」的动作。
  *
+ * `ctx`：**父** session 的 HookContext。O5——在子 run 前后经它把 `onSubagentStart`/`onSubagentEnd`
+ * 事件派发到父 session 的 hook（metrics / sessionLog 等据此统一观测子 agent 生命周期）。
+ * **作用域边界**：只有走本函数（subAgentTool / routedSubAgentTool）spawn 的子才 fire；forkSession /
+ * workPool / 直接 `new AgentSession` 的子无父 ctx 在 scope，**不 fire**（O5 设计的 opt-in 边界）。
+ *
  * `onSpawn`（opt-in）：spawn 完一拿到终态就回调，让调用方（如 SubAgentRegistry）把子 session 留住以便续聊。
  * 不传则子 session 跑完即弃（0.2.4 行为）。在 run 之后调 → 句柄已带完整首轮上下文。
  */
@@ -93,6 +98,7 @@ async function spawnSubAgent(
   task: string,
   depth: number,
   signal: AbortSignal,
+  ctx: HookContext,
   onSpawn?: (session: AgentSession) => void,
 ): Promise<ToolExecResult> {
   // 纵向深度透传：给子 session 挂一个 onSessionStart hook，把子 ctx.state 的深度设为 当前+1。
@@ -106,11 +112,24 @@ async function spawnSubAgent(
     },
   };
   sub.use(depthInjector);
+  // O5：spawn 前 fire onSubagentStart（子在 depth+1）。
+  await ctx.fireSubagentStart({ agentId: sub.id, task, depth: depth + 1 });
   // 父 signal 透传 → sub-agent 可被父的 abort 协作式取消。
   const summary = await sub.run(task, { signal });
   // opt-in 续聊：把跑完首轮的子 session 留住（默认不传 → 跑完即弃）。
   onSpawn?.(sub);
-  return subAgentResult(sub, summary);
+  const result = subAgentResult(sub, summary);
+  // O5：跑完后 fire onSubagentEnd（带终态）。summaryText 复用回灌父模型的同一份文本。
+  await ctx.fireSubagentEnd({
+    agentId: sub.id,
+    task,
+    depth: depth + 1,
+    reason: summary.reason,
+    turns: summary.turns,
+    usage: summary.usage,
+    summaryText: messageText(summary.lastMessage),
+  });
+  return result;
 }
 
 export function subAgentTool(opts: SubAgentToolOptions): HarnessTool {
@@ -148,7 +167,7 @@ export function subAgentTool(opts: SubAgentToolOptions): HarnessTool {
       spawned++;
 
       const sub = opts.sessionFactory(task, ctx);
-      return spawnSubAgent(sub, task, depth, signal, opts.onSpawn);
+      return spawnSubAgent(sub, task, depth, signal, ctx, opts.onSpawn);
     },
   };
 }
@@ -270,7 +289,7 @@ export function routedSubAgentTool(opts: RoutedSubAgentToolOptions): HarnessTool
       spawned++;
 
       const sub = spec.sessionFactory(task, ctx);
-      return spawnSubAgent(sub, task, depth, signal, opts.onSpawn);
+      return spawnSubAgent(sub, task, depth, signal, ctx, opts.onSpawn);
     },
   };
 }


### PR DESCRIPTION
0.3.1 第一项:让**父** session 的 hook 在子 agent spawn 前/跑完后收到生命周期 event,使 metrics/sessionLog 等现有 plugin 统一观测子 agent。**0.3.1 首个碰内核的改动**——严守内核极简。

## 改动(99 行内核纯增量,0 删除/0 现有行修改)
- **hook.ts**:`OnSubagentStartInput{agentId,task,depth}` + `OnSubagentEndInput{+reason,turns,usage,summaryText?}`;`Hook` 加 `onSubagentStart?`/`onSubagentEnd?`(fire-and-observe,返回忽略);`HookContext` 加 `fireSubagentStart`/`fireSubagentEnd`。
- **dispatcher.ts**:`EVENT_METHODS` + `EventInputMap` 各 +2(走现有 `fireEvent` 并行 observe,复用 per-hook timeout / fail-open)。
- **context.ts**:`HookContextDeps` 加 2 个可选 kernel-wired 回调;`HookContextImpl` 实现 2 个 fire 方法(缺省 no-op)。
- **session.ts**:ctxDeps wire 2 回调到 `dispatcher.fireEvent`,忽略返回。
- **plugins/sub-agent-tool.ts**:`spawnSubAgent` 加 `ctx`,`sub.run` 前后各 fire 一次;subAgentTool/routedSubAgentTool 共享。

## 为何要碰内核(必要性,linus 闸已独立核验)
零内核替代(onPostToolUse 读 `details.subAgent`)**结构上拿不到 start 态**,end 态还得靠 tool 名+details 形状嗅探、无 `depth`/`task` 一等字段。让子生命周期成为父 hook 可统一订阅的一等 event,只能在内核开这个最小 seam(信任模型同 `appendMessage`/`abort`)。

## 作用域边界(诚实声明,3 处 JSDoc)
只 subAgentTool/routedSubAgentTool(共享 `spawnSubAgent`)fire;forkSession/workPool/直接 `new AgentSession` 的子**不**fire(无父 ctx)——未改那些 controller。

## 质量
- 3 闸 review-gate(code/test/linus)**全 PASS**;linus 闸专核内核必要性+最小性+信任模型+边界诚实,无 blocker/major。
- 已折入 review 指出的硬化:summaryText 空则省略(对齐契约)、文档化 `sub.run` 永不 throw 的配对不变量、补端到端「throw 的 hook 不破父/子控制流」+「非 done reason 直透」测试、强化 dispatcher observe-only 断言。
- **opt-in 零回归**:不 spawn 子 / 不挂 onSubagent* hook 时与 0.3.0 逐字节一致(回归断言)。
- core 289 + plugins 387 测试绿;build + typecheck 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)