### PR TITLE
fix(plugins): UTF-8 码点边界截断 + sub-agent try/finally (#98 核心)

### DIFF
--- a/packages/plugins/src/__tests__/post-compact-file-reread.test.ts
+++ b/packages/plugins/src/__tests__/post-compact-file-reread.test.ts
@@ -63,6 +63,24 @@ describe("postCompactFileReread", () => {
     expect(providerCalls).toBe(0); // 没压缩 → 根本不解析
   });
 
+  it("UTF-8 截断落在码点边界、不产生 U+FFFD（#98 回归）", async () => {
+    // maxBytes=5，中文每字 3 bytes："日本語…" → 码点边界截断保留 "日"(3 bytes)，
+    // 不切到 "本" 中间（原字节级 Buffer.subarray 会切第 2 字、末尾产生替换字符 U+FFFD）。
+    const hook = postCompactFileReread({
+      maxBytes: 5,
+      fileContentProvider: async () => "日本語テスト",
+    });
+    const ctx = fakeCtx([toolCallMsg("read", { path: "/a.ts" })], { pending: 0 });
+    const out = await hook.onTurnStart!({ turnIdx: 1 }, ctx);
+
+    expect(out).toBeDefined();
+    const text = out!.additionalContext!;
+    expect(text).not.toContain("�"); // 无替换字符
+    expect(text).toContain("日"); // 第 1 字保留（3 ≤ 5）
+    expect(text).not.toContain("本"); // 第 2 字累计 6 > 5，码点边界截掉
+    expect(text).toContain("[truncated to 5 bytes]");
+  });
+
   it("resolves referenced paths and injects their current content after compaction", async () => {
     const fs: Record<string, string> = { "/a.ts": "AAA", "/b.ts": "BBB" };
     const hook = postCompactFileReread({

--- a/packages/plugins/src/controllers/sub-agent-tool.ts
+++ b/packages/plugins/src/controllers/sub-agent-tool.ts
@@ -115,27 +115,44 @@ async function spawnSubAgent(
   // O5：spawn 前 fire onSubagentStart（子在 depth+1）。
   await ctx.fireSubagentStart({ agentId: sub.id, task, depth: depth + 1 });
   // 父 signal 透传 → sub-agent 可被父的 abort 协作式取消。
-  // start↔end 配对依赖 `sub.run()` **永不 throw**：内核 turn loop 把所有终态（done/aborted/error/
-  // max_turns）转成 RunSummary 返回（仅 re-entrancy guard 会 throw，而这里每次造全新 sub 跑一次、不可能命中）。
-  // 若将来 run() 改成某些路径 throw，下面的 fireSubagentEnd 会被跳过、留下没配对 end 的 start——届时需补 try/finally。
-  const summary = await sub.run(task, { signal });
-  // opt-in 续聊：把跑完首轮的子 session 留住（默认不传 → 跑完即弃）。
-  onSpawn?.(sub);
-  const result = subAgentResult(sub, summary);
-  // O5：跑完后 fire onSubagentEnd（带终态）。summaryText 复用回灌父模型的同一份文本；无文本则省略该字段
-  // （对齐 OnSubagentEndInput.summaryText「无文本输出则缺省」的契约）。注意 error 终态下 lastMessage 语义
-  // 同 RunSummary.lastMessage——可能是上一成功 turn 的陈旧文本，消费者应配合 reason 判读。
-  const summaryText = messageText(summary.lastMessage);
-  await ctx.fireSubagentEnd({
-    agentId: sub.id,
-    task,
-    depth: depth + 1,
-    reason: summary.reason,
-    turns: summary.turns,
-    usage: summary.usage,
-    ...(summaryText ? { summaryText } : {}),
-  });
-  return result;
+  // start↔end 配对：`sub.run()` 当前**永不 throw**（内核 turn loop 把所有终态 done/aborted/error/
+  // max_turns 转成 RunSummary 返回；仅 re-entrancy guard throw，而这里每次造全新 sub 跑一次、不可能命中）。
+  // 下面用 try/finally 做**防御性兜底**（#98）：万一将来 run() 某路径 throw，finally 补发 error end
+  // 保证 start↔end 配对、不留 orphan start。
+  let ended = false;
+  try {
+    const summary = await sub.run(task, { signal });
+    // opt-in 续聊：把跑完首轮的子 session 留住（默认不传 → 跑完即弃）。
+    onSpawn?.(sub);
+    const result = subAgentResult(sub, summary);
+    // O5：跑完后 fire onSubagentEnd（带终态）。summaryText 复用回灌父模型的同一份文本；无文本则省略该字段
+    // （对齐 OnSubagentEndInput.summaryText「无文本输出则缺省」的契约）。注意 error 终态下 lastMessage 语义
+    // 同 RunSummary.lastMessage——可能是上一成功 turn 的陈旧文本，消费者应配合 reason 判读。
+    const summaryText = messageText(summary.lastMessage);
+    await ctx.fireSubagentEnd({
+      agentId: sub.id,
+      task,
+      depth: depth + 1,
+      reason: summary.reason,
+      turns: summary.turns,
+      usage: summary.usage,
+      ...(summaryText ? { summaryText } : {}),
+    });
+    ended = true;
+    return result;
+  } finally {
+    // run() 抛错（当前不可达）→ 补发 error end 保证配对；zero usage 占位（无真实终态数据）。
+    if (!ended) {
+      await ctx.fireSubagentEnd({
+        agentId: sub.id,
+        task,
+        depth: depth + 1,
+        reason: "error",
+        turns: 0,
+        usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+      });
+    }
+  }
 }
 
 export function subAgentTool(opts: SubAgentToolOptions): HarnessTool {

--- a/packages/plugins/src/post-compact-file-reread.ts
+++ b/packages/plugins/src/post-compact-file-reread.ts
@@ -119,9 +119,18 @@ export function postCompactFileReread(
         let body = content;
         let truncated = "";
         if (Buffer.byteLength(body, "utf8") > maxBytes) {
-          // 按字节上界截断到 maxBytes。注意：在多字节 UTF-8 字符中间切会让末尾出现一个替换字符
-          // （U+FFFD）——注入内容是给模型看的 advisory，可接受；故不保证截断点落在码点边界。
-          body = Buffer.from(body, "utf8").subarray(0, maxBytes).toString("utf8");
+          // 按 maxBytes 字节上界截断，但只在**码点边界**处切：for...of 按 Unicode 码点迭代
+          // （不拆 surrogate pair），逐码点累加字节直到再加一个就超界——不切断多字节 UTF-8 字符、
+          // 不产生尾随 U+FFFD（修 #98：原 Buffer.subarray 字节级截断会在多字节中间切）。
+          let kept = "";
+          let bytes = 0;
+          for (const ch of body) {
+            const n = Buffer.byteLength(ch, "utf8");
+            if (bytes + n > maxBytes) break;
+            bytes += n;
+            kept += ch;
+          }
+          body = kept;
           truncated = `\n[truncated to ${maxBytes} bytes]`;
         }
         blocks.push(`<file path="${p}">\n${body}${truncated}\n</file>`);


### PR DESCRIPTION
#98 两项实在修复：① post-compact UTF-8 字节截断→码点边界(修 U+FFFD)+回归测试；② sub-agent 防御性 try/finally(start↔end 配对兜底)。剩 5 项纯测试覆盖增强/fixture-typed 作 nonblocking follow-up。Refs #98