### PR TITLE
chore: gitignore .npmrc（发布 token 文件防误提交）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ dist/
 .DS_Store
 .env
 .env.local
+# npm publish token（发布时在 repo 根临时写、用完即删；列此防 token 文件被误提交）
+.npmrc
 
 # coding-agent runtime output (session logs, persisted sessions, metrics)
 .harness-pi/


### PR DESCRIPTION
## 这是什么

把 `.npmrc` 加入 `.gitignore`。发布流程在 repo 根临时写 `.npmrc`（含 keychain `NPM_TOKEN`）再 `trap` 删——列入 gitignore 作纵深防御：即便某次 trap 没及时清（0.4.0 发布时就出现过 trap 晚于检查触发的情况），`git add -A` 也不会把含 token 的文件误提交。

放在 secrets 区（紧跟 `.env`/`.env.local`）。纯 `.gitignore` 单行新增，CI 应平过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)