### PR TITLE
test(coding-agent): D0 testD — provider-verified budget-bound continuation (#82)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ pnpm -r publish --access public --no-git-checks                    # 拓扑序,w
 
 当前 **0.2.0 = hardened spike preview**。区分三层(`README.md`「当前状态」):
 1. **机制已实现** ✅(代码 + 本地/CI 测试覆盖)。
-2. **provider 已验证**(真 LLM 跑 streaming/error/overflow smoke)——**未做**。
+2. **provider 已验证**(真 LLM 跑 smoke):streaming/error/budget-bound continuation 已验证(`scripts/d0-smoke.ts` A/B/D,`pnpm --filter @harness-pi/coding-agent run smoke:provider`);reactive overflow 在容忍型 provider 测不了,由 `context-overflow.test.ts` 覆盖(#82 已知限制)。
 3. **bidding-migration 已验证**(真 `bidding-agent` spike)——**未做**。
 
 → **spike-ready,不是 `bidding-agent` 的生产替代品**。剩的是「真实环境验证」,不是缺机制。

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 判断成熟度时区分三个层级，别把它们混为一谈：
 
 1. **机制已实现**（mechanism implemented，代码 + 本地测试通过）：包括 streaming `message_update` / thinking parity、完整 auto-compaction、PG sink——这些**都已经落地并有本地测试覆盖**，不再是迁移 blocker。
-2. **provider 已验证**（provider-verified）：用真实 provider 跑 streaming / error / overflow 的 smoke。**尚未完成。**
+2. **provider 已验证**（provider-verified）：用真实 provider（DashScope/Qwen）跑 smoke——**streaming、error 提级、budget-bound continuation（小预算下跨 autoCompaction 续跑）已验证**（`apps/coding-agent/scripts/d0-smoke.ts` 的 A/B/D；跑法 `pnpm --filter @harness-pi/coding-agent run smoke:provider`，key 经 env 注入不落盘，任一 ✗ 则非零退出）。reactive overflow（>窗口强行触发）在容忍型 1M 窗口 provider 上测不了，由确定性测试 `context-overflow.test.ts` 覆盖——此为已知限制（#82）。
 3. **bidding-migration 已验证**（bidding-migration-validated）：用真实 `bidding-agent` 做一次 spike 跑通。**尚未完成。**
 
 结论：harness-pi 已经 **spike-ready**，但**还不是 `bidding-agent` 的生产替代品**。剩下的差距是「真实 provider 在规模下的验证」+「一次 bidding-agent 迁移 spike」，**不是缺机制**。当前建议仍是先把 `bidding-agent` 内部接口形状对齐，再用 worktree 做最小 happy-path spike。

--- a/apps/coding-agent/package.json
+++ b/apps/coding-agent/package.json
@@ -38,7 +38,8 @@
     "build": "tsc -p .",
     "typecheck": "tsc -p . --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "smoke:provider": "tsx scripts/d0-smoke.ts"
   },
   "dependencies": {
     "@earendil-works/pi-ai": "^0.74.2",

--- a/apps/coding-agent/scripts/d0-smoke.ts
+++ b/apps/coding-agent/scripts/d0-smoke.ts
@@ -11,9 +11,12 @@
  *   A'. X1/X2 估算校准:estimateRequestTokens(turn-0 含 tool schema) vs 真 usage.input 偏差。
  *   B. provider error(坏 apiKey):#53 —— 真 401 → reason=error(不再静默 done)、不误判 overflow。
  *   C. 容忍型 provider 探针:大(但 < 窗口)prompt 正常完成、不误 fire overflow(记录为何真 overflow 不便宜)。
+ *   D. budget-bound continuation(#82):小预算下 autoCompaction(X2)真触发,真 provider 吃压缩后视图续跑
+ *      到 reason=done,且早期事实跨压缩存活。容忍型 provider 测不了 reactive overflow(见 C),改测这条
+ *      provider-无关的等价路径——这是 #82 的真 provider 缺口所在。
  */
 import { AgentSession, type HarnessTool } from "@harness-pi/core";
-import { estimateRequestTokens } from "@harness-pi/plugins";
+import { autoCompaction, estimateRequestTokens } from "@harness-pi/plugins";
 import { Type } from "@earendil-works/pi-ai";
 import { resolveDashScopeModel } from "../src/providers/dashscope.js";
 
@@ -30,6 +33,19 @@ let failures = 0;
 function check(name: string, cond: boolean, detail = ""): void {
   console.log(`  ${cond ? "✓" : "✗"} ${name}${detail ? ` — ${detail}` : ""}`);
   if (!cond) failures++;
+}
+
+// pi-ai 的 Message.content 可能是 string(user prompt)或 block 数组(assistant);两种都取出纯文本。
+function textOf(m: { content?: unknown } | undefined): string {
+  const c = m?.content;
+  if (typeof c === "string") return c;
+  if (Array.isArray(c)) {
+    return (c as Array<{ type?: string; text?: string }>)
+      .filter((b) => b && b.type === "text")
+      .map((b) => b.text ?? "")
+      .join(" ");
+  }
+  return "";
 }
 
 const addTool: HarnessTool = {
@@ -181,6 +197,78 @@ async function testC(): Promise<void> {
   );
 }
 
+async function testD(): Promise<void> {
+  console.log(`\n[D] budget-bound continuation:小预算下真 provider 跨自动压缩续跑 (model=${MODEL_ID})`);
+  const { model, llmOptions } = resolveDashScopeModel(MODEL_ID, {
+    DASHSCOPE_API_KEY: key,
+  });
+
+  const SECRET = "ZEBRA-42";
+  let compactions = 0;
+  let viewHadSummary = false;
+
+  const session = new AgentSession({
+    model,
+    tools: [],
+    systemPrompt: "You are a terse assistant. Always obey the user's reply-format instruction exactly.",
+    llmOptions,
+    maxTurns: 2,
+    consoleSink: () => {},
+    hooks: [
+      // 小预算自动压缩(X2 #57):估算 token > maxContextTokens*triggerRatio 即把早期消息压成
+      // 一条 summary + 保留 recent tail(view-only,不改 session.messages、不破坏 lineage)。
+      autoCompaction({
+        maxContextTokens: 900,
+        triggerRatio: 0.6,
+        keepRecent: 2,
+        summarize: (early) => {
+          compactions++;
+          // 确定性 summary(不额外烧 LLM):保留早期 user 文本原文 → 秘密词随之进入压缩视图,
+          // 用来验证「事实跨压缩存活 + 真 provider 接受压缩视图」。
+          const earlyText = early.map((m) => textOf(m)).join(" ");
+          return `[COMPACTED] earlier conversation preserved verbatim: ${earlyText}`;
+        },
+      }),
+      // 观测哨兵:压缩触发后,真正发给 provider 的视图里应能看到 [COMPACTED]。
+      // 注册在 autoCompaction 之后 → transform 管线里后跑 → 看到的是压缩后视图。
+      {
+        name: "d0-view-probe",
+        transformMessagesBeforeLlm: (messages) => {
+          if (messages.some((m) => textOf(m).includes("[COMPACTED]"))) {
+            viewHadSummary = true;
+          }
+          return messages;
+        },
+      },
+    ],
+  });
+
+  // 多轮纯文本 user turn(无 tool → 压缩切片不会切断 tool_use/tool_result 对):
+  // turn-1 埋事实 → turn-2/3 灌填充把累计估算顶过预算阈值触发压缩 → 末轮要求跨压缩回忆。
+  const filler = "Background note: the maintenance log records routine readings with no anomalies. ".repeat(40);
+  const r1 = await session.run(`Remember this secret word: ${SECRET}. Reply with only: ok`);
+  const r2 = await session.run(`${filler}\nReply with only: ok`);
+  const r3 = await session.run(`${filler}\nReply with only: ok`);
+  const rF = await session.run(
+    "What was the secret word I told you at the very start? Reply with just that word, nothing else.",
+  );
+  const finalText = textOf(rF.lastMessage);
+
+  // compactions===0 = 填充没顶过阈值、压缩根本没跑 → 这条 smoke 啥也没验,计为失败别假绿。
+  check("autoCompaction 真触发(summarize 被调用)", compactions > 0, `compactions=${compactions}`);
+  check("真 provider 收到的是压缩后视图([COMPACTED] 哨兵可见)", viewHadSummary);
+  check("turn-1 reason=done", r1.reason === "done", `r1=${r1.reason}`);
+  check("turn-2 reason=done(压缩中续跑)", r2.reason === "done", `r2=${r2.reason}`);
+  check("turn-3 reason=done(压缩后续跑)", r3.reason === "done", `r3=${r3.reason}`);
+  check("末轮 reason=done(跨压缩续跑收敛)", rF.reason === "done", `rF=${rF.reason}`);
+  check(
+    `秘密词跨压缩存活(最终回答含 ${SECRET})`,
+    finalText.toUpperCase().includes("ZEBRA"),
+    `final="${finalText.slice(0, 60)}"`,
+  );
+  console.log(`  · 末轮真 usage: input=${rF.usage.input} output=${rF.usage.output}`);
+}
+
 async function main(): Promise<void> {
   console.log(`=== D0 真 provider smoke (DashScope ${MODEL_ID}) ===`);
   try {
@@ -200,6 +288,12 @@ async function main(): Promise<void> {
   } catch (err) {
     failures++;
     console.error("  ✗ [C] 抛异常:", err instanceof Error ? err.message : err);
+  }
+  try {
+    await testD();
+  } catch (err) {
+    failures++;
+    console.error("  ✗ [D] 抛异常:", err instanceof Error ? err.message : err);
   }
   console.log(`\n=== D0 smoke 结束:${failures === 0 ? "全部 ✓" : `${failures} 项 ✗`} ===`);
   process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Closes #82

## 补齐 #82 的真 provider 缺口：budget-bound continuation

#44(D0)已验 streaming(A)/error(B)；#82 余下的真 provider 路径 = **overflow/budget 续跑**。Qwen 是容忍型 + 1M 窗口，灌 4× 窗口都不触发 reactive overflow（见 d0-smoke testC），所以改测 #82 同样接受的 **budget-bound continuation 等价路径**：

**testD**：小预算下 `autoCompaction(maxContextTokens 小)` 真触发 → 真 DashScope 吃压缩后视图跨多轮续跑到 `reason=done` → 早期事实跨压缩存活。
- 断言：`compactions>0`、各轮 `reason=done`、末轮回答含跨压缩秘密词、`[COMPACTED]` 哨兵证明真 provider 收到的是压缩后视图。
- 真 DashScope(qwen-turbo)实跑 **A/B/C/D 全部 ✓**。

### 附带
- **修真 bug**：`textOf()` 统一兼容 `Message.content` 的 string(user)/数组(assistant)两种形态——原 testD 写法对 user 消息 `.some()` 报错且静默抽空 summary。
- `apps/coding-agent` 加 `smoke:provider` 脚本（`pnpm --filter @harness-pi/coding-agent run smoke:provider`，key 经 env 注入不落盘，任一 ✗ 非零退出）。
- 订正 `README.md` / `CLAUDE.md`「provider 已验证 = 未做」过时措辞 → streaming/error/budget-continuation 已验，仅 reactive overflow 留作已知限制。

### 验收
`scripts/d0-smoke.ts` 不进 CI（真 API 外呼），手动跑全绿即验收；CI 跑常规 build/typecheck/test 不受影响（脚本不在 tsconfig include）。
