### PR TITLE
CHA-160: 修复 /goal tool turn 进展判定

### DIFF
--- a/apps/coding-agent/src/__tests__/agent.test.ts
+++ b/apps/coding-agent/src/__tests__/agent.test.ts
@@ -263,6 +263,27 @@ describe("coding-agent dogfood app", () => {
     fake.teardown();
   });
 
+  it("createGoalSession keeps tool-call turns alive until the final GOAL_STATUS", async () => {
+    const cwd = await tempRepo();
+    const goal: GoalOptions = { goal: "inspect then finish", maxTurns: 3 };
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "ls", arguments: { path: "." } }] },
+      { content: [{ type: "toolCall", name: "ls", arguments: { path: "." } }] },
+      { content: [{ type: "toolCall", name: "ls", arguments: { path: "." } }] },
+      { content: [{ type: "text", text: "finished\n---\nGOAL_STATUS: REACHED" }] },
+    ]);
+    const agent = createCodingAgent({ cwd, model: fake, log: false });
+
+    const summary = await agent.createGoalSession(goal).run(buildGoalPrompt(goal));
+
+    expect(summary.reason).toBe("aborted");
+    expect(summary.abortReason).toContain("goal reached");
+    expect(summary.turns).toBe(4);
+    expect(fake.getCalls()).toHaveLength(4);
+    await agent.close();
+    fake.teardown();
+  });
+
   it("createGoalSession forces continuation via turnEndGuard until GOAL_STATUS reaches REACHED", async () => {
     const cwd = await tempRepo();
     const goal: GoalOptions = { goal: "finish issue", maxTurns: 3 };

--- a/apps/coding-agent/src/tui/__tests__/app.smoke.test.ts
+++ b/apps/coding-agent/src/tui/__tests__/app.smoke.test.ts
@@ -652,6 +652,48 @@ describe("TUI app smoke (headless, dual-track via fake terminal)", () => {
     expect(app.isRunning()).toBe(false);
   });
 
+  it("/goal: shows user-visible rounds from continuations, not internal tool turns", async () => {
+    const goalMessage = assistant([{ type: "text", text: "done\n---\nGOAL_STATUS: REACHED" }]);
+    const goalSummary: RunSummary = {
+      turns: 4,
+      continuations: 0,
+      reason: "aborted",
+      abortReason: "progressVerifier: goal reached",
+      usage: { ...ZERO },
+      lastMessage: goalMessage,
+      stopReason: goalMessage.stopReason,
+    };
+    const goalSession: TuiSession = {
+      on: NOOP_ON,
+      runStreaming: () => {
+        const gen = (async function* (): AsyncGenerator<SessionEvent> {
+          yield { type: "turn-start", turnIdx: 0 };
+          yield { type: "turn-start", turnIdx: 1 };
+          yield { type: "turn-start", turnIdx: 2 };
+          yield { type: "turn-start", turnIdx: 3 };
+          yield { type: "llm-end", msg: goalMessage, durationMs: 1 };
+          yield { type: "session-end", summary: goalSummary };
+        })();
+        return Object.assign(gen, { finalSummary: Promise.resolve(goalSummary) });
+      },
+    };
+    const app = createTuiApp({
+      agent: {
+        model: { id: "qwen-turbo" },
+        session: idleSession,
+        createGoalSession: () => goalSession,
+      },
+      terminal: new FakeTerminal(),
+    });
+
+    await app.submit("/goal inspect then finish --max-turns 3");
+
+    const out = strip(app.tui.render(80).join("\n"));
+    expect(out).toContain("第 1 轮完成");
+    expect(out).not.toContain("第 4 轮完成");
+    expect(out).not.toContain("第 2 轮 / 3");
+  });
+
   it("Esc during /goal aborts the dedicated goal session", async () => {
     let capturedSignal: AbortSignal | undefined;
     let release!: () => void;

--- a/apps/coding-agent/src/tui/__tests__/goal.test.ts
+++ b/apps/coding-agent/src/tui/__tests__/goal.test.ts
@@ -199,15 +199,18 @@ describe("goal hook adapters", () => {
     });
   });
 
-  it("progressVerifier judge treats BLOCKED and missing marker as no progress", () => {
+  it("progressVerifier judge treats BLOCKED as no progress", () => {
     expect(judgeGoalProgress("GOAL_STATUS: BLOCKED\nGOAL_REASON: missing env")).toEqual({
       reached: false,
       hasProgress: false,
       message: "missing env",
     });
+  });
+
+  it("progressVerifier judge treats missing marker as in-flight progress", () => {
     expect(judgeGoalProgress("no marker")).toMatchObject({
       reached: false,
-      hasProgress: false,
+      hasProgress: true,
       message: expect.stringContaining("GOAL_STATUS"),
     });
   });

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -469,6 +469,7 @@ export function createTuiApp(opts: TuiAppOptions): TuiApp {
     tui.requestRender();
 
     let round = 0;
+    let nextVisibleRound = 1;
     let usedTokens = 0;
     let lastAssistantText = "";
     let finalSummary: RunSummary | undefined;
@@ -488,23 +489,28 @@ export function createTuiApp(opts: TuiAppOptions): TuiApp {
         const stream = goalSession.runStreaming(buildGoalPrompt(goalOpts), { signal: ac.signal });
         for await (const ev of stream) {
           if (ev.type === "turn-start") {
-            round = ev.turnIdx + 1;
-            append(
-              new Text(
-                color.dim(
-                  formatGoalRoundBanner({
-                    round,
-                    maxTurns: goalOpts.maxTurns,
-                    ...(goalOpts.budgetTokens !== undefined
-                      ? { budgetTokens: goalOpts.budgetTokens, usedTokens }
-                      : {}),
-                  }),
+            if (round < nextVisibleRound) {
+              round = nextVisibleRound;
+              append(
+                new Text(
+                  color.dim(
+                    formatGoalRoundBanner({
+                      round,
+                      maxTurns: goalOpts.maxTurns,
+                      ...(goalOpts.budgetTokens !== undefined
+                        ? { budgetTokens: goalOpts.budgetTokens, usedTokens }
+                        : {}),
+                    }),
+                  ),
+                  0,
+                  0,
                 ),
-                0,
-                0,
-              ),
-            );
-            status.setMessage(`/goal 第 ${round} 轮…`);
+              );
+              status.setMessage(`/goal 第 ${round} 轮…`);
+            }
+          }
+          if (ev.type === "continuation-check") {
+            nextVisibleRound = ev.continuations + 2;
           }
           if (ev.type === "llm-end") {
             lastInputTokens = ev.msg.usage?.input ?? lastInputTokens;
@@ -535,9 +541,10 @@ export function createTuiApp(opts: TuiAppOptions): TuiApp {
 
     // 终态提示
     const outcome = classifyGoalOutcome(finalSummary, lastAssistantText);
+    const finalRounds = finalSummary ? finalSummary.continuations + 1 : Math.max(round, 1);
     const finalText = formatGoalFinalStatus(
       outcome.verdict,
-      finalSummary?.turns ?? round,
+      finalRounds,
       outcome.aborted,
       outcome.budgetExhausted,
     );

--- a/apps/coding-agent/src/tui/goal.ts
+++ b/apps/coding-agent/src/tui/goal.ts
@@ -207,7 +207,7 @@ export function judgeGoalProgress(text: string): GoalProgressJudgement {
   }
   return {
     reached: false,
-    hasProgress: false,
+    hasProgress: true,
     message: "missing GOAL_STATUS block",
   };
 }


### PR DESCRIPTION
## 改动说明

- 修复 `/goal` 的 `judgeGoalProgress`：缺失 `GOAL_STATUS` 的中途 tool-call turn 视为仍在推进，不再让 `progressVerifier` 累计无进展并提前 abort。
- 修正 `/goal` TUI 轮次显示：用户可见轮次来自 continuation 语义，内部 tool turn 不再显示成新一轮。
- 补回归测试：连续 tool-call turn 后最终 REACHED、missing marker 判定、TUI 轮次不受内部 turn 影响。

## 验收对照

- B1：连续 tool-call turn 不会被 `progressVerifier` 当成无进展掐断，最终可跑到 `GOAL_STATUS: REACHED`。
- B2：新增集成回归覆盖 `N >= maxTurns` 个 tool-call turn 后再 REACHED；更新纯逻辑测试，missing marker = in-flight progress。
- N2：一并修正 TUI 轮次展示，避免把内核 tool turn 当作 `/goal` 轮次。

## 测试说明

- `pnpm -r build`
- `pnpm -r typecheck`
- `pnpm -r test`

## Brief 偏差报告

- brief 原文：在现有 PR #95 / `feature-160/goal-command` 上补，不开新 PR。
- 实际情况：PR #95 已于 2026-06-17 03:27:11Z 合并，远端 `feature-160/goal-command` 已删除，已合并 PR 无法再更新。
- 处理方式：基于当前 `origin/dev` 新建 follow-up 分支 `cha-160/goal-r3-fix` 和本 PR，承载同一 R3 修复。
- 出处：`gh pr view 95` 返回 `state=MERGED`、`mergeCommit=a28f6afdb9b54a7a69e923e199c08b2444ccf700`。

Closes #88
