### PR TITLE
chore: gitignore .firecrawl/ 研究产物目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 
 # 研究产物(放 ~/Dev/coding/reports 或本地;不入源码库,避免 git add -A 误扫)
 reports/
+.firecrawl/


### PR DESCRIPTION
## 这是什么

把 `.firecrawl/`（firecrawl 抓取产物目录，含 `hf-agent-*.json` 等）加入 `.gitignore`，与已忽略的 `reports/` 同类——研究产物、不入源码库。

此前未忽略，一直挂在 `git status` 的 untracked 列表里，且有被 `git add -A` 误扫进无关 PR 的风险（已实际差点发生）。放在既有「研究产物」注释块下、紧跟 `reports/`。

## 风险

纯 `.gitignore` 单行新增，CI 应平过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)