### PR TITLE
feat(coding-agent): edit/write/bash 审批显示 diff/内容预览

### DIFF
--- a/apps/coding-agent/src/tui/__tests__/format.test.ts
+++ b/apps/coding-agent/src/tui/__tests__/format.test.ts
@@ -7,6 +7,8 @@ import {
   formatStatusBar,
   formatTokenCount,
   formatContextGauge,
+  formatApprovalPreview,
+  buildLineDiff,
 } from "../format.js";
 
 // 剥 ANSI 颜色，断言结构而非具体转义码。
@@ -111,5 +113,117 @@ describe("format helpers", () => {
   it("formatStatusBar omits the gauge when window is unknown or zero", () => {
     expect(strip(formatStatusBar({ model: "m", contextTokens: 50_000 }))).toBe("m");
     expect(strip(formatStatusBar({ model: "m", contextTokens: 50_000, contextWindow: 0 }))).toBe("m");
+  });
+});
+
+describe("buildLineDiff", () => {
+  it("shows removed and added lines for a simple replacement", () => {
+    const diff = buildLineDiff("foo", "bar");
+    const stripped = diff.map(strip);
+    expect(stripped).toContain("-foo");
+    expect(stripped).toContain("+bar");
+  });
+
+  it("preserves common prefix/suffix as context lines", () => {
+    const old = "a\nb\nc\nd";
+    const neu = "a\nb\nX\nd";
+    const diff = buildLineDiff(old, neu);
+    const stripped = diff.map(strip);
+    expect(stripped).toContain(" a");
+    expect(stripped).toContain(" b");
+    expect(stripped).toContain("-c");
+    expect(stripped).toContain("+X");
+    expect(stripped).toContain(" d");
+  });
+
+  it("shows ellipsis for long common prefix beyond 3 context lines", () => {
+    const prefix = Array.from({ length: 10 }, (_, i) => `line${i}`).join("\n");
+    const old = `${prefix}\nOLD`;
+    const neu = `${prefix}\nNEW`;
+    const diff = buildLineDiff(old, neu);
+    const stripped = diff.map(strip);
+    expect(stripped.some((l) => l.includes("unchanged lines"))).toBe(true);
+    expect(stripped).toContain("-OLD");
+    expect(stripped).toContain("+NEW");
+  });
+
+  it("handles new file (empty oldText)", () => {
+    const diff = buildLineDiff("", "hello\nworld");
+    const stripped = diff.map(strip);
+    expect(stripped).toContain("-");
+    expect(stripped).toContain("+hello");
+    expect(stripped).toContain("+world");
+  });
+
+  it("handles deletion (empty newText)", () => {
+    const diff = buildLineDiff("hello\nworld", "");
+    const stripped = diff.map(strip);
+    expect(stripped).toContain("-hello");
+    expect(stripped).toContain("-world");
+    expect(stripped).toContain("+");
+  });
+});
+
+describe("formatApprovalPreview", () => {
+  it("edit: shows path header and colored diff", () => {
+    const out = strip(
+      formatApprovalPreview({
+        name: "edit",
+        arguments: { path: "src/index.ts", oldText: "const a = 1;", newText: "const a = 2;" },
+      }),
+    );
+    expect(out).toContain("src/index.ts");
+    expect(out).toContain("-const a = 1;");
+    expect(out).toContain("+const a = 2;");
+  });
+
+  it("edit: truncates long diffs", () => {
+    const oldText = Array.from({ length: 50 }, (_, i) => `old-${i}`).join("\n");
+    const newText = Array.from({ length: 50 }, (_, i) => `new-${i}`).join("\n");
+    const out = formatApprovalPreview({
+      name: "edit",
+      arguments: { path: "big.ts", oldText, newText },
+    });
+    expect(strip(out)).toContain("more lines");
+  });
+
+  it("write: shows path, line count, and content preview", () => {
+    const content = Array.from({ length: 50 }, (_, i) => `line ${i}`).join("\n");
+    const out = strip(
+      formatApprovalPreview({ name: "write", arguments: { path: "out.ts", content } }),
+    );
+    expect(out).toContain("out.ts");
+    expect(out).toContain("50 lines");
+    expect(out).toContain("line 0");
+    expect(out).toContain("more lines");
+  });
+
+  it("write: short content shows fully without truncation hint", () => {
+    const out = strip(
+      formatApprovalPreview({ name: "write", arguments: { path: "a.ts", content: "hello" } }),
+    );
+    expect(out).toContain("a.ts");
+    expect(out).toContain("1 lines");
+    expect(out).toContain("hello");
+    expect(out).not.toContain("more lines");
+  });
+
+  it("bash: shows full command", () => {
+    const out = strip(
+      formatApprovalPreview({ name: "bash", arguments: { command: "rm -rf /tmp/junk" } }),
+    );
+    expect(out).toContain("bash");
+    expect(out).toContain("rm -rf /tmp/junk");
+  });
+
+  it("bash: shows multiline command fully", () => {
+    const cmd = "echo hello\necho world";
+    const out = strip(formatApprovalPreview({ name: "bash", arguments: { command: cmd } }));
+    expect(out).toContain("echo hello");
+    expect(out).toContain("echo world");
+  });
+
+  it("returns empty for unknown tools", () => {
+    expect(formatApprovalPreview({ name: "read", arguments: { path: "a" } })).toBe("");
   });
 });

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -23,7 +23,7 @@ import {
 import { createUserMessage, type LiveEvent, type Message, type RunSummary, type SessionEvent, type ToolCall } from "@harness-pi/core";
 import { coarseEventToActions, type TuiAction } from "./event-bridge.js";
 import { LiveStreamAccumulator, type StreamOp } from "./live-stream.js";
-import { formatStatusBar, formatToolCall, formatToolCalls, formatToolResult } from "./format.js";
+import { formatApprovalPreview, formatStatusBar, formatToolCall, formatToolCalls, formatToolResult } from "./format.js";
 import { routeSubmit } from "./submit-router.js";
 import { parseSlashCommand, SLASH_COMMANDS, SLASH_HELP, type SlashCommand } from "./slash.js";
 import { formatMultiSummary, orchestrateMulti, parseMultiCommand, subTaskFor } from "./multi.js";
@@ -312,6 +312,8 @@ export function createTuiApp(opts: TuiAppOptions): TuiApp {
     return new Promise<boolean>((resolve) => {
       pendingApproval = { resolve };
       append(new Text(color.yellow(`⚠ Approve tool call?  ${formatToolCall(call)}`), 0, 0));
+      const preview = formatApprovalPreview(call);
+      if (preview.length > 0) append(new Text(preview, 0, 0));
       append(new Text(color.dim("  [y] allow once   ·   [n] deny   (Enter = allow, Esc = deny)"), 0, 0));
       status.setMessage("waiting for approval…");
       tui.requestRender();

--- a/apps/coding-agent/src/tui/format.ts
+++ b/apps/coding-agent/src/tui/format.ts
@@ -86,6 +86,111 @@ export function formatStatusBar(p: {
   return seg.join(color.dim(" · "));
 }
 
+/**
+ * 审批预览：根据工具类型生成给用户看的 diff / 内容预览。
+ * edit → unified diff（着色 + 截断），write → 路径 + 内容预览，bash → 完整命令。
+ */
+export function formatApprovalPreview(call: Pick<ToolCall, "name" | "arguments">): string {
+  const args = call.arguments ?? {};
+  switch (call.name) {
+    case "edit":
+      return formatEditPreview(String(args.path ?? ""), String(args.oldText ?? ""), String(args.newText ?? ""));
+    case "write":
+      return formatWritePreview(String(args.path ?? ""), String(args.content ?? ""));
+    case "bash":
+      return formatBashPreview(String(args.command ?? ""));
+    default:
+      return "";
+  }
+}
+
+const PREVIEW_MAX_LINES = 20;
+const PREVIEW_MAX_CHARS = 3000;
+
+function formatEditPreview(path: string, oldText: string, newText: string): string {
+  const header = color.bold(`── ${path} ──`);
+  const diffLines = buildLineDiff(oldText, newText);
+  const truncated = truncateLines(diffLines, PREVIEW_MAX_LINES);
+  const body = truncated
+    .map((l) => {
+      if (l.startsWith("-")) return color.red(l);
+      if (l.startsWith("+")) return color.green(l);
+      return color.dim(l);
+    })
+    .join("\n");
+  return `${header}\n${body}`;
+}
+
+function formatWritePreview(path: string, content: string): string {
+  const lines = content.split("\n");
+  const totalLines = lines.length;
+  const header = color.bold(`── ${path} ──`) + color.dim(` (${totalLines} lines)`);
+  const preview = lines.slice(0, PREVIEW_MAX_LINES);
+  let body = preview.join("\n");
+  if (body.length > PREVIEW_MAX_CHARS) body = body.slice(0, PREVIEW_MAX_CHARS);
+  if (totalLines > PREVIEW_MAX_LINES) body += `\n${color.dim(`… (+${totalLines - PREVIEW_MAX_LINES} more lines)`)}`;
+  return `${header}\n${color.dim(body)}`;
+}
+
+function formatBashPreview(command: string): string {
+  const header = color.bold("── bash ──");
+  const body = command.length > PREVIEW_MAX_CHARS
+    ? command.slice(0, PREVIEW_MAX_CHARS) + `… (+${command.length - PREVIEW_MAX_CHARS} chars)`
+    : command;
+  return `${header}\n${color.yellow(body)}`;
+}
+
+/** 简单行级 diff：共同前缀/后缀保留为上下文（dim " "），中间差异段用 -/+ 标记。 */
+export function buildLineDiff(oldText: string, newText: string): string[] {
+  const oldLines = oldText.split("\n");
+  const newLines = newText.split("\n");
+
+  let prefixLen = 0;
+  while (prefixLen < oldLines.length && prefixLen < newLines.length && oldLines[prefixLen] === newLines[prefixLen]) {
+    prefixLen++;
+  }
+
+  let suffixLen = 0;
+  while (
+    suffixLen < oldLines.length - prefixLen &&
+    suffixLen < newLines.length - prefixLen &&
+    oldLines[oldLines.length - 1 - suffixLen] === newLines[newLines.length - 1 - suffixLen]
+  ) {
+    suffixLen++;
+  }
+
+  const contextBefore = Math.min(prefixLen, 3);
+  const contextAfter = Math.min(suffixLen, 3);
+
+  const result: string[] = [];
+
+  if (prefixLen > contextBefore) result.push(color.dim(`  … ${prefixLen - contextBefore} unchanged lines …`));
+
+  for (let i = prefixLen - contextBefore; i < prefixLen; i++) {
+    result.push(` ${oldLines[i]}`);
+  }
+
+  for (let i = prefixLen; i < oldLines.length - suffixLen; i++) {
+    result.push(`-${oldLines[i]}`);
+  }
+  for (let i = prefixLen; i < newLines.length - suffixLen; i++) {
+    result.push(`+${newLines[i]}`);
+  }
+
+  for (let i = newLines.length - suffixLen; i < newLines.length - suffixLen + contextAfter; i++) {
+    result.push(` ${newLines[i]}`);
+  }
+
+  if (suffixLen > contextAfter) result.push(color.dim(`  … ${suffixLen - contextAfter} unchanged lines …`));
+
+  return result;
+}
+
+function truncateLines(lines: string[], max: number): string[] {
+  if (lines.length <= max) return lines;
+  return [...lines.slice(0, max), color.dim(`… (+${lines.length - max} more lines)`)];
+}
+
 function indent(text: string, prefix = "  "): string {
   return text
     .split("\n")


### PR DESCRIPTION
Closes #90

## Summary
- **edit 审批**: 渲染 old→new 的着色 unified diff（共同前缀/后缀作为上下文，变更行红/绿标记，超长截断 20 行）
- **write 审批**: 展示目标路径 + 总行数 + 内容预览（截断 20 行）
- **bash 审批**: 展示完整命令（黄色高亮，超长截断 3000 字符）
- 仅改展示层（`format.ts` + `app.ts` requestApproval），不动 allow/ask/deny 决策逻辑和 session log 脱敏策略
- 12 个新测试覆盖 diff 渲染（含截断、新文件、删除、长共同前缀等场景）

## Before / After
**Before**: `⚠ Approve tool call?  edit(path: src/index.ts, oldText: const a = 1;, newText: const a = 2;)` — 单行摘要，看不到实际改动
**After**: 标题行 + 着色 diff 预览 + 快捷键提示，用户一目了然

## Test plan
- [x] `pnpm --filter @harness-pi/coding-agent test` — 266 tests pass (254 existing + 12 new)
- [x] `pnpm -r build` — clean build
- [x] `pnpm -r test` — full monorepo green