### PR TITLE
feat(plugins): progressVerifier —— loop-engineering 的 turn 级 verifier hook

### DIFF
--- a/docs/05-plugins.md
+++ b/docs/05-plugins.md
@@ -2,7 +2,7 @@
 
 > Plugin 解剖、命名/状态约定、标准库 plugin 的完整设计。
 >
-> **计数（以 `packages/plugins/src/index.ts` 实际导出为准）**：**20 个返回 `Hook` 的 plugin 工厂** + **2 个面向模型的工具/技能工厂**（`toolSearch` 返回 `HarnessTool`、`skills` 返回 `{hook, tool}`）+ **1 个 summary 模板辅助件**（`defaultSummarize` / `DEFAULT_SUMMARY_TEMPLATE`，给压缩插件的 `summarize` 用）。分「核心 12」（§5.1–5.12，bidding-agent parity 起点）与「高级 / 0.3.0 新增」（§5.13–5.21，compaction 体系 + 权限 + deferred/skills）两档。
+> **计数（以 `packages/plugins/src/index.ts` 实际导出为准）**：**21 个返回 `Hook` 的 plugin 工厂** + **2 个面向模型的工具/技能工厂**（`toolSearch` 返回 `HarnessTool`、`skills` 返回 `{hook, tool}`）+ **1 个 summary 模板辅助件**（`defaultSummarize` / `DEFAULT_SUMMARY_TEMPLATE`，给压缩插件的 `summarize` 用）。分「核心 12」（§5.1–5.12，bidding-agent parity 起点）与「高级 / 0.3.0 新增」（§5.13–5.22，compaction 体系 + 权限 + deferred/skills + loop-engineering verifier）两档。
 
 ## 0. 目录
 
@@ -36,6 +36,7 @@
    - [5.19 turn-end-guard](#519-turn-end-guard)
    - [5.20 permission-gate](#520-permission-gate)
    - [5.21 deferred-tools + tool-search + skills](#521-deferred-tools--tool-search--skills)（O1/O2 渐进式暴露）
+   - [5.22 progressVerifier](#522-progressverifier)（loop-engineering verifier 闸）
 6. [测试规约](#6-测试规约)
 
 ## 1. Plugin 是什么
@@ -1819,6 +1820,86 @@ export function skills(specs: SkillSpec[], opts?: { toolName?: string }): { hook
 - execution 与 listing 解耦、permissionGate 仍拦
 - toolSearch / skill 屏障型；skills catalog 不含 body、激活是 union、未知 skill 抛、空/重名构造期抛
 （见 `deferred-tools.test.ts` / `skills.test.ts`）
+
+---
+
+### 5.22 progressVerifier
+
+#### 目的
+
+loop-engineering（`/goal` 循环）的 **turn 级进展/目标 verifier hook**。在每个 turn 结束后，用调用方注入的 `judge` 函数判定：
+
+1. **目标达成**（`reached: true`）→ 立即停止 session。
+2. **连续 N turn 无真实进展**（`hasProgress: false`）→ 停止 session 或触发用户的 `onStall` 升级回调。
+
+是 roadmap「Controller / plugin 候选」`progressVerifier` 的实现。作为 `/goal` 命令的**前置依赖**——有了它，loop 不需要在业务层写 if/else 来判断「啥时候停」，而是把停止条件声明为 hook。
+
+#### Hook 形态
+
+Event（`onTurnEnd`）—— 每 turn 结束后（LLM call + tool batch 执行完）触发。`onSessionStart` 重置计数。返回 `{ continue: false }` 停止 session（`RunSummary.reason = "aborted"`，`abortReason` 含插件标识）。
+
+#### 完整设计
+
+详见 [`packages/plugins/src/progress-verifier.ts`](../packages/plugins/src/progress-verifier.ts)。
+
+签名：
+```ts
+export function progressVerifier(opts: {
+  judge: (ctx, input: TurnEndInput) => Promise<ProgressJudgement> | ProgressJudgement;
+  noProgressThreshold?: number;  // 默认 3，须 > 0
+  onStall?: (ctx, info: { consecutiveNoProgress: number }) => void | Promise<void>;
+  timeoutMs?: number;  // 默认 30000，须 > 0
+}): Hook;
+
+export interface ProgressJudgement {
+  reached: boolean;     // 目标达成 → 立即停止
+  hasProgress?: boolean; // 省略则默认 true（乐观）；false → 计入无进展计数
+  message?: string;      // 停止时写入 abortReason
+}
+```
+
+- **`reached: true`**：立即 `return { continue: false, stopReason: "progressVerifier: goal reached [...]" }`。
+- **`hasProgress: false`**：累计 `noProgressCount`；达 `noProgressThreshold` 时调 `onStall`（如有），再以 `{ continue: false }` 停止（若 `onStall` 已 `ctx.abort()`，不二次停止）。
+- **`hasProgress` 省略**（默认 `true`）：重置计数，session 继续——调用方只需在明确发现无进展时才设 `false`。
+- **judge 抛错**：中性处理（跳过本 turn 计数，不计无进展、不计进展），session 继续——避免瞬时错误误停。
+- **`onStall`**：通知回调（日志/报警/降级），可自行 `ctx.abort(customReason)`；若不 abort，插件用默认原因停止并**不** reset 计数（session 就此停止，计数留原值）。
+
+**timeout 默认 30s**：`onTurnEnd` 是 event 类、dispatcher 默认仅 100ms；`judge` 通常需调 LLM，必然超时 → 判断静默失效。故本插件自设宽默认，可经 `timeoutMs` 覆盖（对齐 `turnEndGuard` / `onAfterFlush` 同款约定）。
+
+#### 与其他 plugin 的语义边界（不重叠原则）
+
+| Plugin | hook point | 判断单位 | 触发方向 |
+|---|---|---|---|
+| `repeatedCallGuard` | `onPostToolUse` | 同 (tool, args) 重复次数 | tool-call 级语义信号，主动 abort |
+| `turnEndGuard` | `onContinuationCheck` | session **想停时**的质量闸 | "不让停"——强制再来一轮 |
+| `progressVerifier` | `onTurnEnd` | turn 级目标/进展判据 | "主动停"——达标或无进展时停止 |
+
+三者互补：`repeatedCallGuard` 检测同 pattern 的语法重复；`turnEndGuard` 在 session 认为 done 时做质量校验；`progressVerifier` 用业务谓词判定何时该停。可同时挂，无语义冲突。
+
+#### 配置选项
+
+- `judge`（必）：domain-free，调用方注入业务/LLM 判据。
+- `noProgressThreshold`：默认 3；`timeoutMs`：默认 30000。
+- `onStall`：可选升级回调；省略则直接停止。
+
+#### 失败模式
+
+- **judge 抛错**：中性（跳过计数），session 继续。
+- **judge 超时**（超 `timeoutMs`）：dispatcher 丢弃结果 → 本 turn 判断失效（如同 judge 抛错）。
+- **`onStall` 抛错**：session 照常停止（插件 catch 后以默认原因停止）。
+
+#### 测试要点
+
+- `noProgressThreshold <= 0` / `timeoutMs <= 0` 构造期抛
+- 设了较宽默认 timeout（event 类 100ms 太短）
+- reached=true → 立即停止，abortReason 含 "goal reached"（含自定义 message）
+- hasProgress=false × N → 计数达阈值后停止，abortReason 含 "no progress"
+- hasProgress=true 重置计数，随后再无进展才停（计数从 0 重新累积）
+- judge 抛错中性处理（不计数），session 继续到自然停止或 reached=true
+- onStall 被调用；onStall 调 ctx.abort() 时插件不二次停止
+- hasProgress 省略默认 true，不会意外累计无进展
+- 两 session 各自独立状态
+（见 `progress-verifier.test.ts`）
 
 ---
 

--- a/examples/05-progress-verifier/package.json
+++ b/examples/05-progress-verifier/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@harness-pi-example/05-progress-verifier",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@harness-pi/core": "workspace:*",
+    "@harness-pi/plugins": "workspace:*",
+    "@earendil-works/pi-ai": "^0.74.2"
+  },
+  "devDependencies": {
+    "tsx": "^4.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/examples/05-progress-verifier/src/index.ts
+++ b/examples/05-progress-verifier/src/index.ts
@@ -1,0 +1,130 @@
+/**
+ * Example 05: progressVerifier —— 演示两种停止场景：
+ *   A. 达到目标判据 → session 立即停止（"goal reached"）
+ *   B. 连续 N turn 无进展 → session 超时停止（"no progress"）
+ *
+ * 真实使用时把 `judge` 换成调用 LLM 或检查业务状态的函数；
+ * 这里用 fake model + 计数器模拟，无需 API key。
+ *
+ * 运行：
+ *   pnpm --filter @harness-pi-example/05-progress-verifier start
+ */
+
+import { AgentSession, Type, type HarnessTool } from "@harness-pi/core";
+import { createFakeModel } from "@harness-pi/core/testing";
+import { progressVerifier } from "@harness-pi/plugins";
+
+// 虚拟工具，供 fake model 调用以驱动多 turn。
+const checkStatusTool: HarnessTool = {
+  name: "check_status",
+  description: "Check the current status of the task",
+  parameters: Type.Object({}),
+  async execute() {
+    return { content: [{ type: "text", text: "status: pending" }] };
+  },
+};
+
+// ────────────────────────────────────────────────────────
+// 场景 A：判据在第 3 turn 达成 → session 在 turn 3 停止
+// ────────────────────────────────────────────────────────
+async function sceneA(): Promise<void> {
+  console.log("\n═══ 场景 A：达标即停 ═══");
+
+  // 模拟：turn 0/1 检查状态（tool call），turn 2 模型报告完成（text）。
+  const model = createFakeModel([
+    { content: [{ type: "toolCall", name: "check_status", arguments: {} }] },
+    { content: [{ type: "toolCall", name: "check_status", arguments: {} }] },
+    { content: [{ type: "text", text: "Task is now complete." }] },
+  ]);
+
+  let turnCount = 0;
+
+  const session = new AgentSession({
+    model,
+    tools: [checkStatusTool],
+    systemPrompt: "You check status and report when done.",
+    hooks: [
+      progressVerifier({
+        // 判据：turn 2 起视为达成（模拟：第 3 次 judge 返回 reached=true）。
+        judge: (_ctx, input) => {
+          turnCount++;
+          const reached = input.turnIdx >= 2;
+          const hasProgress = !reached; // turn 0/1 有进展；turn 2 达成
+          console.log(
+            `  [judge] turn ${input.turnIdx}: reached=${reached}, hasProgress=${hasProgress}`,
+          );
+          if (reached) return { reached, hasProgress, message: "检查通过" };
+          return { reached, hasProgress };
+        },
+        noProgressThreshold: 5, // 阈值高，不会因无进展触发
+      }),
+    ],
+  });
+
+  const summary = await session.run("请持续检查状态直到完成");
+
+  console.log(`\n  turns run: ${summary.turns}`);
+  console.log(`  reason: ${summary.reason}`);
+  console.log(`  abortReason: ${summary.abortReason ?? "(none)"}`);
+  console.log(`  judge calls: ${turnCount}`);
+}
+
+// ────────────────────────────────────────────────────────
+// 场景 B：连续 3 turn 无进展 → session 停止
+// ────────────────────────────────────────────────────────
+async function sceneB(): Promise<void> {
+  console.log("\n═══ 场景 B：无进展 N turn 后停止 ═══");
+
+  // 模拟：3 轮 tool call，每次都返回「无进展」。
+  const model = createFakeModel([
+    { content: [{ type: "toolCall", name: "check_status", arguments: {} }] },
+    { content: [{ type: "toolCall", name: "check_status", arguments: {} }] },
+    // 第 3 个 response 会由 fake model 自动生成
+  ]);
+
+  let turnCount = 0;
+  const stallCalled: number[] = [];
+
+  const session = new AgentSession({
+    model,
+    tools: [checkStatusTool],
+    systemPrompt: "You try to check status.",
+    hooks: [
+      progressVerifier({
+        judge: (_ctx, input) => {
+          turnCount++;
+          console.log(`  [judge] turn ${input.turnIdx}: reached=false, hasProgress=false`);
+          // 每次都报告「无进展」
+          return { reached: false, hasProgress: false };
+        },
+        noProgressThreshold: 3,
+        onStall: (_ctx, info) => {
+          stallCalled.push(info.consecutiveNoProgress);
+          console.log(
+            `  [onStall] 连续无进展 ${info.consecutiveNoProgress} turn，准备停止`,
+          );
+        },
+      }),
+    ],
+    maxTurns: 20,
+  });
+
+  const summary = await session.run("请检查状态");
+
+  console.log(`\n  turns run: ${summary.turns}`);
+  console.log(`  reason: ${summary.reason}`);
+  console.log(`  abortReason: ${summary.abortReason ?? "(none)"}`);
+  console.log(`  judge calls: ${turnCount}`);
+  console.log(`  onStall calls: ${stallCalled.length}`);
+}
+
+async function main(): Promise<void> {
+  await sceneA();
+  await sceneB();
+  console.log("\n✓ 示例运行完毕\n");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/05-progress-verifier/tsconfig.json
+++ b/examples/05-progress-verifier/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/plugins/src/__tests__/progress-verifier.test.ts
+++ b/packages/plugins/src/__tests__/progress-verifier.test.ts
@@ -1,0 +1,305 @@
+/**
+ * progressVerifier 单测 —— 跑真实 AgentSession + fake LLM。
+ *
+ * 覆盖：
+ *   1. 目标达成即停（reached=true）→ abortReason 含 "goal reached"
+ *   2. 连续 N turn 无进展即停（hasProgress=false × N）→ abortReason 含 "no progress"
+ *   3. 进展重置计数（中途插入 hasProgress:true → 计数归零 → 再无进展才停）
+ *   4. judge 抛错：中性处理（不累计无进展、不停止），session 继续正常结束
+ *   5. onStall 回调被调用，且 onStall 调 ctx.abort() 时插件不二次停止
+ *   6. hasProgress 省略时默认 true（乐观），不会意外累计无进展
+ *   7. 配置校验：noProgressThreshold <= 0 / timeoutMs <= 0 抛错
+ *   8. 默认 timeout 宽松（event 类 100ms 太短，默认 30s）
+ *   9. 两个 session 各自独立状态
+ *
+ * ---
+ * 内核 turn 模型：`onTurnEnd` 每次内层 turn（LLM call + tool batch）结束各触发一次。
+ * 驱动多 turn 的方式：fake model 返回 toolCall response → 执行 noop tool → 继续下一 turn。
+ * 最后一个 response 为 text（或 auto-fallback），结束循环。
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { AgentSession, Type, type HarnessTool } from "@harness-pi/core";
+import { createFakeModel } from "@harness-pi/core/testing";
+import { progressVerifier } from "../index.js";
+
+// 最简 noop tool，供 fake model 的 toolCall response 使用（驱动多 turn）。
+const noopTool: HarnessTool = {
+  name: "noop",
+  description: "no-op tool for driving multi-turn sessions in tests",
+  parameters: Type.Object({}),
+  async execute() {
+    return { content: [{ type: "text", text: "noop" }] };
+  },
+};
+
+/** 返回 N-1 个 toolCall response + 留 1 个 auto-fallback，共 N 次 onTurnEnd。 */
+function multiTurnModel(n: number) {
+  const scripted = Array.from({ length: n - 1 }, () => ({
+    content: [{ type: "toolCall" as const, name: "noop", arguments: {} }],
+  }));
+  return createFakeModel(scripted);
+}
+
+describe("progressVerifier", () => {
+  it("throws if noProgressThreshold <= 0", () => {
+    expect(() =>
+      progressVerifier({ judge: () => ({ reached: false }), noProgressThreshold: 0 }),
+    ).toThrow();
+    expect(() =>
+      progressVerifier({ judge: () => ({ reached: false }), noProgressThreshold: -1 }),
+    ).toThrow();
+  });
+
+  it("throws if timeoutMs <= 0", () => {
+    expect(() =>
+      progressVerifier({ judge: () => ({ reached: false }), timeoutMs: 0 }),
+    ).toThrow();
+  });
+
+  it("sets a generous default timeout (event-class 100ms is too short for LLM judge calls)", () => {
+    expect(progressVerifier({ judge: () => ({ reached: false }) }).timeout).toBe(30_000);
+    expect(
+      progressVerifier({ judge: () => ({ reached: false }), timeoutMs: 5_000 }).timeout,
+    ).toBe(5_000);
+  });
+
+  it("stops immediately when judge returns reached=true (goal achieved)", async () => {
+    const model = createFakeModel([
+      { content: [{ type: "text", text: "goal done" }] },
+    ]);
+
+    let judgeCalls = 0;
+    const session = new AgentSession({
+      model,
+      tools: [],
+      hooks: [
+        progressVerifier({
+          judge: () => {
+            judgeCalls++;
+            return { reached: true, message: "issue closed" };
+          },
+        }),
+      ],
+    });
+    const summary = await session.run("go");
+
+    expect(judgeCalls).toBe(1);
+    expect(summary.reason).toBe("aborted");
+    expect(summary.abortReason).toContain("progressVerifier");
+    expect(summary.abortReason).toContain("goal reached");
+    expect(summary.abortReason).toContain("issue closed");
+  });
+
+  it("goal reached with default message (no message field)", async () => {
+    const model = createFakeModel([
+      { content: [{ type: "text", text: "fin" }] },
+    ]);
+
+    const session = new AgentSession({
+      model,
+      tools: [],
+      hooks: [
+        progressVerifier({
+          judge: () => ({ reached: true }),
+        }),
+      ],
+    });
+    const summary = await session.run("go");
+
+    expect(summary.reason).toBe("aborted");
+    expect(summary.abortReason).toBe("progressVerifier: goal reached");
+  });
+
+  it("stops after N consecutive no-progress turns (hasProgress=false)", async () => {
+    // threshold=3, 需要 3 次 onTurnEnd：2 个 toolCall + 1 个 auto-fallback。
+    const model = multiTurnModel(3);
+    const judgeResults = vi.fn(() => ({ reached: false, hasProgress: false as const }));
+
+    const session = new AgentSession({
+      model,
+      tools: [noopTool],
+      hooks: [
+        progressVerifier({
+          judge: judgeResults,
+          noProgressThreshold: 3,
+        }),
+      ],
+      maxTurns: 20,
+    });
+    const summary = await session.run("go");
+
+    expect(judgeResults).toHaveBeenCalledTimes(3);
+    expect(summary.reason).toBe("aborted");
+    expect(summary.abortReason).toContain("progressVerifier");
+    expect(summary.abortReason).toContain("no progress");
+    expect(summary.turns).toBe(3);
+  });
+
+  it("resets no-progress counter when hasProgress=true, then stops only after N fresh no-progress turns", async () => {
+    // turn 0: no-progress (count=1)
+    // turn 1: has progress (count=0)
+    // turn 2: no-progress (count=1)
+    // turn 3: no-progress (count=2, threshold=2) → stop
+    // 需要 4 次 onTurnEnd → 3 个 toolCall + 1 auto-fallback。
+    const model = multiTurnModel(4);
+    let callIdx = 0;
+    const judge = vi.fn(() => {
+      callIdx++;
+      if (callIdx === 2) return { reached: false, hasProgress: true as const };
+      return { reached: false, hasProgress: false as const };
+    });
+
+    const session = new AgentSession({
+      model,
+      tools: [noopTool],
+      hooks: [
+        progressVerifier({
+          judge,
+          noProgressThreshold: 2,
+        }),
+      ],
+      maxTurns: 20,
+    });
+    const summary = await session.run("go");
+
+    expect(judge).toHaveBeenCalledTimes(4);
+    expect(summary.reason).toBe("aborted");
+    expect(summary.abortReason).toContain("no progress");
+    expect(summary.turns).toBe(4);
+  });
+
+  it("treats judge throw as neutral (no count change), session continues until goal reached", async () => {
+    // turn 0: judge throws（中性，不计数）
+    // turn 1: judge throws（中性，不计数）
+    // turn 2: reached:true → abort
+    // 需要 3 次 onTurnEnd → multiTurnModel(3)。
+    const model = multiTurnModel(3);
+
+    let callIdx = 0;
+    const session = new AgentSession({
+      model,
+      tools: [noopTool],
+      hooks: [
+        progressVerifier({
+          judge: () => {
+            callIdx++;
+            if (callIdx <= 2) throw new Error("judge transient error");
+            return { reached: true };
+          },
+          noProgressThreshold: 2, // 若抛错被计数，2 次就停；中性则不触发
+        }),
+      ],
+    });
+    const summary = await session.run("go");
+
+    // 中性处理：抛错不累计，第 3 次 reached:true 才停。
+    expect(callIdx).toBe(3);
+    expect(summary.reason).toBe("aborted");
+    expect(summary.abortReason).toContain("goal reached");
+  });
+
+  it("calls onStall callback when no-progress threshold is reached", async () => {
+    // threshold=2, 需要 2 次 onTurnEnd → multiTurnModel(2)。
+    const model = multiTurnModel(2);
+    const onStall = vi.fn();
+
+    const session = new AgentSession({
+      model,
+      tools: [noopTool],
+      hooks: [
+        progressVerifier({
+          judge: () => ({ reached: false, hasProgress: false }),
+          noProgressThreshold: 2,
+          onStall,
+        }),
+      ],
+      maxTurns: 20,
+    });
+    const summary = await session.run("go");
+
+    expect(onStall).toHaveBeenCalledTimes(1);
+    expect(onStall).toHaveBeenCalledWith(
+      expect.any(Object), // ctx
+      { consecutiveNoProgress: 2 },
+    );
+    // onStall 没有 abort，插件用默认原因停止。
+    expect(summary.reason).toBe("aborted");
+    expect(summary.abortReason).toContain("no progress");
+  });
+
+  it("onStall that calls ctx.abort() with custom reason: plugin does not double-stop", async () => {
+    // threshold=1, 1 次 onTurnEnd → 1 auto-fallback。
+    const model = createFakeModel([]);
+
+    const session = new AgentSession({
+      model,
+      tools: [],
+      hooks: [
+        progressVerifier({
+          judge: () => ({ reached: false, hasProgress: false }),
+          noProgressThreshold: 1,
+          onStall: (ctx) => {
+            ctx.abort("custom escalation reason");
+          },
+        }),
+      ],
+      maxTurns: 20,
+    });
+    const summary = await session.run("go");
+
+    expect(summary.reason).toBe("aborted");
+    // onStall 提供的 custom reason 生效（而非插件默认的 "no progress"）。
+    expect(summary.abortReason).toContain("custom escalation reason");
+  });
+
+  it("hasProgress omitted defaults to true (optimistic), stall counter does not accumulate", async () => {
+    // judge 每次只返回 { reached: false }（不含 hasProgress），视为有进展。
+    // session 跑完自然结束（3 turns），不因无进展被停止。
+    const model = multiTurnModel(3);
+
+    const session = new AgentSession({
+      model,
+      tools: [noopTool],
+      hooks: [
+        progressVerifier({
+          judge: () => ({ reached: false }), // hasProgress omitted → true
+          noProgressThreshold: 2,
+        }),
+      ],
+    });
+    const summary = await session.run("go");
+
+    // session 自然结束（not aborted by progressVerifier）。
+    expect(summary.reason).toBe("done");
+    expect(summary.turns).toBe(3);
+  });
+
+  it("state is isolated between two sessions", async () => {
+    // Session A: threshold=1（第 1 turn 停）→ 1 auto-fallback
+    // Session B: threshold=3（第 3 turn 停）→ multiTurnModel(3)
+    function makeSession(threshold: number, n: number) {
+      return new AgentSession({
+        model: n === 1 ? createFakeModel([]) : multiTurnModel(n),
+        tools: [noopTool],
+        hooks: [
+          progressVerifier({
+            judge: () => ({ reached: false, hasProgress: false }),
+            noProgressThreshold: threshold,
+          }),
+        ],
+        maxTurns: 20,
+      });
+    }
+
+    const [sumA, sumB] = await Promise.all([
+      makeSession(1, 1).run("go"),
+      makeSession(3, 3).run("go"),
+    ]);
+
+    expect(sumA.turns).toBe(1);
+    expect(sumB.turns).toBe(3);
+    expect(sumA.reason).toBe("aborted");
+    expect(sumB.reason).toBe("aborted");
+  });
+});

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -142,3 +142,9 @@ export type { ToolSearchOptions } from "./tool-search.js";
 
 export { skills } from "./skills.js";
 export type { SkillSpec, SkillsOptions } from "./skills.js";
+
+export { progressVerifier } from "./progress-verifier.js";
+export type {
+  ProgressVerifierOptions,
+  ProgressJudgement,
+} from "./progress-verifier.js";

--- a/packages/plugins/src/progress-verifier.ts
+++ b/packages/plugins/src/progress-verifier.ts
@@ -1,0 +1,176 @@
+/**
+ * progressVerifier —— loop-engineering 的 turn 级进展/目标 verifier hook。
+ *
+ * **用途**：供 /goal 循环等 loop-engineering 场景使用。在每个 turn 结束后调用用户提供的
+ * `judge` 函数，判定：
+ *   1. **目标是否达成**（`reached: true`）→ 停止 session（`onTurnEnd continue=false`）。
+ *   2. **本 turn 是否有真实进展**（`hasProgress: false`）→ 累计计数；连续 N turn 无进展
+ *      → 停止 session 或调用用户的 `onStall` 升级回调。
+ *
+ * **与其它 plugin 的语义边界**（不重叠原则）：
+ *   - `repeatedCallGuard`：检测同一 (tool, args) 在滑窗内重复——这是 **tool-call 级别的
+ *     语法/语义信号**（LLM 是否原地打转）。`progressVerifier` 检测的是 **turn 级目标进展**：
+ *     由调用方注入的业务谓词（如「issue 是否已 closed」）或 LLM-judge 回调来判定，不关心
+ *     具体调了哪个 tool。两者互补，不竞争。
+ *   - `turnEndGuard`：挂在 `onContinuationCheck`（session **想停时**先过一道质量闸，可强制
+ *     续跑）。`progressVerifier` 挂在 `onTurnEnd`（每 turn 后**主动停止**），是 verifier 闸
+ *     而非续跑闸——触发方向相反：前者"不让停"，后者"主动停"。
+ *   - `continuationCheck`：内核机制，用于 `turnEndGuard` 强制续跑。`progressVerifier` 不使用
+ *     此 hook，因为其语义是"条件满足时停止"，而非"条件不满足时继续"。
+ *
+ * **hook 位置**：`onTurnEnd`（event 类）—— 返回 `{ continue: false }` 时内核在本 turn 结束
+ * 后 abort session，`RunSummary.reason` 为 `"aborted"`、`abortReason` 含插件标识。
+ *
+ * **防死循环**：`noProgressThreshold` 是硬上限；`onStall` 回调可自定义升级逻辑（如报警、
+ * 降级到人工审查）。默认在阈值触发后直接停止，不让 session 无限空跑。
+ *
+ * **判据抛错**：`judge` 抛错时记 warn 日志并跳过本 turn 计数（中性处理：不计无进展、不计进展），
+ * session 继续运行——避免 judge 瞬时异常导致误停。
+ *
+ * **timeout 默认 30s**：`onTurnEnd` 是 event 类、dispatcher 默认 per-hook timeout 仅 100ms；
+ * 而 `judge` 通常需要 LLM 判定，必然超 100ms。故本插件自设宽 timeout（对齐 `turnEndGuard` /
+ * `onAfterFlush` 的同款约定），可经 `timeoutMs` 覆盖。
+ */
+
+import type {
+  Hook,
+  HookContext,
+  HookResult,
+  TurnEndInput,
+} from "@harness-pi/core";
+
+declare module "@harness-pi/core" {
+  interface HookStateRegistry {
+    "progress-verifier.noProgressCount": number;
+  }
+}
+
+const KEY = "progress-verifier.noProgressCount" as const;
+const DEFAULT_THRESHOLD = 3;
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * `judge` 的返回。
+ *
+ * - `reached: true` → 目标达成，插件立即停止 session。
+ * - `reached: false, hasProgress: true`（或省略 `hasProgress`）→ 本 turn 有真实进展，重置无进展计数。
+ * - `reached: false, hasProgress: false` → 本 turn 无真实进展，累计计数；达阈值时停止/升级。
+ */
+export interface ProgressJudgement {
+  /** 目标是否完全达成。`true` 时 session 立即停止。 */
+  reached: boolean;
+  /**
+   * 本 turn 是否有真实进展。
+   * 省略时默认 `true`（乐观：大多数 turn 都在做事）——只在本 turn 明确无进展时才设为 `false`。
+   * `reached: true` 时本字段无意义。
+   */
+  hasProgress?: boolean;
+  /** 停止时写入 `abortReason` 的说明；省略时用兜底文案。 */
+  message?: string;
+}
+
+export interface ProgressVerifierOptions {
+  /**
+   * 每 turn 结束后调用的进展判断函数。可同步或异步（如需调 LLM）。
+   * 抛错时按「中性」处理（不计无进展、不计进展），session 继续。
+   */
+  judge: (
+    ctx: HookContext,
+    input: TurnEndInput,
+  ) => Promise<ProgressJudgement> | ProgressJudgement;
+
+  /**
+   * 连续多少 turn 无真实进展后触发停止/升级。默认 3，须 > 0。
+   */
+  noProgressThreshold?: number;
+
+  /**
+   * 连续无进展达阈值时的回调。可在此发报警、记 metric、或调 `ctx.abort(customReason)`。
+   * - 若回调内调用了 `ctx.abort()`，插件不再二次停止。
+   * - 若回调正常返回（未 abort），插件用默认 `{ continue: false }` 停止 session。
+   * - 省略时：直接以默认原因停止。
+   */
+  onStall?: (
+    ctx: HookContext,
+    info: { consecutiveNoProgress: number },
+  ) => void | Promise<void>;
+
+  /**
+   * 本插件的 per-hook timeout（毫秒），默认 30000。
+   * `onTurnEnd` 是 event 类、dispatcher 默认仅 100ms；`judge` 做 LLM 调用必然超时 → 判断失效。
+   * `judge` 更慢时调大此值。
+   */
+  timeoutMs?: number;
+}
+
+export function progressVerifier(opts: ProgressVerifierOptions): Hook {
+  const threshold = opts.noProgressThreshold ?? DEFAULT_THRESHOLD;
+  if (threshold <= 0) {
+    throw new Error("progressVerifier: noProgressThreshold must be > 0");
+  }
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  if (timeoutMs <= 0) {
+    throw new Error("progressVerifier: timeoutMs must be > 0");
+  }
+
+  return {
+    name: "progress-verifier",
+    // onTurnEnd 是 event 类，dispatcher 默认 100ms 远不够 judge 做 I/O。
+    timeout: timeoutMs,
+
+    onSessionStart(_input, ctx) {
+      ctx.state.set(KEY, 0);
+    },
+
+    async onTurnEnd(
+      input: TurnEndInput,
+      ctx: HookContext,
+    ): Promise<HookResult | void> {
+      let judgement: ProgressJudgement;
+      try {
+        judgement = await opts.judge(ctx, input);
+      } catch (err) {
+        // judge 抛错：中性处理（跳过本 turn 计数），session 继续。
+        ctx.log.warn("progressVerifier: judge threw, skipping turn", {
+          hook: "progress-verifier",
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return;
+      }
+
+      // 目标达成 → 立即停止。
+      if (judgement.reached) {
+        const stopReason = judgement.message
+          ? `progressVerifier: goal reached — ${judgement.message}`
+          : "progressVerifier: goal reached";
+        ctx.state.set(KEY, 0);
+        return { continue: false, stopReason };
+      }
+
+      // hasProgress 默认 true（乐观）；只有显式 false 才计无进展。
+      const hasProgress = judgement.hasProgress !== false;
+      if (hasProgress) {
+        ctx.state.set(KEY, 0);
+        return;
+      }
+
+      // 本 turn 无进展，累计计数。
+      const count = (ctx.state.get(KEY) ?? 0) + 1;
+      ctx.state.set(KEY, count);
+
+      if (count >= threshold) {
+        // 触发 onStall 回调（如有）。
+        if (opts.onStall) {
+          await opts.onStall(ctx, { consecutiveNoProgress: count });
+        }
+        // onStall 若未 abort，插件用默认原因停止。
+        if (!ctx.signal.aborted) {
+          const stopReason = judgement.message
+            ? `progressVerifier: no progress — ${judgement.message}`
+            : "progressVerifier: no progress";
+          return { continue: false, stopReason };
+        }
+      }
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,25 @@ importers:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@22.19.19)
 
+  examples/05-progress-verifier:
+    dependencies:
+      '@earendil-works/pi-ai':
+        specifier: ^0.74.2
+        version: 0.74.2(ws@8.21.0)(zod@3.25.76)
+      '@harness-pi/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@harness-pi/plugins':
+        specifier: workspace:*
+        version: link:../../packages/plugins
+    devDependencies:
+      tsx:
+        specifier: ^4.0.0
+        version: 4.22.3
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+
   packages/adapters:
     dependencies:
       '@earendil-works/pi-ai':


### PR DESCRIPTION
闭合 #87。

turn 级目标/进展 verifier hook（loop-engineering / `/goal` 前置）：
- `judge` 回调判定 `reached`（达标即停）/ `hasProgress`（连续 N turn 无进展即停/升级）
- `noProgressThreshold`（默认 3）硬上限防死循环；`onStall` 升级回调
- judge 抛错 → 中性处理（不误停）；timeout 默认 30s（onTurnEnd 默认 100ms 不够 judge 做 LLM I/O）
- 纯 hook 零内核改动；状态走 module augmentation
- 含 305 行测试 + docs/05-plugins 边界小节 + examples/05-progress-verifier 离线示例

> agent 已推分支但漏开 PR，由 lead 补开。