### PR TITLE
perf(coding-agent): trimHistory 改 opt-in（默认关）— 护住 prompt cache (#106)

### DIFF
--- a/apps/coding-agent/README.md
+++ b/apps/coding-agent/README.md
@@ -124,6 +124,7 @@ hpi --resume <id>
 | `--tui` / `--repl` | Force the TUI / use a plain readline REPL. |
 | `--cwd <path>` | Workspace directory. Defaults to the current directory. |
 | `--read-only` | Restrict tools to `read`/`grep`/`find`/`ls` (no edits, no bash). |
+| `--trim-history <N>` | Opt in to history trimming (keep N recent tool results). **Off by default** — trimming breaks the prompt cache and is usually a net loss on caching providers; use only on non-caching providers or very long sessions. |
 | `--resume <id>` | Resume a saved TUI session. |
 | `--yolo` | (TUI) skip tool-approval prompts. |
 | `--compact` | (TUI) auto-summarize early messages when the conversation grows long. |

--- a/apps/coding-agent/src/__tests__/agent.test.ts
+++ b/apps/coding-agent/src/__tests__/agent.test.ts
@@ -242,6 +242,42 @@ describe("coding-agent dogfood app", () => {
     fake.teardown();
   });
 
+  // #106: trimHistory 默认关（opt-in）——每轮改写旧 toolResult 会破坏 prompt-cache 前缀、在缓存
+  // provider 上净亏。下面两条钉死「默认不裁」与「显式开了才裁」。
+  const threeBashThenDone = () =>
+    createFakeModel([
+      { content: [{ type: "toolCall", name: "bash", arguments: { command: "echo MARKER_0" } }] },
+      { content: [{ type: "toolCall", name: "bash", arguments: { command: "echo MARKER_1" } }] },
+      { content: [{ type: "toolCall", name: "bash", arguments: { command: "echo MARKER_2" } }] },
+      { content: [{ type: "text", text: "done" }] },
+    ]);
+
+  it("does NOT trim tool-result history by default (preserves prompt-cache prefix, #106)", async () => {
+    const cwd = await tempRepo();
+    const fake = threeBashThenDone();
+    const agent = createCodingAgent({ cwd, model: fake, log: false });
+    await runAgentPrompt(agent, "run three echo commands");
+    const lastMsgs = JSON.stringify(fake.getCalls().at(-1)?.messages);
+    expect(lastMsgs).toContain("MARKER_0"); // 最旧的 toolResult 仍完整
+    expect(lastMsgs).toContain("MARKER_2");
+    expect(lastMsgs).not.toContain("trimmed tool result"); // 没有任何裁剪占位符
+    await agent.close();
+    fake.teardown();
+  });
+
+  it("trims older tool results only when trimHistory is opted in", async () => {
+    const cwd = await tempRepo();
+    const fake = threeBashThenDone();
+    const agent = createCodingAgent({ cwd, model: fake, log: false, trimHistory: { keepRecent: 1 } });
+    await runAgentPrompt(agent, "run three echo commands");
+    const lastMsgs = JSON.stringify(fake.getCalls().at(-1)?.messages);
+    // 3 个 toolResult，keepRecent:1 → 最旧的 2 个 toolResult 内容被换成占位符（最近 1 条保留）。
+    // 注：占位符只替换 toolResult 内容；assistant 的 toolCall 参数(echo MARKER_N)不动，故不按 MARKER 断言。
+    expect((lastMsgs?.match(/trimmed tool result/g) ?? []).length).toBe(2);
+    await agent.close();
+    fake.teardown();
+  });
+
   it("createGoalSession stops naturally when the final GOAL_STATUS is REACHED", async () => {
     const cwd = await tempRepo();
     const goal: GoalOptions = { goal: "make tests pass", maxTurns: 3 };

--- a/apps/coding-agent/src/__tests__/cli-args.test.ts
+++ b/apps/coding-agent/src/__tests__/cli-args.test.ts
@@ -49,6 +49,21 @@ describe("parseArgs — v0.1.0 flags", () => {
     expect(parseArgs(["--no-log"]).noLog).toBe(true);
   });
 
+  it("trimHistory is opt-in: undefined by default (no trimming, preserves prompt cache)", () => {
+    expect(parseArgs([]).trimHistory).toBeUndefined();
+  });
+
+  it("--trim-history <N> opts in with keepRecent", () => {
+    expect(parseArgs(["--trim-history", "8"]).trimHistory).toEqual({ keepRecent: 8 });
+    expect(parseArgs(["--trim-history", "0"]).trimHistory).toEqual({ keepRecent: 0 });
+  });
+
+  it("--trim-history rejects non-integer / negative values", () => {
+    expect(() => parseArgs(["--trim-history", "abc"])).toThrow(/non-negative integer/);
+    expect(() => parseArgs(["--trim-history", "-1"])).toThrow(/non-negative integer/);
+    expect(() => parseArgs(["--trim-history"])).toThrow(/requires a value/);
+  });
+
   it("--log-args parses redacted | full | none", () => {
     expect(parseArgs(["--log-args", "redacted"]).logArgs).toBe("redacted");
     expect(parseArgs(["--log-args", "full"]).logArgs).toBe("full");

--- a/apps/coding-agent/src/agent.ts
+++ b/apps/coding-agent/src/agent.ts
@@ -115,6 +115,14 @@ export interface CreateCodingAgentOptions {
    */
   compaction?: { maxMessages?: number; keepRecent?: number };
   /**
+   * 启用 trimHistory（把 N 条之前的 toolResult 内容换成短占位符喂给 LLM）。
+   * **默认不挂（opt-in）**：trimHistory 每轮改写靠前的旧历史，会破坏 prompt-cache 前缀——在会缓存的
+   * provider（DeepSeek / Anthropic / …）上实测**净亏**（cache 命中 93%→74%、cost 反而更高，见 #106）。
+   * 上下文溢出本就由 `autoCompaction`/`compactSummarize` 兜底。仅在**非缓存 provider / 极长会话 /
+   * 上下文窗口紧**时显式开。
+   */
+  trimHistory?: { keepRecent: number };
+  /**
    * true ⇒ 跳过项目指令（CLAUDE.md / AGENTS.md）自动加载。默认 false（自动向上查找并注入）。
    */
   noProjectInstructions?: boolean;
@@ -370,7 +378,8 @@ function buildAgentContext(opts: CreateCodingAgentOptions): AgentContext {
     // compactSummarize 须排在 trimHistory 前：先把早期消息总结成 summary，再让 trimHistory 裁中段
     // toolResult（docs/09 §3.6「先 summarize 早期、再 trim 中段」的组合顺序）。未启用 compaction 时不挂。
     ...(compactionOpts ? [compactSummarize(compactionOpts)] : []),
-    trimHistory({ keepRecent: 12 }),
+    // trimHistory 默认不挂（opt-in）：每轮改写旧历史会破坏 prompt-cache 前缀、在缓存 provider 上净亏（#106）。
+    ...(opts.trimHistory ? [trimHistory({ keepRecent: opts.trimHistory.keepRecent })] : []),
     emptyRunGuard({ maxEmptyTurns: 3 }),
     repeatedCallGuard({
       threshold: 4,

--- a/apps/coding-agent/src/cli.ts
+++ b/apps/coding-agent/src/cli.ts
@@ -48,6 +48,7 @@ interface CliArgs {
   version: boolean;
   help: boolean;
   noProjectInstructions: boolean;
+  trimHistory?: { keepRecent: number } | undefined;
 }
 
 /** TUI 会话落盘文件路径:.harness-pi/sessions/<id>.jsonl（相对 cwd）。 */
@@ -211,6 +212,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     disabledTools: args.disabledTools,
   };
   if (args.noProjectInstructions) createOptions.noProjectInstructions = true;
+  if (args.trimHistory) createOptions.trimHistory = args.trimHistory;
   if (runtime.llmOptions !== undefined) {
     createOptions.llmOptions = runtime.llmOptions;
   }
@@ -367,6 +369,17 @@ export function parseArgs(argv: string[]): CliArgs {
     }
     if (arg === "--read-only") {
       out.readOnly = true;
+      continue;
+    }
+    if (arg === "--trim-history") {
+      const raw = requireValue(argv, ++i, "--trim-history");
+      const n = Number(raw);
+      if (!Number.isInteger(n) || n < 0) {
+        throw new Error(
+          `--trim-history expects a non-negative integer (keepRecent), got "${raw}"`,
+        );
+      }
+      out.trimHistory = { keepRecent: n };
       continue;
     }
     if (arg === "--tui") {
@@ -564,6 +577,10 @@ Options:
   --repl                   Plain readline REPL instead of the TUI.
   --cwd <path>             Workspace directory. Defaults to the current directory.
   --read-only              Restrict tools to read/grep/find/ls (no edits, no bash).
+  --trim-history <N>       Opt in to history trimming (keep N recent tool results; older ones
+                           become placeholders). OFF by default — trimming breaks the prompt
+                           cache and is usually a net loss on caching providers. Use only on
+                           non-caching providers or very long sessions.
   --resume <id>            Resume a saved TUI session (.harness-pi/sessions/<id>.jsonl).
   --yolo                   (TUI) skip tool-approval prompts — allow bash/write/edit unattended.
   --compact                (TUI) auto-summarize early messages when the conversation grows long.


### PR DESCRIPTION
闭合 #106 的"立即"项。

## 为什么
coding-agent 默认硬编码 `trimHistory({keepRecent:12})`，每轮经 `transformMessagesBeforeLlm` 改写靠前的旧 toolResult → 破坏 prompt-cache 前缀。

**实测 A/B（DeepSeek deepseek-v4-flash，同一多 bug 任务）**：
| | cache 命中 | 未缓存 input | cost |
|---|--:|--:|--:|
| trim-OFF | 93% | ~1.1K | $0.00045 |
| trim-ON | 74% | ~6.9K | $0.0014 (+213%) |

不 trim 时 DeepSeek 缓存命中 93% → 本就便宜；默认 trim 把缓存扔了、净亏。详见 `reports/swe-bench-pilot-2026-06-17.md` / `docs/swe-bench-eval.md`，启发自 [maka-agent#19](https://github.com/jackwener/maka-agent/issues/19)。

## 改动
- `createCodingAgent`: 新增 `trimHistory?: {keepRecent}`，**默认不挂**。
- CLI: `--trim-history <N>` 显式开（非缓存 provider / 极长会话用）；help + README 更新。
- 上下文溢出仍由 `autoCompaction`/`compactSummarize` 兜底，不依赖 trim。
- 测试: cli-args 解析（默认 undefined / 合法值 / 非法抛错）+ 行为回归（默认不裁 → 无占位符；opt-in keepRecent:1 → 裁旧 2 条）。348 测试全过、typecheck 干净。

## 不在本 PR（#106 跟踪的后续）
cache-aware 改写（门控+archive）、prefix-shape 缓存诊断插件、其余 6 个 transform 插件审计、显式 cacheRetention。

🤖 Generated with [Claude Code](https://claude.com/claude-code)