### PR TITLE
CHA-168: 修复 /goal 两钩子与 review-gate findings

### DIFF
--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -78,7 +78,7 @@ Works in any modern terminal (iTerm2, WezTerm, Kitty, Ghostty, VS Code, Windows 
 | Command | What it does |
 |---|---|
 | `/compact` | Turn on compaction for this session — summarize earlier messages for the model (full history is kept). |
-| `/goal <goal> [--max-turns N] [--budget N] [--success <criteria>]` | Run a hook-composed goal loop: `turnEndGuard` keeps going while `GOAL_STATUS` is not reached, `progressVerifier` stops on reached/stall, and `tokenBudget` enforces the token cap. Rounds and budget remaining are shown per turn. Esc interrupts. |
+| `/goal <goal> [--max-turns N] [--budget N] [--success <criteria>]` | Run a hook-composed goal loop: `turnEndGuard` keeps going while `GOAL_STATUS` is not reached, and `tokenBudget` enforces the token cap. Turns and budget remaining are shown per turn. Esc interrupts. |
 | `/multi <question> @file @file …` | Analyze several files **in parallel** with read-only sub-agents (cannot edit), then aggregate the findings. |
 | `/help` | List commands. |
 | `/exit` | Quit the TUI. |

--- a/apps/coding-agent/src/__tests__/agent.test.ts
+++ b/apps/coding-agent/src/__tests__/agent.test.ts
@@ -242,7 +242,7 @@ describe("coding-agent dogfood app", () => {
     fake.teardown();
   });
 
-  it("createGoalSession stops on REACHED through progressVerifier", async () => {
+  it("createGoalSession stops naturally when the final GOAL_STATUS is REACHED", async () => {
     const cwd = await tempRepo();
     const goal: GoalOptions = { goal: "make tests pass", maxTurns: 3 };
     const fake = createFakeModel([
@@ -255,9 +255,8 @@ describe("coding-agent dogfood app", () => {
 
     const summary = await agent.createGoalSession(goal).run(buildGoalPrompt(goal));
 
-    expect(summary.reason).toBe("aborted");
-    expect(summary.abortReason).toContain("progressVerifier");
-    expect(summary.abortReason).toContain("goal reached");
+    expect(summary.reason).toBe("done");
+    expect(summary.abortReason).toBeUndefined();
     expect(summary.turns).toBe(1);
     await agent.close();
     fake.teardown();
@@ -283,11 +282,37 @@ describe("coding-agent dogfood app", () => {
 
     const summary = await agent.createGoalSession(goal).run(buildGoalPrompt(goal));
 
-    expect(summary.reason).toBe("aborted");
-    expect(summary.abortReason).toContain("goal reached");
+    expect(summary.reason).toBe("done");
+    expect(summary.abortReason).toBeUndefined();
     expect(summary.continuations).toBe(1);
     expect(fake.getCalls()).toHaveLength(2);
     expect(JSON.stringify(fake.getCalls()[1]?.messages)).toContain("Goal is not reached yet");
+    await agent.close();
+    fake.teardown();
+  });
+
+  it("createGoalSession allows multiple tool-call turns before the final GOAL_STATUS: REACHED", async () => {
+    const cwd = await tempRepo();
+    const goal: GoalOptions = { goal: "inspect repo and finish", maxTurns: 2 };
+    const fake = createFakeModel([
+      {
+        content: [{ type: "toolCall", name: "read", arguments: { path: "README.md" } }],
+      },
+      {
+        content: [{ type: "toolCall", name: "read", arguments: { path: "package.json" } }],
+      },
+      {
+        content: [{ type: "text", text: "inspected\n---\nGOAL_STATUS: REACHED" }],
+      },
+    ]);
+    const agent = createCodingAgent({ cwd, model: fake, log: false });
+
+    const summary = await agent.createGoalSession(goal).run(buildGoalPrompt(goal));
+
+    expect(summary.reason).toBe("done");
+    expect(summary.abortReason).toBeUndefined();
+    expect(summary.turns).toBe(3);
+    expect(fake.getCalls()).toHaveLength(3);
     await agent.close();
     fake.teardown();
   });

--- a/apps/coding-agent/src/__tests__/project-instructions.test.ts
+++ b/apps/coding-agent/src/__tests__/project-instructions.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -9,6 +9,7 @@ import { emitProjectInstructionsNotice, parseArgs } from "../cli.js";
 
 const dirs: string[] = [];
 afterEach(async () => {
+  vi.unstubAllEnvs();
   while (dirs.length) {
     const d = dirs.pop();
     if (d) await rm(d, { recursive: true, force: true });
@@ -63,6 +64,38 @@ describe("loadProjectInstructions", () => {
     expect(result).not.toBeNull();
     expect(result!.sourcePath).toBe(join(parent, "CLAUDE.md"));
     expect(result!.content).toContain("parent instructions");
+  });
+
+  it("遇到 .git 仓库边界就停止，不读取仓库外层指令", async () => {
+    const outer = await tmp();
+    await writeFile(join(outer, "CLAUDE.md"), "outer instructions\n");
+    const repo = join(outer, "repo");
+    const child = join(repo, "packages", "app");
+    await mkdir(join(repo, ".git"), { recursive: true });
+    await mkdir(child, { recursive: true });
+
+    expect(loadProjectInstructions(child)).toBeNull();
+  });
+
+  it("到 HOME 边界就停止，不读取 HOME 下的指令文件", async () => {
+    const home = await tmp();
+    vi.stubEnv("HOME", home);
+    await writeFile(join(home, "CLAUDE.md"), "home instructions\n");
+    const cwd = join(home, "work", "project");
+    await mkdir(cwd, { recursive: true });
+
+    expect(loadProjectInstructions(cwd)).toBeNull();
+  });
+
+  it("空指令文件视为不存在，继续尝试同目录下一个候选文件", async () => {
+    const cwd = await tmp();
+    await writeFile(join(cwd, "CLAUDE.md"), "");
+    await writeFile(join(cwd, "AGENTS.md"), "agent instructions\n");
+
+    const result = loadProjectInstructions(cwd);
+    expect(result).not.toBeNull();
+    expect(result!.sourcePath).toBe(join(cwd, "AGENTS.md"));
+    expect(result!.content).toBe("agent instructions\n");
   });
 
   it("整棵目录树都没有指令文件 → 不抛错", async () => {

--- a/apps/coding-agent/src/agent.ts
+++ b/apps/coding-agent/src/agent.ts
@@ -20,7 +20,6 @@ import {
   metrics,
   NdjsonFileSink,
   permissionGate,
-  progressVerifier,
   repeatedCallGuard,
   sessionLog,
   toolStats,
@@ -61,8 +60,8 @@ import {
 } from "./providers/dashscope.js";
 import {
   checkGoalContinuation,
+  goalKernelMaxTurns,
   goalTextFromMessage,
-  judgeGoalProgress,
   type GoalOptions,
 } from "./tui/goal.js";
 
@@ -151,7 +150,7 @@ export interface CodingAgent {
   getCompactionState(): { enabled: boolean; maxMessages: number; keepRecent: number } | undefined;
   /** 注册"压缩发生"回调（每次实际跑 summarize 时以被压缩的早期消息条数调用）；用于 TUI 反馈。 */
   setCompactionListener(listener: (coveredCount: number) => void): void;
-  /** 为 /goal 创建一次性专用 session：不污染主交互 session，hook 组合负责续跑/verifier/预算。 */
+  /** 为 /goal 创建一次性专用 session：不污染主交互 session，hook 组合负责续跑与预算。 */
   createGoalSession(goal: GoalOptions): AgentSession;
 }
 
@@ -476,21 +475,21 @@ function buildAgentContext(opts: CreateCodingAgentOptions): AgentContext {
           compactionListener = listener;
         },
         createGoalSession(goal) {
+          const kernelMaxTurns = goalKernelMaxTurns(goal);
+          // /goal 的循环由 turnEndGuard 在 would-be-done 时续跑：
+          // onContinuationCheck 只会在内核准备自然停止后触发，不会限制中间 tool-call turns。
+          // 因此 maxRetries/maxContinuations 约束续跑次数，内核 maxTurns 单独约束工具调用轮数。
           const goalHooks: Hook[] = [
             turnEndGuard({
               check: (ctx) => checkGoalContinuation(latestAssistantText(ctx.messages)),
               maxRetries: goal.maxTurns,
-            }),
-            progressVerifier({
-              judge: (_ctx, input) =>
-                judgeGoalProgress(goalTextFromMessage(input.assistantMessage)),
-              noProgressThreshold: goal.maxTurns,
             }),
             tokenBudget({ budget: goal.budgetTokens ?? null }),
           ];
           return new AgentSession({
             ...deps,
             hooks: [...(deps.hooks ?? []), ...goalHooks],
+            maxTurns: kernelMaxTurns,
             maxContinuations: goal.maxTurns,
           });
         },

--- a/apps/coding-agent/src/project-instructions.ts
+++ b/apps/coding-agent/src/project-instructions.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 /** 候选文件名，按优先级排列：CLAUDE.md 优先，其次 AGENTS.md。 */
@@ -14,17 +14,22 @@ export interface ProjectInstructions {
  * 找不到返回 null（静默回落，不报错）。
  */
 export function loadProjectInstructions(startDir: string): ProjectInstructions | null {
+  const homeDir = process.env.HOME;
   let dir = startDir;
   while (true) {
+    if (homeDir && dir === homeDir) break;
+
     for (const name of CANDIDATE_NAMES) {
       const candidate = join(dir, name);
       try {
         const content = readFileSync(candidate, "utf8");
+        if (content.trim().length === 0) continue;
         return { content, sourcePath: candidate };
       } catch {
         // 文件不存在或不可读，继续尝试
       }
     }
+    if (existsSync(join(dir, ".git"))) break;
     const parent = dirname(dir);
     if (parent === dir) break; // 已到文件系统根
     dir = parent;

--- a/apps/coding-agent/src/tui/__tests__/app.smoke.test.ts
+++ b/apps/coding-agent/src/tui/__tests__/app.smoke.test.ts
@@ -604,8 +604,7 @@ describe("TUI app smoke (headless, dual-track via fake terminal)", () => {
     const goalSummary: RunSummary = {
       turns: 1,
       continuations: 0,
-      reason: "aborted",
-      abortReason: "progressVerifier: goal reached",
+      reason: "done",
       usage: { ...ZERO },
       lastMessage: goalMessage,
       stopReason: goalMessage.stopReason,

--- a/apps/coding-agent/src/tui/__tests__/goal.test.ts
+++ b/apps/coding-agent/src/tui/__tests__/goal.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   parseGoalCommand,
   buildGoalPrompt,
-  buildContinuationPrompt,
+  classifyGoalOutcome,
   checkGoalContinuation,
-  judgeGoalProgress,
+  parseGoalReason,
   parseGoalVerdict,
   formatGoalRoundBanner,
   formatGoalFinalStatus,
@@ -74,6 +74,33 @@ describe("parseGoalCommand", () => {
     const r = parseGoalCommand("some goal --budget -100");
     expect(r?.budgetTokens).toBeUndefined();
   });
+
+  it("ignores an invalid --max-turns value without leaving flag text in the goal", () => {
+    expect(parseGoalCommand("fix flaky tests --max-turns abc")).toEqual({
+      goal: "fix flaky tests",
+      maxTurns: 5,
+      budgetTokens: undefined,
+      successHint: undefined,
+    });
+  });
+
+  it("stops unquoted --success at a stray -- marker", () => {
+    expect(parseGoalCommand("ship release --success all tests pass -- keep note")).toEqual({
+      goal: "ship release -- keep note",
+      maxTurns: 5,
+      budgetTokens: undefined,
+      successHint: "all tests pass",
+    });
+  });
+
+  it("uses the first --success flag and leaves later repeated flags as goal text", () => {
+    expect(parseGoalCommand("ship --success first pass --success second pass")).toEqual({
+      goal: "ship --success second pass",
+      maxTurns: 5,
+      budgetTokens: undefined,
+      successHint: "first pass",
+    });
+  });
 });
 
 describe("buildGoalPrompt", () => {
@@ -97,19 +124,6 @@ describe("buildGoalPrompt", () => {
   it("does not include successHint section when not provided", () => {
     const p = buildGoalPrompt({ goal: "fix lint", maxTurns: 5 });
     expect(p).not.toContain("Success Criteria");
-  });
-});
-
-describe("buildContinuationPrompt", () => {
-  it("includes the round number and goal", () => {
-    const p = buildContinuationPrompt(3, { goal: "make tests pass", maxTurns: 5 });
-    expect(p).toContain("make tests pass");
-    expect(p).toContain("3");
-  });
-
-  it("still includes GOAL_STATUS instructions", () => {
-    const p = buildContinuationPrompt(2, { goal: "refactor", maxTurns: 5 });
-    expect(p).toContain("GOAL_STATUS:");
   });
 });
 
@@ -159,6 +173,18 @@ describe("parseGoalVerdict", () => {
   });
 });
 
+describe("parseGoalReason", () => {
+  it("returns the last GOAL_REASON when multiple markers are present", () => {
+    expect(
+      parseGoalReason("GOAL_REASON: first\nwork log\nGOAL_REASON: final answer"),
+    ).toBe("final answer");
+  });
+
+  it("returns undefined for empty or whitespace-only reasons", () => {
+    expect(parseGoalReason("GOAL_REASON:   ")).toBeUndefined();
+  });
+});
+
 describe("goal hook adapters", () => {
   it("turnEndGuard check lets REACHED and BLOCKED stop", () => {
     expect(checkGoalContinuation("GOAL_STATUS: REACHED")).toEqual({ ok: true });
@@ -183,34 +209,6 @@ describe("goal hook adapters", () => {
     });
   });
 
-  it("progressVerifier judge maps REACHED to reached=true", () => {
-    expect(judgeGoalProgress("all good\nGOAL_STATUS: REACHED")).toMatchObject({
-      reached: true,
-    });
-  });
-
-  it("progressVerifier judge treats NOT_REACHED as progress so turnEndGuard can continue", () => {
-    expect(
-      judgeGoalProgress("GOAL_STATUS: NOT_REACHED\nGOAL_REASON: one assertion remains"),
-    ).toEqual({
-      reached: false,
-      hasProgress: true,
-      message: "one assertion remains",
-    });
-  });
-
-  it("progressVerifier judge treats BLOCKED and missing marker as no progress", () => {
-    expect(judgeGoalProgress("GOAL_STATUS: BLOCKED\nGOAL_REASON: missing env")).toEqual({
-      reached: false,
-      hasProgress: false,
-      message: "missing env",
-    });
-    expect(judgeGoalProgress("no marker")).toMatchObject({
-      reached: false,
-      hasProgress: false,
-      message: expect.stringContaining("GOAL_STATUS"),
-    });
-  });
 });
 
 describe("formatGoalRoundBanner", () => {
@@ -231,6 +229,92 @@ describe("formatGoalRoundBanner", () => {
     // toLocaleString() formats with locale separators; check partial match
     expect(text).toMatch(/2[,_.]?500/);
     expect(text).toMatch(/10[,_.]?000/);
+    expect(text).toContain("25%");
+  });
+});
+
+describe("classifyGoalOutcome", () => {
+  it("classifies done + REACHED as success", () => {
+    expect(
+      classifyGoalOutcome(
+        {
+          turns: 1,
+          continuations: 0,
+          reason: "done",
+          lastMessage: { role: "assistant", content: [{ type: "text", text: "GOAL_STATUS: REACHED" }] },
+        } as any,
+      ),
+    ).toEqual({ verdict: "reached", aborted: false, budgetExhausted: false });
+  });
+
+  it("classifies done + NOT_REACHED as unfinished without interruption", () => {
+    expect(
+      classifyGoalOutcome(undefined, "GOAL_STATUS: NOT_REACHED\nGOAL_REASON: still failing"),
+    ).toEqual({ verdict: "not_reached", aborted: false, budgetExhausted: false });
+  });
+
+  it("classifies done + BLOCKED as blocked without interruption", () => {
+    expect(classifyGoalOutcome(undefined, "GOAL_STATUS: BLOCKED")).toEqual({
+      verdict: "blocked",
+      aborted: false,
+      budgetExhausted: false,
+    });
+  });
+
+  it("classifies token budget aborts as budget exhaustion", () => {
+    expect(
+      classifyGoalOutcome(
+        {
+          turns: 2,
+          continuations: 1,
+          reason: "aborted",
+          abortReason: "token budget exhausted: 120/100",
+        } as any,
+        "GOAL_STATUS: NOT_REACHED",
+      ),
+    ).toEqual({ verdict: "not_reached", aborted: false, budgetExhausted: true });
+  });
+
+  it("classifies user aborts as interrupted", () => {
+    expect(
+      classifyGoalOutcome(
+        {
+          turns: 2,
+          continuations: 1,
+          reason: "aborted",
+          abortReason: "caller signal aborted",
+        } as any,
+        "GOAL_STATUS: NOT_REACHED",
+      ),
+    ).toEqual({ verdict: "not_reached", aborted: true, budgetExhausted: false });
+  });
+
+  it("treats REACHED as success even if an abort reason mentions budget", () => {
+    expect(
+      classifyGoalOutcome(
+        {
+          turns: 1,
+          continuations: 0,
+          reason: "aborted",
+          abortReason: "token budget exhausted: 120/100",
+        } as any,
+        "GOAL_STATUS: REACHED",
+      ),
+    ).toEqual({ verdict: "reached", aborted: false, budgetExhausted: false });
+  });
+
+  it("does not special-case legacy progressVerifier abort reason strings", () => {
+    expect(
+      classifyGoalOutcome(
+        {
+          turns: 2,
+          continuations: 0,
+          reason: "aborted",
+          abortReason: "progressVerifier: no progress",
+        } as any,
+        "GOAL_STATUS: NOT_REACHED",
+      ),
+    ).toEqual({ verdict: "not_reached", aborted: true, budgetExhausted: false });
   });
 });
 

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -32,6 +32,7 @@ import {
   classifyGoalOutcome,
   formatGoalFinalStatus,
   formatGoalRoundBanner,
+  goalKernelMaxTurns,
   goalTextFromMessage,
   parseGoalCommand,
   type GoalOptions,
@@ -422,8 +423,8 @@ export function createTuiApp(opts: TuiAppOptions): TuiApp {
   }
 
   /**
-   * `/goal <desc>` —— 目标 + verifier + 预算 loop-engineering 循环。
-   * TUI 只启动一次专用 goal session；续跑/verifier/预算由 session 上的 hook 组合负责。
+   * `/goal <desc>` —— 目标 + would-be-done guard + 预算 loop-engineering 循环。
+   * TUI 只启动一次专用 goal session；续跑和预算由 session 上的 hook 组合负责。
    */
   async function runGoal(rest: string): Promise<void> {
     if (running) {
@@ -494,7 +495,7 @@ export function createTuiApp(opts: TuiAppOptions): TuiApp {
                 color.dim(
                   formatGoalRoundBanner({
                     round,
-                    maxTurns: goalOpts.maxTurns,
+                    maxTurns: goalKernelMaxTurns(goalOpts),
                     ...(goalOpts.budgetTokens !== undefined
                       ? { budgetTokens: goalOpts.budgetTokens, usedTokens }
                       : {}),

--- a/apps/coding-agent/src/tui/goal.ts
+++ b/apps/coding-agent/src/tui/goal.ts
@@ -1,8 +1,8 @@
 /**
- * /goal 命令 —— 目标 + verifier + 预算的 loop-engineering 循环（纯逻辑，可测）。
+ * /goal 命令 —— 目标 + would-be-done guard + 预算的 loop-engineering 循环（纯逻辑，可测）。
  *
- * 与浅 /loop 的区别：每轮结束后解析模型自报的 GOAL_STATUS 结构化标记（verifier），
- * 而不是单纯重复执行 prompt N 次。配合 maxTurns / budgetTokens 两道硬上限。
+ * 与浅 /loop 的区别：session 想自然停止时解析模型自报的 GOAL_STATUS 结构化标记；
+ * 未达成则由 turnEndGuard 回灌原因并续跑。配合内核 turn 上限与 token budget 两道硬上限。
  */
 
 import type { RunSummary } from "@harness-pi/core";
@@ -10,12 +10,20 @@ import type { RunSummary } from "@harness-pi/core";
 export interface GoalOptions {
   /** 目标描述（主体文本）。 */
   goal: string;
-  /** 最大 act→verify 轮数（默认 5，最小 1）。 */
+  /** 最大 would-be-done 续跑次数（默认 5，最小 1）。 */
   maxTurns: number;
   /** Token 预算硬上限（undefined = 不限）。 */
   budgetTokens?: number;
   /** 额外成功判据提示，注入进 prompt。 */
   successHint?: string;
+}
+
+/** 每个 goal 续跑轮给内层工具调用预留的 turn 数，避免回落到内核默认 200。 */
+const TURNS_PER_GOAL_ROUND = 20;
+
+/** /goal session 的内核 turn 硬上限：用于约束 tool-call turns，不等同于续跑轮数。 */
+export function goalKernelMaxTurns(opts: GoalOptions): number {
+  return Math.max(1, opts.maxTurns) * TURNS_PER_GOAL_ROUND;
 }
 
 /**
@@ -30,9 +38,9 @@ export function parseGoalCommand(rest: string): GoalOptions | null {
   let budgetTokens: number | undefined = undefined;
   let successHint: string | undefined = undefined;
 
-  // --max-turns <N>
-  text = text.replace(/--max-turns\s+(\d+)/i, (_, n: string) => {
-    maxTurns = Math.max(1, parseInt(n, 10));
+  // --max-turns <N>；非法值忽略并清掉 flag，避免污染 goal 文本。
+  text = text.replace(/--max-turns(?:\s+([+-]?\d+)|\s+(?!-)\S+)?/i, (_, n: string | undefined) => {
+    if (n !== undefined) maxTurns = Math.max(1, parseInt(n, 10));
     return "";
   });
 
@@ -43,24 +51,14 @@ export function parseGoalCommand(rest: string): GoalOptions | null {
     return "";
   });
 
-  // --success "quoted" or --success until next flag or end
-  text = text.replace(/--success\s+"([^"]+)"/i, (_, hint: string) => {
-    successHint = hint.trim();
-    return "";
-  });
-  if (successHint === undefined) {
-    text = text.replace(/--success\s+(.+?)(?=\s+--|$)/i, (_, hint: string) => {
-      successHint = hint.trim();
+  // --success "quoted" or --success until next flag / stray -- / end.
+  text = text.replace(
+    /--success\s+(?:"([^"]+)"|(.+?))(?=\s+--|$)/i,
+    (_match: string, quoted: string | undefined, unquoted: string | undefined) => {
+      successHint = (quoted ?? unquoted ?? "").trim();
       return "";
-    });
-    // Handle --success at end without another flag following
-    if (successHint === undefined) {
-      text = text.replace(/--success\s+(.+)/i, (_, hint: string) => {
-        successHint = hint.trim();
-        return "";
-      });
-    }
-  }
+    },
+  );
 
   const goal = text.replace(/\s+/g, " ").trim();
   if (goal.length === 0) return null;
@@ -71,7 +69,7 @@ export function parseGoalCommand(rest: string): GoalOptions | null {
   return opts;
 }
 
-/** 构建第一轮 prompt：包含目标 + verifier 格式要求。 */
+/** 构建第一轮 prompt：包含目标 + GOAL_STATUS 格式要求。 */
 export function buildGoalPrompt(opts: GoalOptions): string {
   const lines: string[] = [
     "## Goal",
@@ -110,32 +108,8 @@ export function buildGoalPrompt(opts: GoalOptions): string {
   return lines.join("\n");
 }
 
-/** 构建第 round 轮（>1）的 continuation prompt。 */
-export function buildContinuationPrompt(round: number, opts: GoalOptions): string {
-  return [
-    `## Goal (round ${round})`,
-    opts.goal,
-    "",
-    `You have completed round ${round - 1}. Continue working towards the goal.`,
-    "Resume where you left off and keep making progress.",
-    "",
-    "When done (or blocked), end with the GOAL_STATUS block:",
-    "",
-    "---",
-    "GOAL_STATUS: REACHED",
-    "",
-    "or NOT_REACHED / BLOCKED with GOAL_REASON.",
-  ].join("\n");
-}
-
 /** Model-reported goal status extracted from response text. */
 export type GoalVerdict = "reached" | "not_reached" | "blocked" | "unknown";
-
-export interface GoalProgressJudgement {
-  reached: boolean;
-  hasProgress?: boolean;
-  message?: string;
-}
 
 export interface GoalContinuationCheck {
   ok: boolean;
@@ -184,34 +158,6 @@ export function goalTextFromMessage(message: GoalTextMessage | undefined): strin
     .join("\n");
 }
 
-/** progressVerifier.judge 的纯逻辑：只负责判定达标/停滞，不负责续跑。 */
-export function judgeGoalProgress(text: string): GoalProgressJudgement {
-  const verdict = parseGoalVerdict(text);
-  const reason = parseGoalReason(text);
-  if (verdict === "reached") {
-    return { reached: true, ...(reason ? { message: reason } : {}) };
-  }
-  if (verdict === "not_reached") {
-    return {
-      reached: false,
-      hasProgress: true,
-      ...(reason ? { message: reason } : {}),
-    };
-  }
-  if (verdict === "blocked") {
-    return {
-      reached: false,
-      hasProgress: false,
-      message: reason ?? "GOAL_STATUS: BLOCKED",
-    };
-  }
-  return {
-    reached: false,
-    hasProgress: false,
-    message: "missing GOAL_STATUS block",
-  };
-}
-
 /** turnEndGuard.check 的纯逻辑：模型想停时，未达标则回灌阻断消息并强制续跑。 */
 export function checkGoalContinuation(text: string): GoalContinuationCheck {
   const verdict = parseGoalVerdict(text);
@@ -245,12 +191,13 @@ export function classifyGoalOutcome(
   const verdict = parseGoalVerdict(text);
   const abortReason = summary?.abortReason ?? "";
   const budgetExhausted =
-    verdict !== "reached" && /token budget exhausted/i.test(abortReason);
+    verdict !== "reached" &&
+    summary?.reason === "aborted" &&
+    /token budget exhausted/i.test(abortReason);
   const aborted =
     summary?.reason === "aborted" &&
     verdict !== "reached" &&
-    !budgetExhausted &&
-    !/^progressVerifier:/i.test(abortReason);
+    !budgetExhausted;
   return { verdict, aborted, budgetExhausted };
 }
 

--- a/apps/coding-agent/src/tui/slash.ts
+++ b/apps/coding-agent/src/tui/slash.ts
@@ -47,7 +47,7 @@ export const SLASH_COMMANDS: ReadonlyArray<{
   {
     name: "goal",
     description:
-      "run a hook-composed goal loop (turnEndGuard + progressVerifier + tokenBudget)",
+      "run a hook-composed goal loop (turnEndGuard + tokenBudget)",
     argumentHint: "<goal> [--max-turns N] [--budget N] [--success <criteria>]",
   },
   {

--- a/docs/05-plugins.md
+++ b/docs/05-plugins.md
@@ -1827,12 +1827,12 @@ export function skills(specs: SkillSpec[], opts?: { toolName?: string }): { hook
 
 #### 目的
 
-loop-engineering（`/goal` 循环）的 **turn 级进展/目标 verifier hook**。在每个 turn 结束后，用调用方注入的 `judge` 函数判定：
+服务端 agent 可复用的 **turn 级进展/目标 verifier hook**。在每个 turn 结束后，用调用方注入的 `judge` 函数判定：
 
 1. **目标达成**（`reached: true`）→ 立即停止 session。
 2. **连续 N turn 无真实进展**（`hasProgress: false`）→ 停止 session 或触发用户的 `onStall` 升级回调。
 
-是 roadmap「Controller / plugin 候选」`progressVerifier` 的实现。作为 `/goal` 命令的**前置依赖**——有了它，loop 不需要在业务层写 if/else 来判断「啥时候停」，而是把停止条件声明为 hook。
+是 roadmap「Controller / plugin 候选」`progressVerifier` 的实现。它适合需要逐 turn 主动停止的服务端 agent；`apps/coding-agent` 的 `/goal` 命令不再挂载本插件，而是用 `turnEndGuard + tokenBudget`：前者只在 would-be-done 时校验 `GOAL_STATUS` 并强制续跑，后者负责预算硬停。
 
 #### Hook 形态
 
@@ -1862,7 +1862,7 @@ export interface ProgressJudgement {
 - **`hasProgress: false`**：累计 `noProgressCount`；达 `noProgressThreshold` 时调 `onStall`（如有），再以 `{ continue: false }` 停止（若 `onStall` 已 `ctx.abort()`，不二次停止）。
 - **`hasProgress` 省略**（默认 `true`）：重置计数，session 继续——调用方只需在明确发现无进展时才设 `false`。
 - **judge 抛错**：中性处理（跳过本 turn 计数，不计无进展、不计进展），session 继续——避免瞬时错误误停。
-- **`onStall`**：通知回调（日志/报警/降级），可自行 `ctx.abort(customReason)`；若不 abort，插件用默认原因停止并**不** reset 计数（session 就此停止，计数留原值）。
+- **`onStall`**：通知回调（日志/报警/降级），可自行 `ctx.abort(customReason)`；若不 abort，插件用默认原因停止并**不** reset 计数（session 就此停止，计数留原值）。若 `onStall` 抛错，插件记录 warning，并继续用默认 no-progress 原因停止。
 
 **timeout 默认 30s**：`onTurnEnd` 是 event 类、dispatcher 默认仅 100ms；`judge` 通常需调 LLM，必然超时 → 判断静默失效。故本插件自设宽默认，可经 `timeoutMs` 覆盖（对齐 `turnEndGuard` / `onAfterFlush` 同款约定）。
 

--- a/packages/plugins/src/__tests__/progress-verifier.test.ts
+++ b/packages/plugins/src/__tests__/progress-verifier.test.ts
@@ -253,6 +253,29 @@ describe("progressVerifier", () => {
     expect(summary.abortReason).toContain("custom escalation reason");
   });
 
+  it("falls back to the default no-progress stop reason when onStall throws", async () => {
+    const model = createFakeModel([]);
+
+    const session = new AgentSession({
+      model,
+      tools: [],
+      hooks: [
+        progressVerifier({
+          judge: () => ({ reached: false, hasProgress: false }),
+          noProgressThreshold: 1,
+          onStall: () => {
+            throw new Error("notification backend unavailable");
+          },
+        }),
+      ],
+      maxTurns: 20,
+    });
+    const summary = await session.run("go");
+
+    expect(summary.reason).toBe("aborted");
+    expect(summary.abortReason).toBe("progressVerifier: no progress");
+  });
+
   it("hasProgress omitted defaults to true (optimistic), stall counter does not accumulate", async () => {
     // judge 每次只返回 { reached: false }（不含 hasProgress），视为有进展。
     // session 跑完自然结束（3 turns），不因无进展被停止。

--- a/packages/plugins/src/progress-verifier.ts
+++ b/packages/plugins/src/progress-verifier.ts
@@ -161,7 +161,14 @@ export function progressVerifier(opts: ProgressVerifierOptions): Hook {
       if (count >= threshold) {
         // 触发 onStall 回调（如有）。
         if (opts.onStall) {
-          await opts.onStall(ctx, { consecutiveNoProgress: count });
+          try {
+            await opts.onStall(ctx, { consecutiveNoProgress: count });
+          } catch (err) {
+            ctx.log.warn("progressVerifier: onStall threw, using default stop reason", {
+              hook: "progress-verifier",
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
         }
         // onStall 若未 abort，插件用默认原因停止。
         if (!ctx.signal.aborted) {


### PR DESCRIPTION
## 改动说明

- `/goal` 从 `turnEndGuard + progressVerifier + tokenBudget` 改为 `turnEndGuard + tokenBudget`，成功回到自然 `reason: "done"`。
- 为 goal session 显式设置内核 `maxTurns`，并保留 `maxContinuations` / `maxRetries` 三层兜底。
- 重写 `classifyGoalOutcome` 的 2-hook 终态判定，删除 progressVerifier 字符串嗅探。
- 修复 `project-instructions` 上爬边界、`parseGoalCommand` 边缘解析、`progressVerifier.onStall` 抛错路径，并更新 README/docs。

## 验收对照

- B1：`createGoalSession` 已去掉 `progressVerifier`，只装配 `turnEndGuard` 和 `tokenBudget`，并设置内核 turn 上限。
- B2：补齐 `classifyGoalOutcome` 直接单测：done+REACHED、done+NOT_REACHED、blocked、budget abort、用户中断、reached 优先于 budget、legacy progressVerifier 字符串不特殊处理。
- N1：新增 fake model 多 tool-call turn 后末轮 `GOAL_STATUS: REACHED` 的集成测试。
- N2：`project-instructions` 遇 `.git` / `$HOME` 停止，空文件跳过，并补测试。
- N3：`agent.ts` 已注释 turnEndGuard 与内核 `maxTurns` 分工。
- N4/N10：`--success` 合并为单条正则，补 stray `--` 与重复 `--success` 测试。
- N5：非法 `--max-turns abc` 被忽略且不污染 goal 文本。
- N6：`formatGoalRoundBanner` 测试断言 `25%`。
- N7：`parseGoalReason` 测试覆盖多条取最后、空 reason 为 undefined。
- N8：删除 `buildContinuationPrompt` 和旧测试。
- N9：`progressVerifier.onStall` 抛错后按默认 no-progress 原因停止，并补测试。
- N11：TUI turn banner 分母改用真实内核 `maxTurns`。
- N12：已跑 `examples/05-progress-verifier` start 冒烟。

## 测试

- `pnpm install`
- `pnpm -r build`
- `pnpm -r typecheck`
- `pnpm -r test`
- `pnpm --filter @harness-pi-example/05-progress-verifier start`

Closes #97
