### PR TITLE
CHA-173: 补齐 /goal 封顶返修测试

### DIFF
--- a/apps/coding-agent/src/__tests__/agent.test.ts
+++ b/apps/coding-agent/src/__tests__/agent.test.ts
@@ -15,7 +15,12 @@ import {
 } from "../agent.js";
 import { parseArgs } from "../cli.js";
 import { renderRunReport } from "../output.js";
-import { buildGoalPrompt, classifyGoalOutcome, type GoalOptions } from "../tui/goal.js";
+import {
+  buildGoalPrompt,
+  clampGoalMaxTurns,
+  classifyGoalOutcome,
+  type GoalOptions,
+} from "../tui/goal.js";
 import {
   estimateDashScopeCostCny,
   getDashScopeModelMetadata,
@@ -341,7 +346,7 @@ describe("coding-agent dogfood app", () => {
     fake.teardown();
   });
 
-  it("createGoalSession caps an unproductive NOT_REACHED loop", async () => {
+  it("createGoalSession aborts a pure-text NOT_REACHED loop via empty-run-guard", async () => {
     const cwd = await tempRepo();
     const goal: GoalOptions = { goal: "finish safely", maxTurns: 3 };
     const fake = createFakeModel(
@@ -361,6 +366,47 @@ describe("coding-agent dogfood app", () => {
     expect(["aborted", "max_continuations"]).toContain(summary.reason);
     expect(summary.continuations).toBeLessThanOrEqual(goal.maxTurns);
     expect(fake.getCalls().length).toBeLessThanOrEqual(goal.maxTurns + 1);
+    expect(classifyGoalOutcome(summary)).toMatchObject({
+      verdict: "not_reached",
+      aborted: false,
+      budgetExhausted: false,
+    });
+    await agent.close();
+    fake.teardown();
+  });
+
+  it("createGoalSession caps a tool-using NOT_REACHED loop via maxContinuations", async () => {
+    const cwd = await tempRepo();
+    const goal: GoalOptions = { goal: "finish safely", maxTurns: 3 };
+    const fake = createFakeModel(
+      Array.from({ length: 10 }).flatMap((_, i) => [
+        {
+          content: [
+            {
+              type: "toolCall" as const,
+              name: "read",
+              arguments: { path: i % 2 === 0 ? "README.md" : "package.json" },
+            },
+          ],
+        },
+        {
+          content: [
+            {
+              type: "text" as const,
+              text: `still not done ${i}\n---\nGOAL_STATUS: NOT_REACHED\nGOAL_REASON: needs another pass`,
+            },
+          ],
+        },
+      ]),
+    );
+    const agent = createCodingAgent({ cwd, model: fake, log: false });
+
+    const summary = await agent.createGoalSession(goal).run(buildGoalPrompt(goal));
+
+    expect(summary.reason).toBe("max_continuations");
+    expect(summary.abortReason).toBeUndefined();
+    expect(summary.continuations).toBe(clampGoalMaxTurns(goal.maxTurns));
+    expect(fake.getCalls().length).toBe((clampGoalMaxTurns(goal.maxTurns) + 1) * 2);
     expect(classifyGoalOutcome(summary)).toMatchObject({
       verdict: "not_reached",
       aborted: false,

--- a/apps/coding-agent/src/tui/__tests__/goal.test.ts
+++ b/apps/coding-agent/src/tui/__tests__/goal.test.ts
@@ -106,6 +106,15 @@ describe("parseGoalCommand", () => {
     });
   });
 
+  it("does not treat words prefixed with goal flags as options", () => {
+    expect(parseGoalCommand("compare --budgetary plans and --max-turnsish wording")).toEqual({
+      goal: "compare --budgetary plans and --max-turnsish wording",
+      maxTurns: 5,
+      budgetTokens: undefined,
+      successHint: undefined,
+    });
+  });
+
   it("stops unquoted --success at a stray -- marker", () => {
     expect(parseGoalCommand("ship release --success all tests pass -- keep note")).toEqual({
       goal: "ship release -- keep note",

--- a/apps/coding-agent/src/tui/goal.ts
+++ b/apps/coding-agent/src/tui/goal.ts
@@ -45,13 +45,13 @@ export function parseGoalCommand(rest: string): GoalOptions | null {
   let successHint: string | undefined = undefined;
 
   // --max-turns <N>；非法值忽略并清掉完整 token，避免污染 goal 文本（如 3.5 残留 .5）。
-  text = text.replace(/--max-turns(?:\s+((?!--)\S+))?/i, (_, n: string | undefined) => {
+  text = text.replace(/--max-turns(?=\s|$)(?:\s+((?!--)\S+))?/i, (_, n: string | undefined) => {
     if (n !== undefined && /^[+-]?\d+$/.test(n)) maxTurns = Math.max(1, parseInt(n, 10));
     return "";
   });
 
   // --budget <N>；非法值也消费掉完整 token，避免把 flag 原样发给 LLM。
-  text = text.replace(/--budget(?:\s+((?!--)\S+))?/i, (_, n: string | undefined) => {
+  text = text.replace(/--budget(?=\s|$)(?:\s+((?!--)\S+))?/i, (_, n: string | undefined) => {
     if (n !== undefined && /^[+-]?\d+$/.test(n)) {
       const v = parseInt(n, 10);
       if (v > 0) budgetTokens = v;


### PR DESCRIPTION
## 改动说明

- 补一条带工具调用的持续 `NOT_REACHED` /goal 集成测试，确保空回合 guard 不参与时由 `maxContinuations` 封顶。
- 将原纯文本 `NOT_REACHED` 测试改名为 empty-run-guard 语义，避免继续表达成 false-green 覆盖。
- 修复 `--budgetary` / `--max-turnsish` 这类目标文本被 flag 正则误截断的问题，并补 parser 回归测试。

## 验收对照

- B1：新增工具调用 + `NOT_REACHED` 交替场景，断言 `summary.reason === "max_continuations"`、`continuations === clampGoalMaxTurns(goal.maxTurns)`、`classifyGoalOutcome` 仍为 `not_reached` 且非用户中断。
- B1 mutation 自查：临时将 `maxContinuations` 改为 `100000` 后，新测试失败为 `expected 'done' to be 'max_continuations'`；还原后通过。
- N1：flag 正则增加 `(?=\s|$)` 边界，普通目标词不会被误当作 `/goal` 参数。

## 测试说明

- `pnpm install`
- `pnpm --filter @harness-pi/coding-agent test -- src/__tests__/agent.test.ts`
- `pnpm --filter @harness-pi/coding-agent test -- src/__tests__/agent.test.ts -t "createGoalSession caps a tool-using"`
- `pnpm --filter @harness-pi/coding-agent test -- src/tui/__tests__/goal.test.ts -t "does not treat words prefixed"`
- `pnpm -r build`
- `pnpm -r typecheck`
- `pnpm -r test`

Closes #102
