### PR TITLE
CHA-173: 修复 /goal 发布门 re-gate-3 findings

### DIFF
--- a/apps/coding-agent/src/__tests__/agent.test.ts
+++ b/apps/coding-agent/src/__tests__/agent.test.ts
@@ -15,7 +15,7 @@ import {
 } from "../agent.js";
 import { parseArgs } from "../cli.js";
 import { renderRunReport } from "../output.js";
-import { buildGoalPrompt, type GoalOptions } from "../tui/goal.js";
+import { buildGoalPrompt, classifyGoalOutcome, type GoalOptions } from "../tui/goal.js";
 import {
   estimateDashScopeCostCny,
   getDashScopeModelMetadata,
@@ -337,6 +337,53 @@ describe("coding-agent dogfood app", () => {
 
     expect(summary.reason).toBe("aborted");
     expect(summary.abortReason).toContain("token budget exhausted");
+    await agent.close();
+    fake.teardown();
+  });
+
+  it("createGoalSession caps an unproductive NOT_REACHED loop", async () => {
+    const cwd = await tempRepo();
+    const goal: GoalOptions = { goal: "finish safely", maxTurns: 3 };
+    const fake = createFakeModel(
+      Array.from({ length: 10 }, (_, i) => ({
+        content: [
+          {
+            type: "text" as const,
+            text: `still not done ${i}\n---\nGOAL_STATUS: NOT_REACHED\nGOAL_REASON: needs another pass`,
+          },
+        ],
+      })),
+    );
+    const agent = createCodingAgent({ cwd, model: fake, log: false });
+
+    const summary = await agent.createGoalSession(goal).run(buildGoalPrompt(goal));
+
+    expect(["aborted", "max_continuations"]).toContain(summary.reason);
+    expect(summary.continuations).toBeLessThanOrEqual(goal.maxTurns);
+    expect(fake.getCalls().length).toBeLessThanOrEqual(goal.maxTurns + 1);
+    expect(classifyGoalOutcome(summary)).toMatchObject({
+      verdict: "not_reached",
+      aborted: false,
+      budgetExhausted: false,
+    });
+    await agent.close();
+    fake.teardown();
+  });
+
+  it("createGoalSession clamps public maxTurns input before wiring guards", async () => {
+    const cwd = await tempRepo();
+    const goal: GoalOptions = { goal: "finish once", maxTurns: 0 };
+    const fake = createFakeModel([
+      {
+        content: [{ type: "text", text: "done\n---\nGOAL_STATUS: REACHED" }],
+      },
+    ]);
+    const agent = createCodingAgent({ cwd, model: fake, log: false });
+
+    const summary = await agent.createGoalSession(goal).run(buildGoalPrompt(goal));
+
+    expect(summary.reason).toBe("done");
+    expect(fake.getCalls()).toHaveLength(1);
     await agent.close();
     fake.teardown();
   });

--- a/apps/coding-agent/src/__tests__/project-instructions.test.ts
+++ b/apps/coding-agent/src/__tests__/project-instructions.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createFakeModel } from "@harness-pi/core/testing";
-import { loadProjectInstructions } from "../project-instructions.js";
+import { PROJECT_INSTRUCTIONS_MAX_BYTES, loadProjectInstructions } from "../project-instructions.js";
 import { createCodingAgent } from "../agent.js";
 import { emitProjectInstructionsNotice, parseArgs } from "../cli.js";
 
@@ -99,12 +99,30 @@ describe("loadProjectInstructions", () => {
   });
 
   it("整棵目录树都没有指令文件 → 不抛错", async () => {
-    const cwd = await tmp();
-    const deep = join(cwd, "a", "b", "c");
+    const home = await tmp();
+    vi.stubEnv("HOME", home);
+    const deep = join(home, "a", "b", "c");
     await mkdir(deep, { recursive: true });
 
-    // 无法保证系统 tmp 父目录也没有文件，因此只断言不抛
-    expect(() => loadProjectInstructions(deep)).not.toThrow();
+    expect(loadProjectInstructions(deep)).toBeNull();
+  });
+
+  it("超大指令文件会被截断，不把整文件注入 prompt", async () => {
+    const cwd = await tmp();
+    const tailMarker = "TAIL_MARKER_SHOULD_NOT_APPEAR";
+    await writeFile(
+      join(cwd, "CLAUDE.md"),
+      `${"A".repeat(PROJECT_INSTRUCTIONS_MAX_BYTES + 1000)}${tailMarker}\n`,
+    );
+
+    const result = loadProjectInstructions(cwd);
+
+    expect(result).not.toBeNull();
+    expect(Buffer.byteLength(result!.content, "utf8")).toBeLessThan(
+      PROJECT_INSTRUCTIONS_MAX_BYTES + 256,
+    );
+    expect(result!.content).toContain("truncated");
+    expect(result!.content).not.toContain(tailMarker);
   });
 
   it("AGENTS.md 是 CLAUDE.md 的符号链接 → 也能正确加载", async () => {

--- a/apps/coding-agent/src/agent.ts
+++ b/apps/coding-agent/src/agent.ts
@@ -60,6 +60,7 @@ import {
 } from "./providers/dashscope.js";
 import {
   checkGoalContinuation,
+  clampGoalMaxTurns,
   goalKernelMaxTurns,
   goalTextFromMessage,
   type GoalOptions,
@@ -475,14 +476,15 @@ function buildAgentContext(opts: CreateCodingAgentOptions): AgentContext {
           compactionListener = listener;
         },
         createGoalSession(goal) {
-          const kernelMaxTurns = goalKernelMaxTurns(goal);
+          const goalMaxTurns = clampGoalMaxTurns(goal.maxTurns);
+          const kernelMaxTurns = goalKernelMaxTurns({ ...goal, maxTurns: goalMaxTurns });
           // /goal 的循环由 turnEndGuard 在 would-be-done 时续跑：
           // onContinuationCheck 只会在内核准备自然停止后触发，不会限制中间 tool-call turns。
           // 因此 maxRetries/maxContinuations 约束续跑次数，内核 maxTurns 单独约束工具调用轮数。
           const goalHooks: Hook[] = [
             turnEndGuard({
               check: (ctx) => checkGoalContinuation(latestAssistantText(ctx.messages)),
-              maxRetries: goal.maxTurns,
+              maxRetries: goalMaxTurns,
             }),
             tokenBudget({ budget: goal.budgetTokens ?? null }),
           ];
@@ -490,7 +492,7 @@ function buildAgentContext(opts: CreateCodingAgentOptions): AgentContext {
             ...deps,
             hooks: [...(deps.hooks ?? []), ...goalHooks],
             maxTurns: kernelMaxTurns,
-            maxContinuations: goal.maxTurns,
+            maxContinuations: goalMaxTurns,
           });
         },
       };

--- a/apps/coding-agent/src/project-instructions.ts
+++ b/apps/coding-agent/src/project-instructions.ts
@@ -1,12 +1,34 @@
-import { existsSync, readFileSync } from "node:fs";
+import { closeSync, existsSync, openSync, readSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 /** 候选文件名，按优先级排列：CLAUDE.md 优先，其次 AGENTS.md。 */
 const CANDIDATE_NAMES = ["CLAUDE.md", "AGENTS.md"] as const;
+export const PROJECT_INSTRUCTIONS_MAX_BYTES = 64 * 1024;
 
 export interface ProjectInstructions {
   content: string;
   sourcePath: string;
+}
+
+function readInstructionFile(path: string): string {
+  const fd = openSync(path, "r");
+  try {
+    const buffer = Buffer.alloc(PROJECT_INSTRUCTIONS_MAX_BYTES + 1);
+    const bytesRead = readSync(fd, buffer, 0, buffer.length, 0);
+    const truncated = bytesRead > PROJECT_INSTRUCTIONS_MAX_BYTES;
+    const content = buffer
+      .subarray(0, Math.min(bytesRead, PROJECT_INSTRUCTIONS_MAX_BYTES))
+      .toString("utf8");
+    if (!truncated) return content;
+    return [
+      content,
+      "",
+      `[Project instructions truncated to ${PROJECT_INSTRUCTIONS_MAX_BYTES} bytes.]`,
+      "",
+    ].join("\n");
+  } finally {
+    closeSync(fd);
+  }
 }
 
 /**
@@ -22,7 +44,7 @@ export function loadProjectInstructions(startDir: string): ProjectInstructions |
     for (const name of CANDIDATE_NAMES) {
       const candidate = join(dir, name);
       try {
-        const content = readFileSync(candidate, "utf8");
+        const content = readInstructionFile(candidate);
         if (content.trim().length === 0) continue;
         return { content, sourcePath: candidate };
       } catch {

--- a/apps/coding-agent/src/tui/__tests__/app.smoke.test.ts
+++ b/apps/coding-agent/src/tui/__tests__/app.smoke.test.ts
@@ -651,6 +651,52 @@ describe("TUI app smoke (headless, dual-track via fake terminal)", () => {
     expect(app.isRunning()).toBe(false);
   });
 
+  it("/goal: renders NOT_REACHED budget exhaustion from the TUI path", async () => {
+    const goalMessage = assistant([
+      {
+        type: "text",
+        text: "still failing\n---\nGOAL_STATUS: NOT_REACHED\nGOAL_REASON: tests still fail",
+      },
+    ]);
+    const goalSummary: RunSummary = {
+      turns: 2,
+      continuations: 1,
+      reason: "aborted",
+      abortReason: "token budget exhausted: 120/100",
+      usage: { ...ZERO },
+      lastMessage: goalMessage,
+      stopReason: goalMessage.stopReason,
+    };
+    const goalSession: TuiSession = {
+      on: NOOP_ON,
+      runStreaming: () => {
+        const gen = (async function* (): AsyncGenerator<SessionEvent> {
+          yield { type: "turn-start", turnIdx: 0 };
+          yield { type: "llm-end", msg: goalMessage, durationMs: 1 };
+          yield { type: "session-end", summary: goalSummary };
+        })();
+        return Object.assign(gen, { finalSummary: Promise.resolve(goalSummary) });
+      },
+    };
+    const app = createTuiApp({
+      agent: {
+        model: { id: "qwen-turbo" },
+        session: idleSession,
+        createGoalSession: () => goalSession,
+      },
+      terminal: new FakeTerminal(),
+    });
+
+    await app.submit("/goal make tests pass --max-turns 1");
+
+    const out = strip(app.tui.render(80).join("\n"));
+    expect(out).toContain("/goal stopped");
+    expect(out).toContain("token budget exhausted: 120/100");
+    expect(out).toContain("not_reached");
+    expect(out).not.toMatch(/interrupt|中断/i);
+    expect(app.isRunning()).toBe(false);
+  });
+
   it("Esc during /goal aborts the dedicated goal session", async () => {
     let capturedSignal: AbortSignal | undefined;
     let release!: () => void;

--- a/apps/coding-agent/src/tui/__tests__/format.test.ts
+++ b/apps/coding-agent/src/tui/__tests__/format.test.ts
@@ -150,7 +150,7 @@ describe("buildLineDiff", () => {
   it("handles new file (empty oldText)", () => {
     const diff = buildLineDiff("", "hello\nworld");
     const stripped = diff.map(strip);
-    expect(stripped).toContain("-");
+    expect(stripped).not.toContain("-");
     expect(stripped).toContain("+hello");
     expect(stripped).toContain("+world");
   });
@@ -160,7 +160,7 @@ describe("buildLineDiff", () => {
     const stripped = diff.map(strip);
     expect(stripped).toContain("-hello");
     expect(stripped).toContain("-world");
-    expect(stripped).toContain("+");
+    expect(stripped).not.toContain("+");
   });
 });
 

--- a/apps/coding-agent/src/tui/__tests__/goal.test.ts
+++ b/apps/coding-agent/src/tui/__tests__/goal.test.ts
@@ -76,6 +76,16 @@ describe("parseGoalCommand", () => {
   it("ignores negative budget (treats as no limit)", () => {
     const r = parseGoalCommand("some goal --budget -100");
     expect(r?.budgetTokens).toBeUndefined();
+    expect(r?.goal).toBe("some goal");
+  });
+
+  it("ignores invalid --budget values without leaving flag text in the goal", () => {
+    expect(parseGoalCommand("some goal --budget nope")).toEqual({
+      goal: "some goal",
+      maxTurns: 5,
+      budgetTokens: undefined,
+      successHint: undefined,
+    });
   });
 
   it("ignores an invalid --max-turns value without leaving flag text in the goal", () => {
@@ -167,6 +177,15 @@ describe("parseGoalVerdict", () => {
 
   it("handles extra whitespace around the value", () => {
     expect(parseGoalVerdict("GOAL_STATUS:  REACHED  ")).toBe("reached");
+  });
+
+  it.each([
+    ["GOAL_STATUS: **REACHED**", "reached"],
+    ["GOAL_STATUS: `BLOCKED`", "blocked"],
+    ["GOAL_STATUS: NOT_REACHED.", "not_reached"],
+    ["GOAL_STATUS: __not_reached__", "not_reached"],
+  ] as const)("tolerates markdown or punctuation around status values: %s", (text, expected) => {
+    expect(parseGoalVerdict(text)).toBe(expected);
   });
 
   it("returns unknown for empty text", () => {
@@ -265,6 +284,14 @@ describe("goalKernelMaxTurns", () => {
 
   it("clamps zero maxTurns to at least one visible goal round", () => {
     expect(goalKernelMaxTurns({ goal: "fix tests", maxTurns: 0 })).toBeGreaterThanOrEqual(20);
+  });
+
+  it("keeps very large maxTurns inside the safe integer range", () => {
+    const turns = goalKernelMaxTurns({ goal: "fix tests", maxTurns: Number.MAX_SAFE_INTEGER });
+
+    expect(Number.isSafeInteger(turns)).toBe(true);
+    expect(turns).toBeGreaterThan(0);
+    expect(turns).toBeLessThanOrEqual(Number.MAX_SAFE_INTEGER);
   });
 });
 

--- a/apps/coding-agent/src/tui/app.ts
+++ b/apps/coding-agent/src/tui/app.ts
@@ -70,8 +70,6 @@ export interface TuiAgentLike {
   /** contextWindow（若已知）用于状态栏的上下文占用读数 `ctx N/W`。 */
   model: { id: string; contextWindow?: number };
   getCostEstimate?(): { amount: number; currency: string } | undefined;
-  /** 累计 cost 统计（costTracker 提供）；用于 /goal 预算跟踪。 */
-  getCostStats?(): { inputTokens: number; outputTokens: number } | undefined;
   /** 最近一次 run 的工具统计；用于状态栏 `🔧 calls/errors`。 */
   getToolStats?(): { totalCalls: number; error: number } | undefined;
   /** 注入 tool 审批"问人"实现（permissionGate.onAsk 委托到它）。 */
@@ -489,6 +487,7 @@ export function createTuiApp(opts: TuiAppOptions): TuiApp {
         for await (const ev of stream) {
           if (ev.type === "turn-start") {
             round = ev.turnIdx + 1;
+            // 当前轮 usage 只有 llm-end 后才可得；turn-start 横幅显示上一轮累计用量。
             append(
               new Text(
                 color.dim(

--- a/apps/coding-agent/src/tui/format.ts
+++ b/apps/coding-agent/src/tui/format.ts
@@ -142,8 +142,8 @@ function formatBashPreview(command: string): string {
 
 /** 简单行级 diff：共同前缀/后缀保留为上下文（dim " "），中间差异段用 -/+ 标记。 */
 export function buildLineDiff(oldText: string, newText: string): string[] {
-  const oldLines = oldText.split("\n");
-  const newLines = newText.split("\n");
+  const oldLines = oldText.length === 0 ? [] : oldText.split("\n");
+  const newLines = newText.length === 0 ? [] : newText.split("\n");
 
   let prefixLen = 0;
   while (prefixLen < oldLines.length && prefixLen < newLines.length && oldLines[prefixLen] === newLines[prefixLen]) {

--- a/apps/coding-agent/src/tui/goal.ts
+++ b/apps/coding-agent/src/tui/goal.ts
@@ -20,10 +20,16 @@ export interface GoalOptions {
 
 /** 每个 goal 续跑轮给内层工具调用预留的 turn 数，避免回落到内核默认 200。 */
 const TURNS_PER_GOAL_ROUND = 20;
+const MAX_GOAL_ROUNDS = Math.floor(Number.MAX_SAFE_INTEGER / TURNS_PER_GOAL_ROUND);
+
+export function clampGoalMaxTurns(maxTurns: number): number {
+  const finite = Number.isFinite(maxTurns) ? Math.trunc(maxTurns) : 1;
+  return Math.min(MAX_GOAL_ROUNDS, Math.max(1, finite));
+}
 
 /** /goal session 的内核 turn 硬上限：用于约束 tool-call turns，不等同于续跑轮数。 */
 export function goalKernelMaxTurns(opts: GoalOptions): number {
-  return Math.max(1, opts.maxTurns) * TURNS_PER_GOAL_ROUND;
+  return clampGoalMaxTurns(opts.maxTurns) * TURNS_PER_GOAL_ROUND;
 }
 
 /**
@@ -44,10 +50,12 @@ export function parseGoalCommand(rest: string): GoalOptions | null {
     return "";
   });
 
-  // --budget <N>
-  text = text.replace(/--budget\s+(\d+)/i, (_, n: string) => {
-    const v = parseInt(n, 10);
-    if (v > 0) budgetTokens = v;
+  // --budget <N>；非法值也消费掉完整 token，避免把 flag 原样发给 LLM。
+  text = text.replace(/--budget(?:\s+((?!--)\S+))?/i, (_, n: string | undefined) => {
+    if (n !== undefined && /^[+-]?\d+$/.test(n)) {
+      const v = parseInt(n, 10);
+      if (v > 0) budgetTokens = v;
+    }
     return "";
   });
 
@@ -133,7 +141,16 @@ function finalGoalStatusBlock(text: string): { block: string; hasDelimiter: bool
 }
 
 function verdictFromValue(value: string): GoalVerdict {
-  const normalized = value.trim().toLowerCase();
+  let normalized = value.trim();
+  for (const marker of ["**", "__", "`"] as const) {
+    while (normalized.startsWith(marker) && normalized.endsWith(marker)) {
+      normalized = normalized.slice(marker.length, -marker.length).trim();
+    }
+  }
+  normalized = normalized
+    .replace(/^[\s`*_~"'([{<,:;.!?]+/, "")
+    .replace(/[\s`*_~"')\]}>,:;.!?]+$/, "")
+    .toLowerCase();
   if (normalized === "reached") return "reached";
   if (normalized === "not_reached") return "not_reached";
   if (normalized === "blocked") return "blocked";


### PR DESCRIPTION
## 改动说明

- 补齐 `/goal` 不收敛循环的封顶集成测试，锁定 `NOT_REACHED` 连续返回时不会无限续跑。
- 修复 `GOAL_STATUS` 解析对 markdown/标点包裹值不容忍的问题。
- 统一 `createGoalSession` 的 `maxTurns` clamp，避免公开接口传 `0` 时让 guard 抛错。
- 修复 `--budget` 负数/非法值残留进目标文本的问题，并补大值 `maxTurns` 安全整数边界测试。
- 给 project instructions 增加 64KiB 读取上限与截断提示，并强化无文件目录树测试。
- 修复空 old/new text 的 diff 预览裸 `-`/`+` 行。
- 补 TUI `/goal` 预算耗尽终态 smoke，移除未使用的 `TuiAgentLike.getCostStats` 表面积，并标注预算横幅使用上一轮累计 usage。

## 验收对照

- [x] 模型持续 `NOT_REACHED` 时 `/goal` session 会在 `maxTurns` 附近封顶停止，且 `classifyGoalOutcome` 仍判为 `not_reached`、非用户中断。
- [x] `GOAL_STATUS: **REACHED**`、``GOAL_STATUS: `BLOCKED` ``、`GOAL_STATUS: NOT_REACHED.` 等可正确解析。
- [x] `createGoalSession({ maxTurns: 0 })` 走统一 clamp，不再触发 `turnEndGuard: maxRetries must be > 0`。
- [x] `--budget -100` / `--budget nope` 不再残留 flag 文本。
- [x] project instructions 超大文件不会整段注入 prompt。
- [x] `buildLineDiff('', 'a\nb')` 与删除场景不再产生裸标记行。
- [x] TUI smoke 覆盖 `NOT_REACHED` + token budget exhausted 终态渲染。
- [x] `goalKernelMaxTurns` 大值结果保持在安全整数范围内。

## 测试说明

- `pnpm install`
- `pnpm --filter @harness-pi/coding-agent test -- src/__tests__/agent.test.ts src/tui/__tests__/goal.test.ts src/__tests__/project-instructions.test.ts src/tui/__tests__/format.test.ts src/tui/__tests__/app.smoke.test.ts`
- `pnpm -r build`
- `pnpm -r typecheck`
- `pnpm -r test`

Closes #102
