### PR TITLE
fix(coding-agent): /goal flag 解析卫生 + classifyGoalOutcome 可读性 (#105 实在项)

### DIFF
--- a/apps/coding-agent/src/tui/__tests__/goal.test.ts
+++ b/apps/coding-agent/src/tui/__tests__/goal.test.ts
@@ -115,13 +115,48 @@ describe("parseGoalCommand", () => {
     });
   });
 
-  it("uses the first --success flag and leaves later repeated flags as goal text", () => {
+  it("consumes all repeated --success flags (last wins, no literal leaks to goal)", () => {
+    // 全局 replace：重复 flag 全部消费、last-wins；旧非全局只去首个、残留 `--success second pass` 发给 LLM。
     expect(parseGoalCommand("ship --success first pass --success second pass")).toEqual({
-      goal: "ship --success second pass",
+      goal: "ship",
       maxTurns: 5,
       budgetTokens: undefined,
-      successHint: "first pass",
+      successHint: "second pass",
     });
+  });
+
+  it("consumes all repeated --budget flags (last wins, no literal leaks to goal)", () => {
+    expect(parseGoalCommand("optimize --budget 100 --budget 200")).toEqual({
+      goal: "optimize",
+      maxTurns: 5,
+      budgetTokens: 200,
+      successHint: undefined,
+    });
+  });
+
+  it("does not partial-match a flag-prefixed word (word boundary)", () => {
+    // `--max-turns-doc` 不是 `--max-turns`：词边界挡住后续 `-`，整词原样留在 goal、maxTurns 取默认。
+    expect(parseGoalCommand("write the --max-turns-doc section")).toEqual({
+      goal: "write the --max-turns-doc section",
+      maxTurns: 5,
+      budgetTokens: undefined,
+      successHint: undefined,
+    });
+  });
+
+  it("treats --budget 0 as no limit (v>0 guard boundary)", () => {
+    expect(parseGoalCommand("tidy up --budget 0")).toEqual({
+      goal: "tidy up",
+      maxTurns: 5,
+      budgetTokens: undefined,
+      successHint: undefined,
+    });
+  });
+
+  it('treats empty --success "" as no hint (not present-but-empty)', () => {
+    const r = parseGoalCommand('ship it --success ""');
+    expect(r?.successHint).toBeUndefined();
+    expect(r?.goal).toBe("ship it");
   });
 });
 
@@ -413,6 +448,17 @@ describe("classifyGoalOutcome", () => {
           abortReason: "token budget exhausted: 120/100",
         } as any,
         "GOAL_STATUS: REACHED",
+      ),
+    ).toMatchObject({ verdict: "reached", aborted: false, budgetExhausted: false });
+  });
+
+  it("treats REACHED as success even when a user abort lands on the same turn", () => {
+    // Esc 正好撞上 REACHED：success 优先于中断修饰符 → aborted=false（钉死 aborted=userAborted&&!success 简化）。
+    expect(
+      classifyGoalOutcome(
+        { turns: 2, continuations: 1, reason: "aborted" } as any,
+        "GOAL_STATUS: REACHED",
+        true,
       ),
     ).toMatchObject({ verdict: "reached", aborted: false, budgetExhausted: false });
   });

--- a/apps/coding-agent/src/tui/__tests__/goal.test.ts
+++ b/apps/coding-agent/src/tui/__tests__/goal.test.ts
@@ -134,6 +134,23 @@ describe("parseGoalCommand", () => {
     });
   });
 
+  it("repeated --budget with later 0 clears the limit (last-wins, codex P2)", () => {
+    // last-wins + `--budget 0`=无限：后者必须解除前者的 100，不能残留旧上限。
+    expect(parseGoalCommand("optimize --budget 100 --budget 0")).toEqual({
+      goal: "optimize",
+      maxTurns: 5,
+      budgetTokens: undefined,
+      successHint: undefined,
+    });
+  });
+
+  it('repeated --success with later "" clears the hint (last-wins, codex P3)', () => {
+    // last-wins + 空=无 hint：空的后者必须解除前者，不能把旧 success criteria 织进 prompt。
+    const r = parseGoalCommand('ship --success tests pass --success ""');
+    expect(r?.successHint).toBeUndefined();
+    expect(r?.goal).toBe("ship");
+  });
+
   it("does not partial-match a flag-prefixed word (word boundary)", () => {
     // `--max-turns-doc` 不是 `--max-turns`：词边界挡住后续 `-`，整词原样留在 goal、maxTurns 取默认。
     expect(parseGoalCommand("write the --max-turns-doc section")).toEqual({

--- a/apps/coding-agent/src/tui/goal.ts
+++ b/apps/coding-agent/src/tui/goal.ts
@@ -44,14 +44,17 @@ export function parseGoalCommand(rest: string): GoalOptions | null {
   let budgetTokens: number | undefined = undefined;
   let successHint: string | undefined = undefined;
 
+  // 全局 replace + 词边界 `(?![-\w])`：① 重复 flag 全部消费（非全局只去首个、残留字面量会发给 LLM）；
+  // ② `--max-turns-doc` / `--budgetary` 这类把 flag 当子串的词不被部分吞掉（边界挡住后续 `-`/字母）。
+
   // --max-turns <N>；非法值忽略并清掉完整 token，避免污染 goal 文本（如 3.5 残留 .5）。
-  text = text.replace(/--max-turns(?:\s+((?!--)\S+))?/i, (_, n: string | undefined) => {
+  text = text.replace(/--max-turns(?![-\w])(?:\s+((?!--)\S+))?/gi, (_, n: string | undefined) => {
     if (n !== undefined && /^[+-]?\d+$/.test(n)) maxTurns = Math.max(1, parseInt(n, 10));
     return "";
   });
 
   // --budget <N>；非法值也消费掉完整 token，避免把 flag 原样发给 LLM。
-  text = text.replace(/--budget(?:\s+((?!--)\S+))?/i, (_, n: string | undefined) => {
+  text = text.replace(/--budget(?![-\w])(?:\s+((?!--)\S+))?/gi, (_, n: string | undefined) => {
     if (n !== undefined && /^[+-]?\d+$/.test(n)) {
       const v = parseInt(n, 10);
       if (v > 0) budgetTokens = v;
@@ -61,9 +64,12 @@ export function parseGoalCommand(rest: string): GoalOptions | null {
 
   // --success "quoted" or --success until next flag / stray -- / end.
   text = text.replace(
-    /--success\s+(?:"([^"]+)"|(.+?))(?=\s+--|$)/i,
+    /--success(?![-\w])\s+(?:"([^"]*)"|(.+?))(?=\s+--|$)/gi,
     (_match: string, quoted: string | undefined, unquoted: string | undefined) => {
-      successHint = (quoted ?? unquoted ?? "").trim();
+      const hint = (quoted ?? unquoted ?? "").trim();
+      // 空 hint（`--success ""` 或纯空白）语义统一为「无 hint」——与 buildGoalPrompt 的
+      // `if(opts.successHint)` 一致，不留 present-but-empty 的歧义态。
+      if (hint.length > 0) successHint = hint;
       return "";
     },
   );
@@ -231,7 +237,8 @@ export function classifyGoalOutcome(
   const rawAbortReason = summary?.abortReason?.trim();
   const runAborted = summary?.reason === "aborted" || userAborted;
   const success = verdict === "reached";
-  const aborted = runAborted && userAborted && !success;
+  // 吸收律：runAborted = (reason==="aborted") || userAborted，故 `runAborted && userAborted` ≡ `userAborted`。
+  const aborted = userAborted && !success;
   const guardAborted = runAborted && !userAborted && !success;
   const budgetExhausted =
     guardAborted && rawAbortReason !== undefined && /token budget exhausted/i.test(rawAbortReason);

--- a/apps/coding-agent/src/tui/goal.ts
+++ b/apps/coding-agent/src/tui/goal.ts
@@ -55,9 +55,11 @@ export function parseGoalCommand(rest: string): GoalOptions | null {
 
   // --budget <N>；非法值也消费掉完整 token，避免把 flag 原样发给 LLM。
   text = text.replace(/--budget(?![-\w])(?:\s+((?!--)\S+))?/gi, (_, n: string | undefined) => {
+    // last-wins：每个**合法数值**出现都覆盖最终值，≤0 视为「无限」→ 清空（修 codex P2：
+    // `--budget 100 --budget 0` 的后者应解除上限，旧 `if(v>0)` 会残留前值 100）。非法值不动既有值。
     if (n !== undefined && /^[+-]?\d+$/.test(n)) {
       const v = parseInt(n, 10);
-      if (v > 0) budgetTokens = v;
+      budgetTokens = v > 0 ? v : undefined;
     }
     return "";
   });
@@ -67,9 +69,10 @@ export function parseGoalCommand(rest: string): GoalOptions | null {
     /--success(?![-\w])\s+(?:"([^"]*)"|(.+?))(?=\s+--|$)/gi,
     (_match: string, quoted: string | undefined, unquoted: string | undefined) => {
       const hint = (quoted ?? unquoted ?? "").trim();
-      // 空 hint（`--success ""` 或纯空白）语义统一为「无 hint」——与 buildGoalPrompt 的
-      // `if(opts.successHint)` 一致，不留 present-but-empty 的歧义态。
-      if (hint.length > 0) successHint = hint;
+      // last-wins：每个 --success 出现都覆盖最终值。空 hint（`--success ""` 或纯空白）语义统一为
+      // 「无 hint」→ 清空（修 codex P3：`--success a --success ""` 的空后者应解除前 hint，而非残留 a）。
+      // 与 buildGoalPrompt 的 `if(opts.successHint)` 一致，不留 present-but-empty 的歧义态。
+      successHint = hint.length > 0 ? hint : undefined;
       return "";
     },
   );


### PR DESCRIPTION
#105 中与 #111(/goal v2 重设计)无关、survives-redesign 的 parser/classifier 子集：① flag 正则词边界(`--max-turns-doc` 不再漏 `-doc`)；② 全局 replace 全消费重复 flag last-wins(不再泄字面量给 LLM)；③ 空 `--success ""` 语义统一为无 hint；④ classifyGoalOutcome 吸收律消恒真合取(行为不变)。+6 cheap 测试。剩 UX 口径/横幅/TURNS 校准缓到 #111(force-continue 已证伪、表现层将重做)。Refs #105