### PR TITLE
feat(plugins): prefix-shape —— prompt-cache 前缀诊断插件（#106 后续）

### DIFF
--- a/docs/05-plugins.md
+++ b/docs/05-plugins.md
@@ -2,7 +2,7 @@
 
 > Plugin 解剖、命名/状态约定、标准库 plugin 的完整设计。
 >
-> **计数（以 `packages/plugins/src/index.ts` 实际导出为准）**：**21 个返回 `Hook` 的 plugin 工厂** + **2 个面向模型的工具/技能工厂**（`toolSearch` 返回 `HarnessTool`、`skills` 返回 `{hook, tool}`）+ **1 个 summary 模板辅助件**（`defaultSummarize` / `DEFAULT_SUMMARY_TEMPLATE`，给压缩插件的 `summarize` 用）。分「核心 12」（§5.1–5.12，bidding-agent parity 起点）与「高级 / 0.3.0 新增」（§5.13–5.22，compaction 体系 + 权限 + deferred/skills + loop-engineering verifier）两档。
+> **计数（以 `packages/plugins/src/index.ts` 实际导出为准）**：**22 个返回 `Hook` 的 plugin 工厂** + **2 个面向模型的工具/技能工厂**（`toolSearch` 返回 `HarnessTool`、`skills` 返回 `{hook, tool}`）+ **1 个 summary 模板辅助件**（`defaultSummarize` / `DEFAULT_SUMMARY_TEMPLATE`，给压缩插件的 `summarize` 用）。分「核心 12」（§5.1–5.12，bidding-agent parity 起点）与「高级 / 0.3.0 新增」（§5.13–5.22，compaction 体系 + 权限 + deferred/skills + loop-engineering verifier）两档。
 
 ## 0. 目录
 
@@ -36,6 +36,7 @@
    - [5.19 turn-end-guard](#519-turn-end-guard)
    - [5.20 permission-gate](#520-permission-gate)
    - [5.21 deferred-tools + tool-search + skills](#521-deferred-tools--tool-search--skills)（O1/O2 渐进式暴露）
+   - [5.22 prefix-shape](#522-prefix-shape)（prompt-cache 失效实时归因）
 6. [测试规约](#6-测试规约)
 
 ## 1. Plugin 是什么
@@ -185,7 +186,7 @@ export function _resetForTests(): void { ... }
 
 ## 5. 标准库 plugin
 
-> 共 **20 个 `Hook` 工厂** + **2 个工具/技能工厂**（`toolSearch` / `skills`）+ **1 个 summary 模板辅助件**（`defaultSummarize`）。下分「核心 12」（§5.1–5.12）与「高级 / 0.3.0 新增」（§5.13–5.21）。
+> 共 **21 个 `Hook` 工厂** + **2 个工具/技能工厂**（`toolSearch` / `skills`）+ **1 个 summary 模板辅助件**（`defaultSummarize`）。下分「核心 12」（§5.1–5.12）与「高级 / 0.3.0 新增」（§5.13–5.22）。
 
 ### 核心 12
 
@@ -1819,6 +1820,61 @@ export function skills(specs: SkillSpec[], opts?: { toolName?: string }): { hook
 - execution 与 listing 解耦、permissionGate 仍拦
 - toolSearch / skill 屏障型；skills catalog 不含 body、激活是 union、未知 skill 抛、空/重名构造期抛
 （见 `deferred-tools.test.ts` / `skills.test.ts`）
+
+---
+
+### 5.22 prefix-shape
+
+#### 目的
+
+给 prompt-cache 失效装上**实时归因**。provider 在 durable prefix（model/provider 标识 + system + tools schema）边界做 KV-cache，前缀逐字节不变才可能命中。本插件每 turn canonicalize 出这段 durable prefix、算稳定 hash、与上一 turn 比，变了就分类原因（model / system / tool_schema / provider_options）并经 `ctx.log` 暴露；可选在 `onLlmEnd` 用真实 `usage.cacheRead` 做「预测 vs 实测」对账。把「这一 turn 为什么没命中 cache」从事后 A/B 提前到每 turn 可见（背景见 #106：`trimHistory` 每轮改写旧历史破坏前缀、命中 93%→74%）。移植自 maka `request-shape.ts`，砍到 durable-prefix-only（不做 history projection / tool-source-economy / zod 转换）。
+
+#### Hook 形态
+
+Transform-observe（`transformToolsBeforeLlm` 观测式 passthrough，**返回 void 不改写 tools**）+ 可选 Event（`onLlmEnd` 只读 usage 对账）。零内核改动、fail-open。
+
+#### 完整设计
+
+```ts
+import { prefixShape, getPrefixShapeState } from "@harness-pi/plugins";
+
+// 最小：只 log「prefix 变了 + 原因」
+prefixShape();
+
+// 接 metric / 对账（典型生产形态，与 cost-tracker 一样 metric 走 opt-in 回调，不占 CoreMetricKind）
+prefixShape({
+  onPrefixChange: (ctx, diag) => emitMetric(ctx, { kind: "prefix.shape", reason: diag.changeReason }),
+  onCacheReconcile: (ctx, info) =>
+    emitMetric(ctx, { kind: "cache.reconcile", predicted: info.changeReason, hitRatio: info.cacheHitRatio }),
+});
+```
+
+每 turn 把 `PrefixShapeDiagnostic { prefixHash, changeReason, components, turnIdx, toolCount }` 写进 `ctx.state["prefix-shape.last"]`，`getPrefixShapeState(ctx)` 读取。`changeReason ∈ {first_turn, model_or_provider_changed, system_prompt_changed, tool_schema_changed, provider_options_changed, stable}`，优先级 model > system > tools > providerOptions。
+
+> tools 的**线上顺序**计入 hash（canonicalize 不排顶层数组，只排 schema 内 `required`/`enum`）—— 工具重排会真正破坏前缀，应被如实标成 `tool_schema_changed`，不 pre-sort 掩盖。
+
+#### 配置选项
+
+- `providerOptions?: (ctx) => Record<string, unknown>` —— provider options 指纹源。**默认不参与**（内核不经 hook 暴露 provider options；只有你每 turn 主动改 temperature / thinking budget 时才需要喂）。
+- `onPrefixChange?` —— prefix 变化（非 stable/first_turn）时回调，典型 emit metric。
+- `onCacheReconcile?` —— `onLlmEnd` 把预测 reason 与真实 `usage.cacheRead` 配对（默认不挂）。
+- `log?: boolean` —— 变化时自动 `ctx.log.info` 一行（默认 true）。
+
+#### 与其他 plugin 交互
+
+- 挂在 `deferred-tools` **之后**才能看到激活后的 active 子集（pipe 按注册顺序串行）；反了也只是「按全集算 hash」，退化不致命。
+- 与 `cost-tracker` 正交：cost-tracker 读 `usage` 算钱，本插件读 `usage.cacheRead` 看命中，互不耦合。
+- 诊断的是「durable prefix 这一段稳不稳」，**不**解释全部 cache miss——history 增长本身会让超出公共前缀的后缀 miss（那是 `trim-history`/compaction 那条线的事）。
+
+#### 失败模式
+
+- 纯观测、fail-open：hook 抛错不挡 LLM call（pipe 语义）。
+- **两条已知盲区（文档化、不修——修就破坏零内核改动，与 `auto-compaction` 同档）**：① system 指纹取 `ctx.config.systemPrompt` = 构造期 pre-pipe base，若挂了 `transformSystemPromptBeforeLlm` 每 turn 改写 system 会漏报 `system_prompt_changed`（当前无 first-party hook 这么干）；② provider options 默认不参与分类。
+- ⚠️ `reason === "stable"` 是命中的**必要非充分**条件，不等于该 100% 命中；`onCacheReconcile` 给的是关联信号、非因果证明。
+
+#### 测试要点
+
+纯函数（`stableHash` 键序无关/数组顺序敏感、`required`/`enum` 乱序同 hash、`classifyPrefixChange` 各分支 + 优先级）+ 插件行为（`createTestContext` 直调：first_turn / stable 不 log / tool_schema_changed 触发 log+回调 / log:false / providerOptions opt-in）+ 真管线冒烟（`AgentSession`+`createFakeModel`：两 turn 同 tools → turn-2 stable、注入 `usage.cached` 对账）。见 `prefix-shape.test.ts`。
 
 ---
 

--- a/packages/plugins/src/__tests__/prefix-shape.test.ts
+++ b/packages/plugins/src/__tests__/prefix-shape.test.ts
@@ -1,0 +1,338 @@
+/**
+ * prefix-shape 单测：纯函数（hash 稳定性 + 变更分类）+ 插件行为（createTestContext 直调 hook）
+ * + 真管线冒烟（AgentSession + createFakeModel，证实装配顺序下 active tools 引用稳定 → hash 稳定）。
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  AgentSession,
+  Type,
+  type HarnessTool,
+  type Hook,
+  type HookContext,
+  type Tool,
+} from "@harness-pi/core";
+import { createFakeModel, createTestContext } from "@harness-pi/core/testing";
+import {
+  prefixShape,
+  getPrefixShapeState,
+  computeDurablePrefix,
+  classifyPrefixChange,
+  stableHash,
+  type PrefixChangeReason,
+  type PrefixShapeDiagnostic,
+  type CacheReconcileInfo,
+} from "../prefix-shape.js";
+
+/** 裸 Tool（name/description/parameters）——纯函数 / createTestContext 用。parameters 当普通数据处理。 */
+function tool(name: string, parameters: unknown): Tool {
+  return { name, description: `${name} tool`, parameters } as Tool;
+}
+
+/** 可执行 HarnessTool ——AgentSession 冒烟用。 */
+function trivialTool(name: string): HarnessTool {
+  return {
+    name,
+    description: `${name} tool`,
+    parameters: Type.Object({}),
+    isConcurrencySafe: () => true,
+    async execute() {
+      return { content: [{ type: "text", text: `${name} ran` }] };
+    },
+  };
+}
+
+const M = { id: "m", provider: "p" };
+
+describe("prefix-shape 纯函数", () => {
+  it("stableHash：键序无关、数组顺序敏感", () => {
+    expect(stableHash({ a: 1, b: 2 })).toBe(stableHash({ b: 2, a: 1 }));
+    expect(stableHash([1, 2])).not.toBe(stableHash([2, 1]));
+  });
+
+  it("tool schema 内 required/enum 数组乱序 → 同 hash（canonicalize 只排这俩 key）", () => {
+    const a = tool("x", { type: "object", required: ["a", "b"], properties: {} });
+    const b = tool("x", { type: "object", required: ["b", "a"], properties: {} });
+    const ha = computeDurablePrefix({ model: M, systemPrompt: "", activeTools: [a] });
+    const hb = computeDurablePrefix({ model: M, systemPrompt: "", activeTools: [b] });
+    expect(ha.toolSchemaHash).toBe(hb.toolSchemaHash);
+  });
+
+  it("tool 线上顺序敏感：重排两个工具 → toolSchemaHash 变（如实反映前缀被破坏）", () => {
+    const a = tool("a", { type: "object" });
+    const b = tool("b", { type: "object" });
+    const ab = computeDurablePrefix({ model: M, systemPrompt: "", activeTools: [a, b] });
+    const ba = computeDurablePrefix({ model: M, systemPrompt: "", activeTools: [b, a] });
+    expect(ab.toolSchemaHash).not.toBe(ba.toolSchemaHash);
+  });
+
+  it("classifyPrefixChange：各分支 + 优先级 model>system>tools>providerOptions", () => {
+    const tA = tool("A", { type: "object" });
+    const tB = tool("B", { type: "object" });
+    const base = computeDurablePrefix({ model: M, systemPrompt: "s", activeTools: [tA] });
+
+    expect(classifyPrefixChange(base, undefined)).toBe("first_turn");
+    expect(classifyPrefixChange(base, base)).toBe("stable");
+
+    const sys = computeDurablePrefix({ model: M, systemPrompt: "s2", activeTools: [tA] });
+    expect(classifyPrefixChange(sys, base)).toBe("system_prompt_changed");
+
+    const mdl = computeDurablePrefix({ model: { id: "m2", provider: "p" }, systemPrompt: "s", activeTools: [tA] });
+    expect(classifyPrefixChange(mdl, base)).toBe("model_or_provider_changed");
+
+    const tls = computeDurablePrefix({ model: M, systemPrompt: "s", activeTools: [tA, tB] });
+    expect(classifyPrefixChange(tls, base)).toBe("tool_schema_changed");
+
+    const poBase = computeDurablePrefix({ model: M, systemPrompt: "s", activeTools: [tA], providerOptions: { temperature: 0.1 } });
+    const poNew = computeDurablePrefix({ model: M, systemPrompt: "s", activeTools: [tA], providerOptions: { temperature: 0.9 } });
+    expect(classifyPrefixChange(poNew, poBase)).toBe("provider_options_changed");
+
+    // 全变 → model 优先胜出
+    const all = computeDurablePrefix({ model: { id: "m2", provider: "p" }, systemPrompt: "s2", activeTools: [tA, tB] });
+    expect(classifyPrefixChange(all, base)).toBe("model_or_provider_changed");
+  });
+
+  it("providerOptions 缺省 → 跨 turn stable（默认盲区，不误报 provider_options_changed）", () => {
+    const tA = tool("A", { type: "object" });
+    const a = computeDurablePrefix({ model: M, systemPrompt: "s", activeTools: [tA] });
+    const b = computeDurablePrefix({ model: M, systemPrompt: "s", activeTools: [tA] });
+    expect(classifyPrefixChange(b, a)).toBe("stable");
+  });
+
+  it("空 tools 数组：跨 turn stable；[]→[x] 判 tool_schema_changed（空集是合法 prior，非 first_turn）", () => {
+    const e1 = computeDurablePrefix({ model: M, systemPrompt: "s", activeTools: [] });
+    const e2 = computeDurablePrefix({ model: M, systemPrompt: "s", activeTools: [] });
+    expect(classifyPrefixChange(e2, e1)).toBe("stable");
+    const withTool = computeDurablePrefix({ model: M, systemPrompt: "s", activeTools: [tool("x", { type: "object" })] });
+    expect(classifyPrefixChange(withTool, e1)).toBe("tool_schema_changed");
+  });
+
+  it("canonicalize 只排 required/enum：其他数组字段（examples）乱序 → hash 变（钉死 shouldSortArray 边界）", () => {
+    const a = tool("x", { type: "object", properties: { tags: { type: "array", examples: ["p", "q"] } } });
+    const b = tool("x", { type: "object", properties: { tags: { type: "array", examples: ["q", "p"] } } });
+    const ha = computeDurablePrefix({ model: M, systemPrompt: "", activeTools: [a] });
+    const hb = computeDurablePrefix({ model: M, systemPrompt: "", activeTools: [b] });
+    expect(ha.toolSchemaHash).not.toBe(hb.toolSchemaHash);
+  });
+
+  it("回归哨兵：TypeBox schema 无 symbol key（toolShapeForDiagnostics 直传 parameters 的确定性前提；上游换 TypeBox 即红）", () => {
+    expect(Object.getOwnPropertySymbols(Type.Object({ a: Type.String() }))).toHaveLength(0);
+  });
+});
+
+describe("prefixShape 插件行为（createTestContext 直调）", () => {
+  it("首 turn → first_turn，passthrough 返回 void（不改写 tools）", () => {
+    const h = createTestContext({ captureLog: true });
+    const ret = prefixShape().transformToolsBeforeLlm!([tool("read", {})], h.ctx);
+    expect(ret).toBeUndefined();
+    expect(getPrefixShapeState(h.ctx)?.changeReason).toBe("first_turn");
+    expect(h.logs).toHaveLength(0); // first_turn 不 log
+  });
+
+  it("同 tools 跨 turn → stable，不 log、不触发 onPrefixChange", () => {
+    const changes: PrefixShapeDiagnostic[] = [];
+    const h = createTestContext({ captureLog: true });
+    const hook = prefixShape({ onPrefixChange: (_c, d) => changes.push(d) });
+    const tools = [tool("read", {}), tool("bash", {})];
+    hook.transformToolsBeforeLlm!(tools, h.ctx); // first_turn
+    h.setTurnIdx(1);
+    hook.transformToolsBeforeLlm!(tools, h.ctx); // stable
+    expect(getPrefixShapeState(h.ctx)?.changeReason).toBe("stable");
+    expect(changes).toHaveLength(0);
+    expect(h.logs).toHaveLength(0);
+  });
+
+  it("少一个 tool → tool_schema_changed，log 一行 + onPrefixChange（toolCount 正确）", () => {
+    const changes: PrefixShapeDiagnostic[] = [];
+    const h = createTestContext({ captureLog: true });
+    const hook = prefixShape({ onPrefixChange: (_c, d) => changes.push(d) });
+    hook.transformToolsBeforeLlm!([tool("read", {}), tool("bash", {})], h.ctx); // first_turn, count 2
+    h.setTurnIdx(1);
+    hook.transformToolsBeforeLlm!([tool("read", {})], h.ctx); // tool_schema_changed, count 1
+    expect(getPrefixShapeState(h.ctx)?.changeReason).toBe("tool_schema_changed");
+    expect(changes).toHaveLength(1);
+    expect(changes[0]!.toolCount).toBe(1);
+    expect(h.logs).toHaveLength(1);
+    expect(h.logs[0]!.level).toBe("info");
+    expect(h.logs[0]!.fields.reason).toBe("tool_schema_changed");
+  });
+
+  it("log:false → 不 log，但 onPrefixChange 仍触发", () => {
+    const changes: PrefixShapeDiagnostic[] = [];
+    const h = createTestContext({ captureLog: true });
+    const hook = prefixShape({ log: false, onPrefixChange: (_c, d) => changes.push(d) });
+    hook.transformToolsBeforeLlm!([tool("read", {})], h.ctx);
+    h.setTurnIdx(1);
+    hook.transformToolsBeforeLlm!([tool("read", {}), tool("bash", {})], h.ctx);
+    expect(getPrefixShapeState(h.ctx)?.changeReason).toBe("tool_schema_changed");
+    expect(changes).toHaveLength(1);
+    expect(h.logs).toHaveLength(0);
+  });
+
+  it("providerOptions opt-in：跨 turn 改值 → provider_options_changed", () => {
+    let temp = 0.1;
+    const h = createTestContext({ captureLog: true });
+    const hook = prefixShape({ providerOptions: () => ({ temperature: temp }) });
+    const tools = [tool("read", {})];
+    hook.transformToolsBeforeLlm!(tools, h.ctx); // first_turn
+    h.setTurnIdx(1);
+    temp = 0.9;
+    hook.transformToolsBeforeLlm!(tools, h.ctx); // provider_options_changed
+    expect(getPrefixShapeState(h.ctx)?.changeReason).toBe("provider_options_changed");
+  });
+
+  it("state 跨 context 隔离：h1 跑过后 h2 仍 undefined（诊断不串味）", () => {
+    const h1 = createTestContext();
+    const h2 = createTestContext();
+    prefixShape().transformToolsBeforeLlm!([tool("a", {})], h1.ctx);
+    expect(getPrefixShapeState(h1.ctx)?.changeReason).toBe("first_turn");
+    expect(getPrefixShapeState(h2.ctx)).toBeUndefined();
+  });
+});
+
+describe("prefixShape onLlmEnd 对账 + 真管线", () => {
+  it("用真实 usage.cacheRead 做预测 vs 实测对账", async () => {
+    const recon: CacheReconcileInfo[] = [];
+    const fake = createFakeModel([
+      {
+        content: [{ type: "text", text: "done" }],
+        stopReason: "stop",
+        usage: { input: 100, output: 10, cached: 900 },
+      },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [trivialTool("read")],
+      hooks: [prefixShape({ onCacheReconcile: (_c, info) => recon.push(info) })],
+    });
+    await session.run("go");
+    expect(recon).toHaveLength(1);
+    expect(recon[0]!.cacheReadTokens).toBe(900);
+    expect(recon[0]!.inputTokens).toBe(100);
+    expect(recon[0]!.cacheHitRatio).toBeCloseTo(0.9);
+    expect(recon[0]!.changeReason).toBe("first_turn");
+    fake.teardown();
+  });
+
+  it("无 onCacheReconcile → onLlmEnd 早退、run 正常收尾（不抛）", async () => {
+    const fake = createFakeModel([
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [trivialTool("read")],
+      hooks: [prefixShape()],
+    });
+    const summary = await session.run("go");
+    expect(summary.reason).toBe("done");
+    fake.teardown();
+  });
+
+  it("真装配管线：两 turn 同 tools → turn-2 stable（active 引用稳定 → hash 稳定）", async () => {
+    const reasons: PrefixChangeReason[] = [];
+    const probe: Hook = {
+      name: "probe",
+      onLlmEnd(_input, ctx: HookContext) {
+        const d = getPrefixShapeState(ctx);
+        if (d) reasons.push(d.changeReason);
+      },
+    };
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "read", arguments: {} }], stopReason: "toolUse" },
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [trivialTool("read")],
+      hooks: [prefixShape(), probe],
+    });
+    await session.run("go");
+    expect(reasons).toEqual(["first_turn", "stable"]);
+    fake.teardown();
+  });
+
+  it("多-turn reconcile：changeReason 随 turn 推进而变（证 onLlmEnd 读的是当前 turn 诊断）", async () => {
+    const recon: CacheReconcileInfo[] = [];
+    // turn-2 砍掉一个 tool（active listing 变）→ prefixShape 判 tool_schema_changed
+    const shrink: Hook = {
+      name: "shrink",
+      transformToolsBeforeLlm(tools, ctx: HookContext) {
+        return ctx.turnIdx === 0 ? undefined : tools.slice(0, 1);
+      },
+    };
+    const fake = createFakeModel([
+      { content: [{ type: "toolCall", name: "read", arguments: {} }], stopReason: "toolUse" },
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [trivialTool("read"), trivialTool("bash")],
+      hooks: [shrink, prefixShape({ onCacheReconcile: (_c, i) => recon.push(i) })], // shrink 先于 prefixShape
+    });
+    await session.run("go");
+    expect(recon.map((r) => r.changeReason)).toEqual(["first_turn", "tool_schema_changed"]);
+    fake.teardown();
+  });
+
+  it("usage 缺失（denom 0）→ cacheHitRatio 为 0 而非 NaN", async () => {
+    const recon: CacheReconcileInfo[] = [];
+    const fake = createFakeModel([
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" }, // 默认 zeroUsage
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [trivialTool("read")],
+      hooks: [prefixShape({ onCacheReconcile: (_c, i) => recon.push(i) })],
+    });
+    await session.run("go");
+    expect(recon).toHaveLength(1);
+    expect(recon[0]!.cacheHitRatio).toBe(0);
+    expect(recon[0]!.inputTokens).toBe(0);
+    expect(recon[0]!.cacheReadTokens).toBe(0);
+    fake.teardown();
+  });
+
+  it("fail-open：providerOptions 回调抛错（transformToolsBeforeLlm 内）→ run 仍正常收尾", async () => {
+    const fake = createFakeModel([
+      { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [trivialTool("read")],
+      hooks: [
+        prefixShape({
+          providerOptions: () => {
+            throw new Error("boom");
+          },
+        }),
+      ],
+    });
+    const summary = await session.run("go");
+    expect(summary.reason).toBe("done");
+    fake.teardown();
+  });
+
+  it("fail-open：onCacheReconcile 回调抛错（onLlmEnd 内）→ run 仍正常收尾", async () => {
+    const fake = createFakeModel([
+      {
+        content: [{ type: "text", text: "done" }],
+        stopReason: "stop",
+        usage: { input: 100, output: 1, cached: 900 },
+      },
+    ]);
+    const session = new AgentSession({
+      model: fake,
+      tools: [trivialTool("read")],
+      hooks: [
+        prefixShape({
+          onCacheReconcile: () => {
+            throw new Error("boom");
+          },
+        }),
+      ],
+    });
+    const summary = await session.run("go");
+    expect(summary.reason).toBe("done");
+    fake.teardown();
+  });
+});

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -142,3 +142,19 @@ export type { ToolSearchOptions } from "./tool-search.js";
 
 export { skills } from "./skills.js";
 export type { SkillSpec, SkillsOptions } from "./skills.js";
+
+export {
+  prefixShape,
+  getPrefixShapeState,
+  computeDurablePrefix,
+  classifyPrefixChange,
+  stableHash,
+} from "./prefix-shape.js";
+export type {
+  PrefixShapeOptions,
+  PrefixShapeDiagnostic,
+  PrefixChangeReason,
+  DurablePrefixComponents,
+  DurablePrefixInput,
+  CacheReconcileInfo,
+} from "./prefix-shape.js";

--- a/packages/plugins/src/prefix-shape.ts
+++ b/packages/plugins/src/prefix-shape.ts
@@ -1,0 +1,259 @@
+/**
+ * prefix-shape —— prompt-cache 前缀诊断（#106 后续：给「为什么 cache 这一 turn 可能 miss」装上实时归因）。
+ *
+ * provider 在 durable prefix（model/provider 标识 + system + tools schema）边界做 KV-cache：前缀逐字节
+ * 不变才可能命中。本插件每次 LLM call 前 canonicalize 出这段 durable prefix、算稳定 hash、与上一 turn 比，
+ * 变了就分类原因（model / system / tool_schema / provider_options）并经 `ctx.log` 暴露；可选在 `onLlmEnd`
+ * 用真实 `usage.cacheRead` 做「预测 vs 实测」对账，把诊断从「猜」变成「证伪」。
+ *
+ * 零内核改动、纯观测：`transformToolsBeforeLlm` 里 fail-open passthrough（返回 void 不改写 tools），
+ * `onLlmEnd` 只读 usage。移植自 maka `request-shape.ts`，砍到 durable-prefix-only（不做 history projection /
+ * tool-source-economy / zod 转换）。详见 docs/05-plugins.md §5.x。
+ *
+ * 两条已知局限（与 autoCompaction 同档，文档化、不修——修就破坏「零内核改动」）：
+ *  1. system 指纹取 `ctx.config.systemPrompt` = 构造期 **pre-pipe base**。若挂了
+ *     `transformSystemPromptBeforeLlm` 每 turn 改写 system，本插件看不到那个增量、会漏报
+ *     `system_prompt_changed`（当前无 first-party hook 这么干）。
+ *  2. provider options 内核不经 hook 暴露；`provider_options_changed` 仅在调用方主动通过
+ *     `opts.providerOptions` 喂指纹时才有意义。默认这一维是盲区。
+ *
+ * ⚠️ prefix 稳定只是 cache 命中的**必要非充分**条件：history 增长本身会让超出公共前缀的后缀 miss（那是
+ * cost/trim 那条线的事）。`reason === "stable"` 不等于该 100% 命中；`onCacheReconcile` 给的是关联信号、
+ * 非因果证明。
+ */
+
+import { createHash } from "node:crypto";
+import type { Hook, HookContext, Tool } from "@harness-pi/core";
+
+/* ── 在 core 的 HookStateRegistry 上 augment 本 plugin 用到的 key ── */
+declare module "@harness-pi/core" {
+  interface HookStateRegistry {
+    "prefix-shape.last": PrefixShapeDiagnostic;
+  }
+}
+
+export type PrefixChangeReason =
+  | "first_turn"
+  | "model_or_provider_changed"
+  | "system_prompt_changed"
+  | "tool_schema_changed"
+  | "provider_options_changed"
+  | "stable";
+
+export interface DurablePrefixComponents {
+  modelProviderHash: string;
+  systemPromptHash: string;
+  toolSchemaHash: string;
+  /** 仅当 `opts.providerOptions` 提供时为非空对象 hash；否则恒为空对象 hash（这一维不参与分类）。 */
+  providerOptionsHash: string;
+}
+
+export interface PrefixShapeDiagnostic {
+  /** 整段 durable prefix 的稳定 hash（`sha256:<hex>`）。 */
+  prefixHash: string;
+  changeReason: PrefixChangeReason;
+  components: DurablePrefixComponents;
+  turnIdx: number;
+  /** 本 turn 真正上线（active）的工具数，便于人读「tools 12→13」。 */
+  toolCount: number;
+}
+
+export interface CacheReconcileInfo {
+  changeReason: PrefixChangeReason;
+  cacheReadTokens: number;
+  inputTokens: number;
+  /**
+   * `cacheRead / (input + cacheRead)`；0 表示全 miss。假设 `input` 不含已缓存 token（Anthropic /
+   * OpenAI-completions 系约定）；若某 provider 把 `input` 报成「含缓存的总 prompt token」，分母会
+   * 重复计数、该比值偏低——故这是同 provider 内的趋势信号，不是跨 provider 可比的硬指标。
+   */
+  cacheHitRatio: number;
+}
+
+export interface PrefixShapeOptions {
+  /**
+   * provider options 指纹源（默认不参与：多数 provider options 每 turn 稳定，且内核不经 hook 暴露）。
+   * 给了就纳入 hash —— 调用方知道自己每 turn 在改 temperature / thinking budget 时才需要。
+   */
+  providerOptions?: (ctx: HookContext) => Record<string, unknown> | undefined;
+  /** 每次 prefix 变化（`changeReason` 既非 `"stable"` 也非 `"first_turn"`）时回调，典型：emit metric。 */
+  onPrefixChange?: (ctx: HookContext, diag: PrefixShapeDiagnostic) => void;
+  /** `onLlmEnd` 对账：把「本 turn 预测的 changeReason」与「真实 usage.cacheRead」配对回调（默认不挂）。 */
+  onCacheReconcile?: (ctx: HookContext, info: CacheReconcileInfo) => void;
+  /** `changeReason` 非 stable/first_turn 时自动 `ctx.log.info` 一行（默认 true）。 */
+  log?: boolean;
+}
+
+// `as const` 保留字面类型，让 TypedStateMap 走 typed overload 而非 string fallback。
+const KEY = "prefix-shape.last" as const;
+
+export function prefixShape(opts: PrefixShapeOptions = {}): Hook {
+  return {
+    name: "prefix-shape",
+    internal: true,
+    timeout: 50,
+
+    // 观测式 passthrough：入参 tools 即「本 turn 真正上线的 active 子集」（已过 deferred-tools 过滤，
+    // 若有）。返回 void 不改写 —— 纯观测。注册顺序应在 deferred-tools 之后才能看到过滤后子集；
+    // 即便反了，结论也只是「按全集算 hash」而非崩溃（退化不致命）。
+    transformToolsBeforeLlm(tools, ctx) {
+      const components = computeDurablePrefix({
+        model: ctx.config.model,
+        systemPrompt: ctx.config.systemPrompt,
+        activeTools: tools,
+        providerOptions: opts.providerOptions?.(ctx),
+      });
+      const prior = ctx.state.get(KEY);
+      const changeReason = classifyPrefixChange(components, prior?.components);
+      const diag: PrefixShapeDiagnostic = {
+        prefixHash: stableHash(components),
+        changeReason,
+        components,
+        turnIdx: ctx.turnIdx,
+        toolCount: tools.length,
+      };
+      ctx.state.set(KEY, diag);
+
+      if (changeReason !== "stable" && changeReason !== "first_turn") {
+        if (opts.log !== false) {
+          ctx.log.info("prefix changed (cache prefix likely cold this turn)", {
+            hook: "prefix-shape",
+            reason: changeReason,
+            turnIdx: ctx.turnIdx,
+            toolCount: tools.length,
+          });
+        }
+        opts.onPrefixChange?.(ctx, diag);
+      }
+      // 返回 void：不改写 tools listing
+    },
+
+    onLlmEnd(input, ctx) {
+      if (!opts.onCacheReconcile) return;
+      const diag = ctx.state.get(KEY);
+      if (!diag) return;
+      const usage = input.msg.usage;
+      const cacheReadTokens = usage?.cacheRead ?? 0;
+      const inputTokens = usage?.input ?? 0;
+      const denom = inputTokens + cacheReadTokens;
+      opts.onCacheReconcile(ctx, {
+        changeReason: diag.changeReason,
+        cacheReadTokens,
+        inputTokens,
+        cacheHitRatio: denom > 0 ? cacheReadTokens / denom : 0,
+      });
+    },
+  };
+}
+
+/** 读取本 session 最近一次的 prefix-shape 诊断（跨 turn 留存在 `ctx.state`）。 */
+export function getPrefixShapeState(
+  ctx: HookContext,
+): PrefixShapeDiagnostic | undefined {
+  return ctx.state.get(KEY);
+}
+
+/* ────────────── 纯函数（移植自 maka request-shape.ts，砍到 durable-prefix-only）────────────── */
+
+export interface DurablePrefixInput {
+  model: { id: string; provider: string };
+  systemPrompt: string;
+  activeTools: ReadonlyArray<Tool>;
+  providerOptions?: Record<string, unknown> | undefined;
+}
+
+export function computeDurablePrefix(
+  input: DurablePrefixInput,
+): DurablePrefixComponents {
+  return {
+    modelProviderHash: stableHash({
+      provider: input.model.provider,
+      modelId: input.model.id,
+    }),
+    systemPromptHash: stableHash(input.systemPrompt ?? ""),
+    // 保留 active 子集的**线上顺序**（canonicalize 不排顶层数组）—— 工具重排会真正破坏 cache 前缀，
+    // 应被如实标成 tool_schema_changed，不能 pre-sort 掩盖。schema 内部 required/enum 才排序。
+    toolSchemaHash: stableHash(input.activeTools.map(toolShapeForDiagnostics)),
+    providerOptionsHash: stableHash(input.providerOptions ?? {}),
+  };
+}
+
+export function classifyPrefixChange(
+  current: DurablePrefixComponents,
+  prior: DurablePrefixComponents | undefined,
+): PrefixChangeReason {
+  if (!prior) return "first_turn";
+  if (current.modelProviderHash !== prior.modelProviderHash)
+    return "model_or_provider_changed";
+  if (current.systemPromptHash !== prior.systemPromptHash)
+    return "system_prompt_changed";
+  if (current.toolSchemaHash !== prior.toolSchemaHash)
+    return "tool_schema_changed";
+  if (current.providerOptionsHash !== prior.providerOptionsHash)
+    return "provider_options_changed";
+  return "stable";
+}
+
+export function stableHash(value: unknown): string {
+  return `sha256:${createHash("sha256").update(stableStringify(value)).digest("hex")}`;
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+/**
+ * harness/pi-ai 的 `Tool.parameters` 已是纯 JSON-schema 对象（TypeBox `TSchema`：keys = type/required/
+ * properties，零 symbol key、`JSON.stringify` 确定性）——直接 canonicalize，无需 maka 的 zod `toJSONSchema` /
+ * strip 包装层。
+ */
+function toolShapeForDiagnostics(tool: Tool): unknown {
+  return {
+    name: tool.name,
+    description: tool.description,
+    parameters: tool.parameters,
+  };
+}
+
+function canonicalize(value: unknown, parentKey?: string): unknown {
+  if (value === null) return null;
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  if (typeof value === "bigint") return value.toString();
+  if (
+    typeof value === "undefined" ||
+    typeof value === "function" ||
+    typeof value === "symbol"
+  ) {
+    return `[${typeof value}]`;
+  }
+  if (Array.isArray(value)) {
+    const items = value.map((item) => canonicalize(item));
+    return shouldSortArray(parentKey)
+      ? items
+          .slice()
+          .sort((a, b) => stableStringify(a).localeCompare(stableStringify(b)))
+      : items;
+  }
+  if (value instanceof Date) return value.toISOString();
+  if (!isObjectLike(value)) return String(value);
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(value).sort()) {
+    out[key] = canonicalize(value[key], key);
+  }
+  return out;
+}
+
+/** 只排 JSON-schema 里语义无序的 `required` / `enum` 两个数组；其余数组顺序敏感（含 tools 线上顺序）。 */
+function shouldSortArray(parentKey: string | undefined): boolean {
+  return parentKey === "required" || parentKey === "enum";
+}
+
+function isObjectLike(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}


### PR DESCRIPTION
## 这是什么

`#106` 的后续：给 prompt-cache 失效装上**实时归因**。provider 在 durable prefix（model/provider 标识 + system + tools schema）边界做 KV-cache，前缀逐字节不变才可能命中。本插件每 turn canonicalize 出这段 durable prefix、算稳定 hash、与上一 turn 比，变了就分类原因（`model_or_provider_changed` / `system_prompt_changed` / `tool_schema_changed` / `provider_options_changed`）经 `ctx.log` 暴露；可选在 `onLlmEnd` 用真实 `usage.cacheRead` 做「预测 vs 实测」对账。

把「这一 turn 为什么没命中 cache」从**事后 A/B** 提前到**每 turn 可见**（背景见 #106：`trimHistory` 每轮改写旧历史破坏前缀、命中 93%→74%）。

## 设计要点

- **零内核改动、纯观测**：`transformToolsBeforeLlm` fail-open passthrough（返回 void 不改写 tools）+ `onLlmEnd` 只读 usage。对齐 `cost-tracker`/`deferred-tools` 既有惯例（`HookStateRegistry` augment、`internal:true`、metric 走 opt-in 回调不占 `CoreMetricKind`）。
- **移植自 maka `request-shape.ts`，砍到 durable-prefix-only**：不抄 history-projection / tool-source-economy / zod 转换——pi-ai 的 `tool.parameters` 已是纯 JSON-schema `TSchema`，直接 canonicalize（约 255 行 vs maka ~360）。
- **tools 线上顺序计入 hash**（重排=真破前缀，不 pre-sort 掩盖）；schema 内 `required`/`enum` 才排序。
- **两条已知盲区文档化、不修**（修就破坏零内核改动，与 `auto-compaction` 同档）：① system 指纹是构造期 pre-pipe base；② provider options 默认不参与分类（内核不经 hook 暴露）。

## 这是 #106 三个后续里唯一该建的

附带在 spike 阶段对两个姊妹方案做了对抗核验，结论 **drop**：
- **gatedTrimHistory**（cache-aware trim）→ drop：真实增量仅 ~30 行单调门控，`microcompact` 已是阈值门控；无真模型 A/B 背书 = 徒增第 8 个 cache-naive 插件。
- **cacheRetention:long**（dashscope）→ drop：被本仓源码自证伪——DashScope 是 implicit cache、不认显式 `prompt_cache_retention`，写死 long 大概率 no-op/有害；真杠杆「长跑别用 trim-history」已由 #106 落地。

## 验证

- 21 个测试：纯函数（hash 键序无关/数组顺序敏感、`required`/`enum` 乱序同 hash、`classifyPrefixChange` 各分支+优先级、`shouldSortArray` 边界、**TypeBox 无 symbol-key 回归哨兵**）+ 插件行为（first_turn/stable 不 log、tool_schema_changed 触发 log+回调、log:false、providerOptions opt-in、state 跨 context 隔离）+ 真管线（`AgentSession`+`createFakeModel`：fail-open 抛错仍收尾、denom=0 防 NaN、多-turn reconcile 证读当前 turn 诊断、usage 注入对账）。
- 本地全量 `pnpm -r build && typecheck && test` 全绿（408 测试）。

## 两阶段对抗核验

- **spec 级**（实现前）：verdict `ready`（"异常扎实，非拼凑"）；修正了 `inputSchema`→`t.parameters`、TypeBox 输出确定性可省 zod 包装。
- **实现级**（本 PR 代码）：正确性/风格两视角 `ship`（全 nit，实测核对 hash 确定性/classify 优先级/字段名/fail-open）；测试可证伪性视角补齐 1 blocking（fail-open 零覆盖）+ 5 should-fix（state 隔离、denom=0、多-turn reconcile、空 tools、shouldSortArray 边界）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)