### PR TITLE
test: 补 #98 剩余覆盖缺口（provider 抛错/跨 continue/分支/typed fixture）

### DIFF
--- a/packages/core/src/__tests__/dispatcher.test.ts
+++ b/packages/core/src/__tests__/dispatcher.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, vi } from "vitest";
 import { HookDispatcher, mergeResults, defaultTimeoutFor } from "../dispatcher.js";
-import type { Hook, HookContext } from "../index.js";
+import type { Hook, HookContext, OnSubagentEndInput, Usage } from "../index.js";
 import { createTestContext } from "../testing.js";
 
 function fakeCtx(): HookContext {
@@ -407,12 +407,19 @@ describe("HookDispatcher subagent events (O5)", () => {
   });
 
   it("fireEvent('onSubagentEnd') dispatches terminal state to matched hooks", async () => {
-    const seen: any[] = [];
+    const seen: OnSubagentEndInput[] = [];
     const hooks: Hook[] = [
       { name: "probe", onSubagentEnd: (input) => { seen.push(input); } },
     ];
     const d = new HookDispatcher(hooks);
-    const usage = { input: 1, output: 2 } as any;
+    const usage: Usage = {
+      input: 1,
+      output: 2,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 3,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    };
     await d.fireEvent(
       "onSubagentEnd",
       { agentId: "sub-1", task: "do x", depth: 1, reason: "done", turns: 3, usage, summaryText: "result" },

--- a/packages/plugins/src/__tests__/post-compact-file-reread.test.ts
+++ b/packages/plugins/src/__tests__/post-compact-file-reread.test.ts
@@ -132,6 +132,25 @@ describe("postCompactFileReread", () => {
     expect(await hook.onTurnStart!({ turnIdx: 1 }, ctx)).toBeUndefined();
   });
 
+  it("recovers from a provider throw: skips the failing file, still injects siblings (#98)", async () => {
+    // provider 对某个 path 抛错不该拖垮整个 turn——记一笔、跳过该文件，兄弟文件照常注入、onTurnStart 不 reject。
+    const hook = postCompactFileReread({
+      fileContentProvider: async (p) => {
+        if (p === "/boom.ts") throw new Error("read failed");
+        return "OK_BODY";
+      },
+    });
+    const ctx = fakeCtx(
+      [toolCallMsg("read", { path: "/boom.ts" }), toolCallMsg("read", { path: "/good.ts" })],
+      { pending: 0 },
+    );
+    const out = await hook.onTurnStart!({ turnIdx: 1 }, ctx); // 不 reject
+    const text = (out as { additionalContext: string }).additionalContext;
+    expect(text).toContain("OK_BODY"); // 好文件仍注入
+    expect(text).not.toContain("/boom.ts"); // 抛错文件被跳过
+    expect(text).not.toContain("read failed");
+  });
+
   it("bounds the number of files to maxFiles (most-recently-referenced first)", async () => {
     const calls: string[] = [];
     const hook = postCompactFileReread({

--- a/packages/plugins/src/__tests__/summary-template.test.ts
+++ b/packages/plugins/src/__tests__/summary-template.test.ts
@@ -113,4 +113,16 @@ describe("defaultSummarize / summary template", () => {
     const out = renderSummaryPrompt([createUserMessage("x")]);
     expect(out).toBe(DEFAULT_SUMMARY_TEMPLATE.replace("{transcript}", "user: x"));
   });
+
+  it("renderMessage covers string content and image blocks (#98)", () => {
+    // 两条未覆盖分支：① content 为裸 string（非 block 数组）；② block 数组里的 image block → "[image]"。
+    const stringMsg = { role: "user", content: "PLAIN_STRING" } as unknown as Message;
+    const imageMsg = {
+      role: "user",
+      content: [{ type: "image", source: { kind: "base64", data: "x", mimeType: "image/png" } }],
+    } as unknown as Message;
+    const out = renderSummaryPrompt([stringMsg, imageMsg], "{transcript}");
+    expect(out).toContain("user: PLAIN_STRING");
+    expect(out).toContain("user: [image]");
+  });
 });

--- a/packages/plugins/src/__tests__/turn-end-guard.test.ts
+++ b/packages/plugins/src/__tests__/turn-end-guard.test.ts
@@ -144,6 +144,28 @@ describe("turnEndGuard", () => {
     expect(injected).toHaveLength(2);
   });
 
+  it("regression: retry budget is fresh across run → continue (no stale count, no premature give-up) (#98)", async () => {
+    // onSessionStart 每轮重置计数：run() 把 maxRetries 预算用尽放行后，continue() 必须拿到**全新**预算、
+    // 仍能强制续跑——否则上一轮的计数残留会让 continue() 立刻 give-up（continuations=0）。
+    const model = createFakeModel([]); // 自动补默认响应，无需精确计数
+    const check = vi.fn(() => ({ ok: false, message: "not yet" })); // 永远不过
+
+    const session = new AgentSession({
+      model,
+      tools: [],
+      hooks: [turnEndGuard({ check, maxRetries: 1 })],
+      maxContinuations: 10,
+    });
+
+    const s1 = await session.run("go");
+    expect(s1.continuations).toBe(1); // 强制 1 次后预算耗尽、放行停止
+
+    const s2 = await session.continue();
+    // continue 重新拿到 maxRetries 预算 → 又强制 1 次（若计数残留则提前 give-up、continuations=0）。
+    expect(s2.continuations).toBe(1);
+    expect(check).toHaveBeenCalledTimes(4); // 两轮各 2 次（强制 1 次 + 预算用尽 1 次）
+  });
+
   it("regression: without turnEndGuard, no continuation happens", async () => {
     const model = createFakeModel([
       { content: [{ type: "text", text: "done" }] },


### PR DESCRIPTION
#98 剩 4 项纯测试补充(零行为变更)：① post-compact provider 抛错恢复；② turn-end-guard retry 预算跨 run→continue 刷新回归；③ summary-template string/image 分支；④ dispatcher O5 fixture typed。#98-7(abort 墙钟)issue 自评安全、仅考虑，留 follow-up。Closes #98