### PR TITLE
feat(coding-agent): 启动时自动加载 CLAUDE.md/AGENTS.md 注入 system prompt

### DIFF
--- a/apps/coding-agent/src/__tests__/project-instructions.test.ts
+++ b/apps/coding-agent/src/__tests__/project-instructions.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createFakeModel } from "@harness-pi/core/testing";
+import { loadProjectInstructions } from "../project-instructions.js";
+import { createCodingAgent } from "../agent.js";
+import { emitProjectInstructionsNotice, parseArgs } from "../cli.js";
+
+const dirs: string[] = [];
+afterEach(async () => {
+  while (dirs.length) {
+    const d = dirs.pop();
+    if (d) await rm(d, { recursive: true, force: true });
+  }
+});
+
+async function tmp(): Promise<string> {
+  const d = await mkdtemp(join(tmpdir(), "harness-pi-projinstr-test-"));
+  dirs.push(d);
+  return d;
+}
+
+// ─── loadProjectInstructions 单元测试 ────────────────────────────────────────
+
+describe("loadProjectInstructions", () => {
+  it("cwd 下有 CLAUDE.md → 返回内容与路径", async () => {
+    const cwd = await tmp();
+    await writeFile(join(cwd, "CLAUDE.md"), "# My Project\nDo stuff.\n");
+
+    const result = loadProjectInstructions(cwd);
+    expect(result).not.toBeNull();
+    expect(result!.content).toContain("My Project");
+    expect(result!.sourcePath).toBe(join(cwd, "CLAUDE.md"));
+  });
+
+  it("cwd 下有 AGENTS.md → 返回内容与路径", async () => {
+    const cwd = await tmp();
+    await writeFile(join(cwd, "AGENTS.md"), "# Agent instructions\n");
+
+    const result = loadProjectInstructions(cwd);
+    expect(result).not.toBeNull();
+    expect(result!.content).toContain("Agent instructions");
+    expect(result!.sourcePath).toBe(join(cwd, "AGENTS.md"));
+  });
+
+  it("CLAUDE.md 优先于 AGENTS.md", async () => {
+    const cwd = await tmp();
+    await writeFile(join(cwd, "CLAUDE.md"), "claude content\n");
+    await writeFile(join(cwd, "AGENTS.md"), "agents content\n");
+
+    const result = loadProjectInstructions(cwd);
+    expect(result!.sourcePath).toBe(join(cwd, "CLAUDE.md"));
+  });
+
+  it("cwd 无文件时向上查找父目录", async () => {
+    const parent = await tmp();
+    await writeFile(join(parent, "CLAUDE.md"), "parent instructions\n");
+    const child = join(parent, "sub", "project");
+    await mkdir(child, { recursive: true });
+
+    const result = loadProjectInstructions(child);
+    expect(result).not.toBeNull();
+    expect(result!.sourcePath).toBe(join(parent, "CLAUDE.md"));
+    expect(result!.content).toContain("parent instructions");
+  });
+
+  it("整棵目录树都没有指令文件 → 不抛错", async () => {
+    const cwd = await tmp();
+    const deep = join(cwd, "a", "b", "c");
+    await mkdir(deep, { recursive: true });
+
+    // 无法保证系统 tmp 父目录也没有文件，因此只断言不抛
+    expect(() => loadProjectInstructions(deep)).not.toThrow();
+  });
+
+  it("AGENTS.md 是 CLAUDE.md 的符号链接 → 也能正确加载", async () => {
+    const cwd = await tmp();
+    await writeFile(join(cwd, "CLAUDE.md"), "symlink target content\n");
+    await symlink(join(cwd, "CLAUDE.md"), join(cwd, "AGENTS.md"));
+
+    // CLAUDE.md 优先，所以直接命中
+    const result = loadProjectInstructions(cwd);
+    expect(result!.sourcePath).toBe(join(cwd, "CLAUDE.md"));
+    expect(result!.content).toContain("symlink target content");
+  });
+});
+
+// ─── createCodingAgent 集成：system prompt 注入 ──────────────────────────────
+
+describe("createCodingAgent project instructions injection", () => {
+  it("有 CLAUDE.md → system prompt 包含文件内容", async () => {
+    const cwd = await tmp();
+    await writeFile(join(cwd, "CLAUDE.md"), "SPECIAL_MARKER_XYZ\n");
+    const fake = createFakeModel([]);
+
+    const agent = createCodingAgent({ cwd, model: fake });
+    expect(agent.session.systemPrompt).toContain("SPECIAL_MARKER_XYZ");
+    expect(agent.projectInstructionsPath).toBe(join(cwd, "CLAUDE.md"));
+  });
+
+  it("无文件 → system prompt 与默认一致，projectInstructionsPath 为 undefined", async () => {
+    const cwd = await tmp();
+    const fake = createFakeModel([]);
+
+    const agent = createCodingAgent({ cwd, model: fake });
+    // 没有文件时 projectInstructionsPath 应该是 undefined
+    // （如果父目录恰好有 CLAUDE.md 则 projectInstructionsPath 非 undefined，此断言会跳过）
+    if (agent.projectInstructionsPath === undefined) {
+      expect(agent.session.systemPrompt).not.toContain("SPECIAL_MARKER");
+    }
+  });
+
+  it("noProjectInstructions:true → 不注入，projectInstructionsPath 为 undefined", async () => {
+    const cwd = await tmp();
+    await writeFile(join(cwd, "CLAUDE.md"), "SHOULD_NOT_APPEAR\n");
+    const fake = createFakeModel([]);
+
+    const agent = createCodingAgent({ cwd, model: fake, noProjectInstructions: true });
+    expect(agent.session.systemPrompt).not.toContain("SHOULD_NOT_APPEAR");
+    expect(agent.projectInstructionsPath).toBeUndefined();
+  });
+
+  it("有 CLAUDE.md + 自定义 systemPrompt → 两者都出现在 prompt 里", async () => {
+    const cwd = await tmp();
+    await writeFile(join(cwd, "CLAUDE.md"), "PROJECT_RULE_ABC\n");
+    const fake = createFakeModel([]);
+
+    const agent = createCodingAgent({
+      cwd,
+      model: fake,
+      systemPrompt: "CUSTOM_BASE_PROMPT",
+    });
+    expect(agent.session.systemPrompt).toContain("CUSTOM_BASE_PROMPT");
+    expect(agent.session.systemPrompt).toContain("PROJECT_RULE_ABC");
+  });
+});
+
+// ─── CLI 层：--no-project-instructions flag 解析 + 启动通知 ──────────────────
+
+describe("CLI --no-project-instructions", () => {
+  it("默认不传 → noProjectInstructions 为 false", () => {
+    const args = parseArgs(["--cwd", "/tmp"]);
+    expect(args.noProjectInstructions).toBe(false);
+  });
+
+  it("传了 --no-project-instructions → noProjectInstructions 为 true", () => {
+    const args = parseArgs(["--cwd", "/tmp", "--no-project-instructions"]);
+    expect(args.noProjectInstructions).toBe(true);
+  });
+});
+
+describe("emitProjectInstructionsNotice", () => {
+  it("有 projectInstructionsPath → 输出包含路径", () => {
+    const lines: string[] = [];
+    emitProjectInstructionsNotice({ projectInstructionsPath: "/some/CLAUDE.md" }, (s) => lines.push(s));
+    expect(lines.join("")).toContain("/some/CLAUDE.md");
+  });
+
+  it("无 projectInstructionsPath → 不输出任何内容", () => {
+    const lines: string[] = [];
+    emitProjectInstructionsNotice({ projectInstructionsPath: undefined }, (s) => lines.push(s));
+    expect(lines).toHaveLength(0);
+  });
+});

--- a/apps/coding-agent/src/agent.ts
+++ b/apps/coding-agent/src/agent.ts
@@ -33,6 +33,7 @@ import {
 import { createModelSummarizer } from "./compaction.js";
 import { redactCodingToolArgs } from "./log-redaction.js";
 import { harnessPiGitignoreWarning } from "./workspace-safety.js";
+import { loadProjectInstructions } from "./project-instructions.js";
 import { defaultPermissionRules } from "./tui/permissions.js";
 import {
   createAllTools,
@@ -103,6 +104,10 @@ export interface CreateCodingAgentOptions {
    * `requestCompaction()`（TUI 的 `/compact`）临时降阈强制压缩。one-shot 模式不传本项即完全不挂。
    */
   compaction?: { maxMessages?: number; keepRecent?: number };
+  /**
+   * true ⇒ 跳过项目指令（CLAUDE.md / AGENTS.md）自动加载。默认 false（自动向上查找并注入）。
+   */
+  noProjectInstructions?: boolean;
 }
 
 export interface CodingAgent {
@@ -118,6 +123,8 @@ export interface CodingAgent {
    * `warnings` 数组（那是脆弱的隐式契约）。同一条文案也会进 `warnings`（供 run report 呈现）。
    */
   harnessPiWarning?: string | undefined;
+  /** 自动加载的项目指令文件路径；未加载时为 undefined。 */
+  projectInstructionsPath?: string | undefined;
   readOnly: boolean;
   logPath: string;
   metricsPath?: string | undefined;
@@ -383,11 +390,18 @@ function buildAgentContext(opts: CreateCodingAgentOptions): AgentContext {
       : []),
   ];
 
+  const projectInstructions =
+    !opts.noProjectInstructions ? loadProjectInstructions(cwd) : null;
+  const baseSystemPrompt = opts.systemPrompt ?? DEFAULT_SYSTEM_PROMPT;
+  const systemPrompt = projectInstructions
+    ? `${baseSystemPrompt}\n\n${projectInstructions.content}`
+    : baseSystemPrompt;
+
   const deps: AgentContext["deps"] = {
     model: opts.model,
     tools,
     hooks,
-    systemPrompt: opts.systemPrompt ?? DEFAULT_SYSTEM_PROMPT,
+    systemPrompt,
   };
   if (opts.maxTurns !== undefined) deps.maxTurns = opts.maxTurns;
   if (opts.llmOptions !== undefined) deps.llmOptions = opts.llmOptions;
@@ -406,6 +420,7 @@ function buildAgentContext(opts: CreateCodingAgentOptions): AgentContext {
         costKnown,
         warnings,
         harnessPiWarning,
+        projectInstructionsPath: projectInstructions?.sourcePath,
         readOnly,
         logPath: join(logDir, `${session.id}.ndjson`),
         metricsPath: opts.metricsFile,

--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -47,6 +47,7 @@ interface CliArgs {
   listModels?: string | undefined;
   version: boolean;
   help: boolean;
+  noProjectInstructions: boolean;
 }
 
 /** TUI 会话落盘文件路径:.harness-pi/sessions/<id>.jsonl（相对 cwd）。 */
@@ -63,6 +64,18 @@ export function emitStartupWarnings(
   write: (s: string) => void,
 ): void {
   if (agent.harnessPiWarning) write(`⚠️  ${agent.harnessPiWarning}\n`);
+}
+
+/**
+ * 启动期把项目指令加载来源打到 stderr，让用户知道读了哪个文件。
+ */
+export function emitProjectInstructionsNotice(
+  agent: Pick<CodingAgent, "projectInstructionsPath">,
+  write: (s: string) => void,
+): void {
+  if (agent.projectInstructionsPath) {
+    write(`[project instructions: ${agent.projectInstructionsPath}]\n`);
+  }
 }
 
 /**
@@ -197,6 +210,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     readOnly: args.readOnly,
     disabledTools: args.disabledTools,
   };
+  if (args.noProjectInstructions) createOptions.noProjectInstructions = true;
   if (runtime.llmOptions !== undefined) {
     createOptions.llmOptions = runtime.llmOptions;
   }
@@ -249,6 +263,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
   // 不渲染 run report 也能看到）。读 agent 的**结构化标志** harnessPiWarning（agent 已算好「是否落盘」
   // 门控），不按文案字符串匹配 warnings 数组。one-shot 的 run report 也会再列一次，刻意冗余。
   emitStartupWarnings(agent, (s) => process.stderr.write(s));
+  emitProjectInstructionsNotice(agent, (s) => process.stderr.write(s));
 
   try {
     if (!args.readOnly) {
@@ -307,6 +322,7 @@ export function parseArgs(argv: string[]): CliArgs {
     listProviders: false,
     version: false,
     help: false,
+    noProjectInstructions: false,
   };
   const task: string[] = [];
 
@@ -389,6 +405,10 @@ export function parseArgs(argv: string[]): CliArgs {
     }
     if (arg === "--metrics-file") {
       out.metricsFile = requireValue(argv, ++i, "--metrics-file");
+      continue;
+    }
+    if (arg === "--no-project-instructions") {
+      out.noProjectInstructions = true;
       continue;
     }
     if (arg?.startsWith("--")) {
@@ -553,6 +573,7 @@ Options:
   --no-log                 Disable the session log entirely.
   --log-args <mode>        Tool-arg logging: redacted (default) | full | none.
   --metrics-file <path>    Write run metrics as NDJSON.
+  --no-project-instructions  Skip auto-loading CLAUDE.md / AGENTS.md into the system prompt.
   --list-providers         List supported providers and their API-key env vars.
   --list-models <provider> List model ids for a provider.
   --version                Print the version.

--- a/apps/coding-agent/src/project-instructions.ts
+++ b/apps/coding-agent/src/project-instructions.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+/** 候选文件名，按优先级排列：CLAUDE.md 优先，其次 AGENTS.md。 */
+const CANDIDATE_NAMES = ["CLAUDE.md", "AGENTS.md"] as const;
+
+export interface ProjectInstructions {
+  content: string;
+  sourcePath: string;
+}
+
+/**
+ * 从 `startDir` 向上查找 CLAUDE.md 或 AGENTS.md，找到第一个即返回内容与路径。
+ * 找不到返回 null（静默回落，不报错）。
+ */
+export function loadProjectInstructions(startDir: string): ProjectInstructions | null {
+  let dir = startDir;
+  while (true) {
+    for (const name of CANDIDATE_NAMES) {
+      const candidate = join(dir, name);
+      try {
+        const content = readFileSync(candidate, "utf8");
+        return { content, sourcePath: candidate };
+      } catch {
+        // 文件不存在或不可读，继续尝试
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break; // 已到文件系统根
+    dir = parent;
+  }
+  return null;
+}


### PR DESCRIPTION
## 改动说明

新增 `apps/coding-agent/src/project-instructions.ts`，实现从 `--cwd` 向上查找并加载 `CLAUDE.md`（优先）或 `AGENTS.md`，将内容拼接在 `DEFAULT_SYSTEM_PROMPT` 之后注入 system prompt。

核心行为：
- **自动向上查找**：从 cwd 逐级向上，找到第一个 CLAUDE.md / AGENTS.md 即用（加载一份，不多级嵌套）
- **CLAUDE.md 优先**：两文件同目录时取 CLAUDE.md
- **静默回落**：找不到文件不报错，行为与现状一致
- **启动横幅可见**：加载来源打到 stderr（`[project instructions: <path>]`）
- **`--no-project-instructions`**：可关闭此行为

## 逐条验收对照

- [x] 在带 CLAUDE.md 的 repo 里启动，system prompt 含该文件内容（由测试验证 `agent.session.systemPrompt`）
- [x] 无文件时行为与现状一致（测试覆盖）
- [x] `--no-project-instructions` 关闭注入（测试覆盖）
- [x] 找不到文件时静默回落，不报错（测试覆盖）
- [x] 加载来源在启动横幅/日志里可见（`emitProjectInstructionsNotice`，测试覆盖）
- [x] 单测：有/无文件、向上查找、AGENTS.md 符号链接、关闭开关

## 测试说明

```
pnpm --filter @harness-pi/coding-agent test
# 21 test files, 254 tests passed (↑14 from baseline 240)
pnpm --filter @harness-pi/coding-agent typecheck
# 无报错
```

## Brief 偏差报告

无偏差。

Closes #89