### PR TITLE
docs: 根 version 0.1.0→0.4.0 对齐口径 (#86)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "harness-pi",
   "private": true,
-  "version": "0.1.0",
-  "description": "Production harness for pi-ai-based agents — kernel + plugins",
+  "version": "0.4.0",
+  "description": "Service-runtime harness for @earendil-works/pi-ai agents — minimal kernel + plugins",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
#86 收口最后一处版本漂移（根 package.json）。其余四处(README/roadmap/CLAUDE/GitHub description)+ 上游包名 + 计数此前已对齐 0.4.0。Closes #86