### PR TITLE
docs+example: #111 Loop Engineering 定位 + maker-verifier cookbook + /goal v2 设计

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ POSTGRES_TEST_URL=postgres://postgres:test@localhost:5432/harness_pi_test pnpm -
 
 # 跑 dogfood agent / 示例
 pnpm --filter @harness-pi/coding-agent start -- --cwd . --model dashscope:qwen-plus "inspect this repo"
-pnpm --filter @harness-pi-example/01-bare-kernel start   # examples/ 下 01~04
+pnpm --filter @harness-pi-example/01-bare-kernel start   # examples/ 下 01~05
 ```
 
 dogfood agent(命令名 **`hpi`**):默认 full mode 挂全部 tools(`--read-only` 只挂只读);`--disable bash,write` 关指定 tool;session log 默认对高危 tool args 脱敏(`--log-args full|none`、`--no-log`)。详见 `README.md` Dogfood 段。

--- a/README.md
+++ b/README.md
@@ -39,6 +39,22 @@
    - Adapter：plugin 的 I/O 后端（metric sink、log sink、session store）
 5. **不强加 DB**、**不强加 frontend**、**不强加 metric kinds**。Sink 走接口 + peerDep；自定义 metric kind 用 TS module augmentation。
 
+## harness-pi 与 Loop Engineering
+
+"Loop Engineering"——把 agent 跑成**带护栏的循环**（"harness 的上一层"）——正在成为共识。Claude Code / Codex 把 `/loop`、`/goal` 这类循环做成**不透明的内置命令**；harness-pi 的定位是互补的另一端：**不卖某一条 loop 命令，卖装那台循环的可编程零件**。一条生产级 loop 需要的护栏，在 harness-pi 里几乎都已是 first-class hook / controller（且方向正是后端服务 / 批处理 agent，不是终端 UX）：
+
+| Loop 需要的护栏 | harness-pi 现成件（均已 ship + 测试覆盖） |
+|---|---|
+| 停止条件 / 验收闸门 | `turnEndGuard`（模型想停时跑 check，不过则回灌原因强制续跑） |
+| 生成者 / 验证者分离（maker-verifier） | `subAgentTool` / `routedSubAgentTool`——把验证放进**回合之外的独立 sub-agent**（不同指令、只回 PASS/FAIL），符合"别批改自己的作业" |
+| 硬保险丝（预算 / 无进展 / 熔断） | `tokenBudget` / `repeatedCallGuard` / `emptyRunGuard` / `watchdog` |
+| 上下文经济（cache 友好） | `autoCompaction` + **封存投影**（v0.5.0）+ `prefixShape` 前缀诊断 |
+| 知识固化（skills） | `skills` / `deferredTools`（O1/O2 渐进暴露） |
+| 外置状态 / 可恢复 | `SessionStore`（append-only）+ `compaction_boundary` |
+| 并行 / 扇出编排 | controllers：`parallel` / `pipeline` / `workPool` / `forkSession` |
+
+> Claude Code 给你一个不透明的 `/goal`；harness-pi 给你**装那台摇柄的零件**。用上表的现成 hook 可以从零件拼出一条 maker-verifier loop（生成者干活 → 独立 reviewer 回合外判 PASS/FAIL → 预算 / 无进展做硬保险丝），不依赖任何内置命令——可运行示例见 [`examples/05-maker-verifier-loop`](examples/05-maker-verifier-loop)。
+
 ## 当前状态
 
 `harness-pi` 现在处在 **v0.5.0** 阶段：core loop、hook dispatcher、standard plugins、controllers、first-party tools、dogfood coding agent、offline examples 和测试都已经落地，足够做 spike/review。v0.5.0 的重点是 **cache-aware 封存投影**——把 `compaction_boundary` 提为 live 投影一等公民，让上下文投影前缀字节稳定、对 provider prompt-cache 友好（配 prefix 稳定性回归门 + 真 provider cache A/B 脚本验证）。
@@ -83,7 +99,9 @@ harness-pi/
 ├── examples/
 │   ├── 01-bare-kernel/
 │   ├── 02-with-plugins/
-│   └── 03-tools/
+│   ├── 03-tools/
+│   ├── 04-batch-pipeline/
+│   └── 05-maker-verifier-loop/  # maker-verifier loop assembled from hooks
 └── README.md
 ```
 

--- a/docs/10-goal-v2-design.md
+++ b/docs/10-goal-v2-design.md
@@ -1,0 +1,122 @@
+# /goal v2 设计 —— 独立 reviewer sub-agent（替代 in-loop verifier）
+
+> 状态：**设计稿（未实现）**。对应 #111「Loop Engineering substrate」里的 `/goal` v2 重设计项。
+> 关联：#88（/goal v1）、#87（progressVerifier roadmap）、#100（移除 in-loop verifier）、#105（flag 解析卫生）、
+> `examples/05-maker-verifier-loop`（本设计的可运行 spike）。
+>
+> ⚠️ 这是「**若**重启 /goal 命令」的设计；要不要把它做成命令本身是开放决策（见 §7）。harness-pi 的定位是
+> 卖 hook 零件库、不卖命令——v2 的价值首先是**模式**（maker-verifier），已由 example 05 以零件交付；
+> 包装成 `/goal` 命令是次级的 dogfood 取舍。
+
+## 1. 问题回顾：v1 为什么没差异化
+
+`/goal` v1 = `turnEndGuard`(force-continue) + `tokenBudget`，并在 #100 **移除了 verifier**（`progressVerifier`
+在回合内打断生产性回合、误杀正常推进，是被移除的根因）。
+
+两条证据汇合（#111）：
+
+- **内部证伪**：3 次真模型 dogfood（dashscope:qwen-plus），`turnEndGuard` 的 force-continue 主路
+  （NOT_REACHED→强制续跑）**三次全 0 触发**。称职模型本来就会把 turn-loop 走到底，那条强制路只在 CI fake
+  model 下可达 → 真实世界几乎不触发。
+- **外部对账**：`/loop`+`/goal` 已是 Claude Code / Codex 的标准原语（commodity）；行业（"Loop Engineering"）
+  点破防摆烂的真价值 = **生成者/验证者分离**（"别批改自己的作业"），而那正是 #100 删掉的 verifier。
+
+**结论**：v1 差异化空，不是概念差，而是**把唯一有价值的零件（独立 verifier）拆了**，剩下纯 force-continue =
+commodity。force-continue 从来不是卖点，**verify gate / maker-verifier 分离才是**。
+
+## 2. 设计原则
+
+1. **验证在回合之外**。reviewer 是独立上下文（不同 system prompt、不能改代码），不在生产回合内打断——结构上
+   绕开 #100 移除 in-loop verifier 的根因。这是 #87 诉求的**正确形态**（#87 的意图保留、#100 的张力和解）。
+2. **强制闸，不是可选工具**。验证必须发生在 maker 想停的那一刻，由内核保证调用——而不是把工具丢给 maker 让它
+   "自觉"调。
+3. **全部用现成件**。不进内核加新概念；v2 是 `turnEndGuard` + 独立 `AgentSession`（或 `subAgentTool`）+
+   `tokenBudget`/`repeatedCallGuard` 的**组装**。
+
+## 3. 关键设计判断：闸放在 `turnEndGuard.check`，不是 `subAgentTool`
+
+#111 原文说"复用 subAgentTool / routedSubAgentTool"，这里**收紧一处常见误解**：
+
+- `subAgentTool` 是给 **maker 模型**的一个**工具**——maker **主动**决定要不要调、何时调（用于把子任务委派出去）。
+  把验证寄望于 maker 自觉调用 subAgentTool 是**可选**的：称职模型可能跳过、摆烂模型更会跳过 → 验证形同虚设。
+- **强制验证闸**必须挂在 maker **想停的那一刻**——即 `turnEndGuard.check`。check 是内核在「模型自然停止 + 还有
+  续跑预算」时**必然 fire** 的钩子；在 check 内部跑独立 reviewer，PASS 才放行、FAIL 回灌 gap 强制返工，验证
+  就是**不可绕过**的 gate。
+
+→ v2 用 **`turnEndGuard.check` 内跑独立 reviewer**。`subAgentTool` 仍可作为 maker 侧的委派工具并存，但不是验证
+闸本身。`examples/05-maker-verifier-loop` 已用这套 wiring 跑通（独立 reviewer AgentSession + turnEndGuard 闸 +
+tokenBudget/repeatedCallGuard 保险丝），是本设计的活 spike。
+
+## 4. 架构
+
+```
+┌────────────────────────── maker session ──────────────────────────┐
+│  系统提示：任务 + 工具（read/edit/write/bash...）                     │
+│  turn-loop：干活……当模型自然想停（text, no tools）                    │
+│      │                                                              │
+│      ▼  onContinuationCheck                                         │
+│  turnEndGuard.check ───────────────┐                               │
+│      │                              ▼                              │
+│      │                    ┌──── reviewer sub-agent ────┐           │
+│      │                    │  独立 AgentSession          │           │
+│      │                    │  系统提示：rubric(=--success)│           │
+│      │                    │  无 edit 工具（只读/只判）    │           │
+│      │                    │  输入：maker 的产出/ diff     │           │
+│      │                    │  输出：PASS / FAIL: <gap>     │           │
+│      │                    └──────────────┬──────────────┘           │
+│      │                                   │                          │
+│      ◀── PASS → {ok:true} 放行停止 ───────┤                          │
+│      ◀── FAIL → {ok:false, message:gap} ─┘ 回灌 gap、强制返工         │
+│                                                                    │
+│  硬保险丝（并行挂着）：tokenBudget（总预算）/ repeatedCallGuard（无进展熔断）│
+└────────────────────────────────────────────────────────────────────┘
+```
+
+终止矩阵：
+- reviewer **PASS** → `reason:"done"`，verdict=reached。
+- reviewer 连续 FAIL 到 `maxReworks` 上限 → turnEndGuard 放行停止（`reason:"done"`，但 verdict=未达成，
+  展示为「N 轮返工仍未过」）。**有界，绝不无限转。**
+- `tokenBudget` 耗尽 / `repeatedCallGuard` 熔断 → `reason:"aborted"`，abortReason 区分来源。
+
+## 5. reviewer 设计要点
+
+- **独立上下文**：全新 `AgentSession`，system prompt = rubric（来自 `--success`），**不挂 edit/write/bash**
+  （只读判定，物理上不能改代码——"别批改自己的作业"的强约束）。
+- **输入 = maker 的可验证产出**。toy spike 里是 `submit(solution)`；真实编码场景应喂 **diff / 改动文件内容 /
+  测试输出**，而不是整个对话历史（既省 token 又聚焦验收物）。这是落地时要定的 seam（见 §7）。
+- **输出协议**：要求 reviewer 回 `PASS` 或 `FAIL: <one-line gap>`。解析失败按 FAIL 兜底（保守：判不出就返工）。
+- **model 选择**：reviewer 可与 maker 同 model，也可换更便宜/更严的 model（reviewer 任务比生成简单）。作为
+  `routedSubAgentTool` 的一种 agent_type 分派也可行。
+- **成本**：每次 review = 一次 sub-agent run = 真实 token。`maxReworks` + `tokenBudget` 共同封顶，避免 review
+  本身烧穿预算。
+
+## 6. CLI 表面（复用 v1 解析 + #105 卫生）
+
+```
+/goal <task> --success <验收标准> [--max-reworks N] [--budget N]
+```
+
+- `--success` 从 v1 的「注入 prompt 的提示」升级为 **reviewer 的 rubric**（PASS/FAIL 依据）。这是语义升级，
+  解析器复用 #105 修过的 flag 卫生（词边界、重复 flag last-wins、空值清空）。
+- `--max-reworks` = `turnEndGuard.maxRetries`（v1 的 `--max-turns` 语义并入；kernel turn 上限单独配）。
+- `--budget` = `tokenBudget`。
+- 去掉 v1 的 `GOAL_STATUS` 自报协议（让 maker 自报达成 = 自批作业，正是要消除的）——达成与否由**独立
+  reviewer** 判，不由 maker 自陈。
+
+## 7. 开放决策（不在本设计内拍板）
+
+1. **要不要做成命令**：定位是「卖零件不卖命令」。example 05 已把模式作为零件交付；`/goal` v2 作为命令只是
+   dogfood 的便利封装，**可选**。若做，它应是「用现成 hook 拼好的一个预设组合」，而非内核新增。
+2. **reviewer 怎么看 maker 的工作**：真实编码场景喂 diff / 测试输出的 seam 如何取（需接 first-party tools 的
+   改动追踪或让 maker 显式 submit 验收物）。
+3. **relaunch / 解 HOLD**：本设计**不自动解 HOLD**——#111 明确「行业文章不给新性能数据」。relaunch 需 owner
+   拍板，且真正剩的成熟度缺口是 bidding-migration 验证（见 `docs/roadmap.md`、CLAUDE.md 成熟度三层），与本
+   设计正交。
+
+## 8. 验收（落地时）
+
+- maker-verifier loop 的纯逻辑单测（reviewer FAIL→强制返工→PASS→停；达 maxReworks 上限有界停止）——已由
+  `examples/05-maker-verifier-loop` 覆盖，命令化时移植/扩展。
+- `/goal` 命令解析单测复用并扩展 #105 的 goal.test.ts（`--success` 作 rubric 的端到端织入）。
+- 若接真 provider：一次真模型 dogfood，证明独立 reviewer 在称职模型下**确有**打回-返工发生（补上 v1 force-continue
+  三次 0 触发的差异化空洞）。

--- a/docs/10-goal-v2-design.md
+++ b/docs/10-goal-v2-design.md
@@ -101,6 +101,14 @@ tokenBudget/repeatedCallGuard 保险丝），是本设计的活 spike。
 2. **关掉 `tokenBudget` 的「递减收益」启发式**（`diminishingThreshold: 0`），只保留显式预算上限。递减检测按
    maker 每 turn 的 token delta 判「无进展」，但 maker-verifier loop 的实际进展发生在**回合外的 reviewer**、
    不计入 maker delta —— 简洁回合会被误判摆烂、在 reviewer 评判前 abort（`reason:"aborted"`）。
+3. **`turnEndGuard` 的 `timeoutMs` 要覆盖真 reviewer LLM 调用**。它是 event 类 hook，超时 **fail-open**——
+   续跑结果被丢弃、maker 直接 `done` 而没拿到 PASS（gate 被静默绕过），reviewer promise 还在后台跑。默认 30s
+   对真 provider 不够，按 reviewer 耗时给足。
+4. **reviewer 失败要显式 surface，别当普通 FAIL**。reviewer 子 session 以 `reason:"error"`/`"max_turns"`
+   结束（provider 5xx/401、坏 tool-call 循环）时，若仍读 `lastMessage` 把空/陈旧 verdict 当 FAIL，外层会以
+   `done`+`passed=false` 收场、掩盖**验证闸本身坏了**。必须先查 `summary.reason`，非 `done` 就 abort / 上报。
+5. **reviewer 的 token 在独立 session、不进 maker 的 `tokenBudget`**。要么对 reviewer 也挂一道 budget（聚合
+   上界 ≈ maker 预算 + (maxReworks+1) × reviewer 单次预算），要么共享用量记账——否则「硬预算」名不副实。
 
 ## 6. CLI 表面（复用 v1 解析 + #105 卫生）
 

--- a/docs/10-goal-v2-design.md
+++ b/docs/10-goal-v2-design.md
@@ -90,6 +90,18 @@ tokenBudget/repeatedCallGuard 保险丝），是本设计的活 spike。
 - **成本**：每次 review = 一次 sub-agent run = 真实 token。`maxReworks` + `tokenBudget` 共同封顶，避免 review
   本身烧穿预算。
 
+## 5b. 落地必踩的两个 wiring 坑（来自 example 05 + codex 交叉验证）
+
+把这套从零件拼出来时，有两处内核/插件交互必须显式处理，否则「有界 loop」会在未测路径上失效：
+
+1. **`maxContinuations` 要从 `maxReworks` 抬高**。内核在 fire `onContinuationCheck` **之前**先查
+   `maxContinuations`（默认 5）；turnEndGuard 每次 FAIL→force 算一次 continuation。若不抬高，`maxReworks ≥ 5`
+   会在最后一次评判 check 触发前就以 `reason:"max_continuations"` 退出，reviewer 永远等不到那次 PASS。
+   修法：`maxContinuations = maxReworks + 1`（+1 留给最终评判的那次 check）。
+2. **关掉 `tokenBudget` 的「递减收益」启发式**（`diminishingThreshold: 0`），只保留显式预算上限。递减检测按
+   maker 每 turn 的 token delta 判「无进展」，但 maker-verifier loop 的实际进展发生在**回合外的 reviewer**、
+   不计入 maker delta —— 简洁回合会被误判摆烂、在 reviewer 评判前 abort（`reason:"aborted"`）。
+
 ## 6. CLI 表面（复用 v1 解析 + #105 卫生）
 
 ```

--- a/examples/05-maker-verifier-loop/package.json
+++ b/examples/05-maker-verifier-loop/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@harness-pi-example/05-maker-verifier-loop",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Reference example: a maker-verifier loop assembled from existing hooks (turnEndGuard gate + independent reviewer AgentSession + tokenBudget/repeatedCallGuard fuses). Shows #111 'Loop Engineering substrate' — build the loop from parts, no bespoke /goal command. Doubles as a cross-package integration test.",
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "typecheck": "tsc -p . --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@harness-pi/core": "workspace:*",
+    "@harness-pi/plugins": "workspace:*",
+    "@earendil-works/pi-ai": "^0.74.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/examples/05-maker-verifier-loop/src/__tests__/maker-verifier.test.ts
+++ b/examples/05-maker-verifier-loop/src/__tests__/maker-verifier.test.ts
@@ -1,0 +1,70 @@
+/**
+ * 集成测试：证明用现成 hook 拼出的 maker-verifier loop **真能跑通**完整闭环——
+ * 独立 reviewer 打回首版 → turnEndGuard 强制返工 → 修复版被放行。纯 domain-free（toy submit + fake model）。
+ *
+ * 这是 #111「Loop Engineering substrate」的可执行佐证：loop 的护栏是零件、不是内置命令。
+ */
+import { describe, it, expect } from "vitest";
+import { createFakeModel } from "@harness-pi/core/testing";
+import { runMakerVerifierLoop } from "../maker-verifier.js";
+
+const V1_BUGGY = "def first(xs): return xs[0]";
+const V2_FIXED = "def first(xs): return xs[0] if xs else None";
+
+// usage 给真实量级：fake 的 ~0 token 会被 tokenBudget 的「递减收益」检测误判为无进展、提前熔断。
+const USAGE = { input: 600, output: 2000 };
+
+describe("maker-verifier loop（现成 hook 拼装）", () => {
+  it("独立 reviewer 打回首版 → 强制返工一次 → 修复版放行", async () => {
+    const makerModel = createFakeModel([
+      { content: [{ type: "toolCall", name: "submit", arguments: { solution: V1_BUGGY } }], stopReason: "toolUse", usage: USAGE },
+      { content: [{ type: "text", text: "Submitted. Done." }], usage: USAGE },
+      { content: [{ type: "toolCall", name: "submit", arguments: { solution: V2_FIXED } }], stopReason: "toolUse", usage: USAGE },
+      { content: [{ type: "text", text: "Fixed and resubmitted. Done." }], usage: USAGE },
+    ]);
+    const reviewerModel = createFakeModel([
+      { content: [{ type: "text", text: "FAIL: crashes on the empty list" }] },
+      { content: [{ type: "text", text: "PASS" }] },
+    ]);
+
+    const result = await runMakerVerifierLoop({
+      makerModel,
+      reviewerModel,
+      task: "Write first(xs) and submit it.",
+      stopCondition: "must handle the empty list",
+      maxReworks: 3,
+    });
+
+    expect(result.passed).toBe(true); // reviewer 最终放行
+    expect(result.reworks).toBe(1); // 恰好被强制返工一次
+    expect(result.reason).toBe("done"); // 正常停止（不是预算/上限兜底）
+    expect(result.finalSolution).toBe(V2_FIXED); // maker 确实改了解（v1 → v2）
+  });
+
+  it("达 maxReworks 上限仍 FAIL → 放行停止、passed=false、不无限转", async () => {
+    // reviewer 永远 FAIL；maker 每轮想停（纯文本）。maxReworks=2 → 强制 2 次后第 3 次 check 放行停止。
+    const makerModel = createFakeModel(
+      Array.from({ length: 4 }, () => ({
+        content: [{ type: "text" as const, text: "I think it's done." }],
+        usage: USAGE,
+      })),
+    );
+    const reviewerModel = createFakeModel(
+      Array.from({ length: 5 }, () => ({
+        content: [{ type: "text" as const, text: "FAIL: still not good enough" }],
+      })),
+    );
+
+    const result = await runMakerVerifierLoop({
+      makerModel,
+      reviewerModel,
+      task: "do the thing",
+      stopCondition: "impossible bar",
+      maxReworks: 2,
+    });
+
+    expect(result.passed).toBe(false); // 从未放行
+    expect(result.reworks).toBe(2); // 恰好强制到上限
+    expect(result.reason).toBe("done"); // 上限后放行停止——有界，不无限空转
+  });
+});

--- a/examples/05-maker-verifier-loop/src/__tests__/maker-verifier.test.ts
+++ b/examples/05-maker-verifier-loop/src/__tests__/maker-verifier.test.ts
@@ -11,16 +11,13 @@ import { runMakerVerifierLoop } from "../maker-verifier.js";
 const V1_BUGGY = "def first(xs): return xs[0]";
 const V2_FIXED = "def first(xs): return xs[0] if xs else None";
 
-// usage 给真实量级：fake 的 ~0 token 会被 tokenBudget 的「递减收益」检测误判为无进展、提前熔断。
-const USAGE = { input: 600, output: 2000 };
-
 describe("maker-verifier loop（现成 hook 拼装）", () => {
   it("独立 reviewer 打回首版 → 强制返工一次 → 修复版放行", async () => {
     const makerModel = createFakeModel([
-      { content: [{ type: "toolCall", name: "submit", arguments: { solution: V1_BUGGY } }], stopReason: "toolUse", usage: USAGE },
-      { content: [{ type: "text", text: "Submitted. Done." }], usage: USAGE },
-      { content: [{ type: "toolCall", name: "submit", arguments: { solution: V2_FIXED } }], stopReason: "toolUse", usage: USAGE },
-      { content: [{ type: "text", text: "Fixed and resubmitted. Done." }], usage: USAGE },
+      { content: [{ type: "toolCall", name: "submit", arguments: { solution: V1_BUGGY } }], stopReason: "toolUse" },
+      { content: [{ type: "text", text: "Submitted. Done." }] },
+      { content: [{ type: "toolCall", name: "submit", arguments: { solution: V2_FIXED } }], stopReason: "toolUse" },
+      { content: [{ type: "text", text: "Fixed and resubmitted. Done." }] },
     ]);
     const reviewerModel = createFakeModel([
       { content: [{ type: "text", text: "FAIL: crashes on the empty list" }] },
@@ -46,7 +43,6 @@ describe("maker-verifier loop（现成 hook 拼装）", () => {
     const makerModel = createFakeModel(
       Array.from({ length: 4 }, () => ({
         content: [{ type: "text" as const, text: "I think it's done." }],
-        usage: USAGE,
       })),
     );
     const reviewerModel = createFakeModel(
@@ -66,5 +62,27 @@ describe("maker-verifier loop（现成 hook 拼装）", () => {
     expect(result.passed).toBe(false); // 从未放行
     expect(result.reworks).toBe(2); // 恰好强制到上限
     expect(result.reason).toBe("done"); // 上限后放行停止——有界，不无限空转
+  });
+
+  it("maxReworks≥内核默认 maxContinuations(5) 时仍能等到最终 PASS（回归 codex P2-A）", async () => {
+    // 内核在 fire onContinuationCheck 前先查 maxContinuations。若不把它从 maxReworks 抬高，
+    // maxReworks=5 会在第 6 次 check 前以 max_continuations 退出、reviewer 等不到最后那次 PASS。
+    const makerModel = createFakeModel([]); // 每轮自动补文本响应（想停）→ 触发 check
+    const reviewerModel = createFakeModel([
+      ...Array.from({ length: 5 }, () => ({ content: [{ type: "text" as const, text: "FAIL: not yet" }] })),
+      { content: [{ type: "text" as const, text: "PASS" }] }, // 第 6 次 check 放行
+    ]);
+
+    const result = await runMakerVerifierLoop({
+      makerModel,
+      reviewerModel,
+      task: "do the thing",
+      stopCondition: "high bar",
+      maxReworks: 5,
+    });
+
+    expect(result.passed).toBe(true); // 第 6 次 check 拿到 PASS（没被 max_continuations 截断）
+    expect(result.reworks).toBe(5); // 强制返工 5 次
+    expect(result.reason).toBe("done");
   });
 });

--- a/examples/05-maker-verifier-loop/src/__tests__/maker-verifier.test.ts
+++ b/examples/05-maker-verifier-loop/src/__tests__/maker-verifier.test.ts
@@ -85,4 +85,24 @@ describe("maker-verifier loop（现成 hook 拼装）", () => {
     expect(result.reworks).toBe(5); // 强制返工 5 次
     expect(result.reason).toBe("done");
   });
+
+  it("reviewer 基础设施失败（provider 错误）→ maker abort、surface 出来、不掩盖为普通 FAIL（回归 codex P2）", async () => {
+    const makerModel = createFakeModel([
+      { content: [{ type: "toolCall", name: "submit", arguments: { solution: "x" } }], stopReason: "toolUse" },
+      { content: [{ type: "text", text: "Done." }] },
+    ]);
+    // reviewer 第一次 review 就 provider 错误（stream 抛）→ 子 session reason="error"。
+    const reviewerModel = createFakeModel([{ content: [], streamThrows: new Error("provider 500") }]);
+
+    const result = await runMakerVerifierLoop({
+      makerModel,
+      reviewerModel,
+      task: "do the thing",
+      stopCondition: "anything",
+      maxReworks: 3,
+    });
+
+    expect(result.gateError).toBeDefined(); // gate 失败显式 surface —— 不是 done+passed=false 掩盖
+    expect(result.passed).toBe(false);
+  });
 });

--- a/examples/05-maker-verifier-loop/src/index.ts
+++ b/examples/05-maker-verifier-loop/src/index.ts
@@ -1,0 +1,56 @@
+/**
+ * Example 05: maker-verifier loop —— 用现成 hook 拼一条「生成者 / 验证者分离」循环。
+ *
+ * 剧情（fake model 离线确定性演示）：
+ *   maker 写一个「取列表首元素」函数 → 先交了个崩在空列表上的版本 → 独立 reviewer 判 FAIL（指出
+ *   gap）→ turnEndGuard 回灌 gap、强制 maker 返工 → maker 补上空列表处理、重交 → reviewer 判 PASS
+ *   → loop 停。全程没有任何内置 `/goal` 命令，护栏全是 @harness-pi/plugins 现成件。
+ */
+import { createFakeModel } from "@harness-pi/core/testing";
+import { runMakerVerifierLoop } from "./maker-verifier.js";
+
+const V1_BUGGY = "def first(xs): return xs[0]";
+const V2_FIXED = "def first(xs): return xs[0] if xs else None";
+
+async function main(): Promise<void> {
+  // maker：先交崩版（v1）→ 被打回后交修复版（v2）。每次「想停」都以纯文本结束本回合 → 触发 turnEndGuard。
+  // usage 给真实量级（>500 token/轮）：否则 tokenBudget 的「递减收益」检测会把 fake 的 ~0 token 误判为
+  // 无进展、提前熔断（fake-model 假象）。真 provider 自带真实 usage，无需手设。
+  const usage = { input: 600, output: 2000 };
+  const makerModel = createFakeModel([
+    { content: [{ type: "toolCall", name: "submit", arguments: { solution: V1_BUGGY } }], stopReason: "toolUse", usage },
+    { content: [{ type: "text", text: "Submitted. I think it's done." }], usage },
+    { content: [{ type: "toolCall", name: "submit", arguments: { solution: V2_FIXED } }], stopReason: "toolUse", usage },
+    { content: [{ type: "text", text: "Fixed the empty-list case and resubmitted. Done." }], usage },
+  ]);
+
+  // reviewer：同一 model 实例，response 队列驱动两轮 review —— 第 1 轮 FAIL（指出 gap）、第 2 轮 PASS。
+  const reviewerModel = createFakeModel([
+    { content: [{ type: "text", text: "FAIL: crashes on the empty list instead of returning None" }] },
+    { content: [{ type: "text", text: "PASS" }] },
+  ]);
+
+  const result = await runMakerVerifierLoop({
+    makerModel,
+    reviewerModel,
+    task: "Write a Python function `first(xs)` that returns the first element of a list. Submit it for review.",
+    stopCondition: "the function must handle the empty list (return None instead of crashing)",
+    maxReworks: 3,
+  });
+
+  console.log("=== maker-verifier loop 结果 ===");
+  console.log(`maker 终态:        ${result.reason}`);
+  console.log(`reviewer 放行:     ${result.passed}`);
+  console.log(`被强制返工次数:    ${result.reworks}`);
+  console.log(`最终提交的解:      ${result.finalSolution}`);
+  console.log(
+    result.passed && result.reworks === 1
+      ? "\n✓ 独立 reviewer 打回了第一版、强制返工一次、第二版放行——maker-verifier 闭环成立。"
+      : "\n✗ 与预期剧情不符。",
+  );
+}
+
+main().catch((err) => {
+  console.error("[05-maker-verifier-loop] 失败:", err);
+  process.exit(1);
+});

--- a/examples/05-maker-verifier-loop/src/index.ts
+++ b/examples/05-maker-verifier-loop/src/index.ts
@@ -14,14 +14,11 @@ const V2_FIXED = "def first(xs): return xs[0] if xs else None";
 
 async function main(): Promise<void> {
   // maker：先交崩版（v1）→ 被打回后交修复版（v2）。每次「想停」都以纯文本结束本回合 → 触发 turnEndGuard。
-  // usage 给真实量级（>500 token/轮）：否则 tokenBudget 的「递减收益」检测会把 fake 的 ~0 token 误判为
-  // 无进展、提前熔断（fake-model 假象）。真 provider 自带真实 usage，无需手设。
-  const usage = { input: 600, output: 2000 };
   const makerModel = createFakeModel([
-    { content: [{ type: "toolCall", name: "submit", arguments: { solution: V1_BUGGY } }], stopReason: "toolUse", usage },
-    { content: [{ type: "text", text: "Submitted. I think it's done." }], usage },
-    { content: [{ type: "toolCall", name: "submit", arguments: { solution: V2_FIXED } }], stopReason: "toolUse", usage },
-    { content: [{ type: "text", text: "Fixed the empty-list case and resubmitted. Done." }], usage },
+    { content: [{ type: "toolCall", name: "submit", arguments: { solution: V1_BUGGY } }], stopReason: "toolUse" },
+    { content: [{ type: "text", text: "Submitted. I think it's done." }] },
+    { content: [{ type: "toolCall", name: "submit", arguments: { solution: V2_FIXED } }], stopReason: "toolUse" },
+    { content: [{ type: "text", text: "Fixed the empty-list case and resubmitted. Done." }] },
   ]);
 
   // reviewer：同一 model 实例，response 队列驱动两轮 review —— 第 1 轮 FAIL（指出 gap）、第 2 轮 PASS。

--- a/examples/05-maker-verifier-loop/src/maker-verifier.ts
+++ b/examples/05-maker-verifier-loop/src/maker-verifier.ts
@@ -42,6 +42,12 @@ export interface MakerVerifierResult {
   passed: boolean;
   /** maker 最后提交的解。 */
   finalSolution: string;
+  /**
+   * **验证闸本身**失败时的原因（reviewer provider 抛错 / 非正常终态）。set 即表示这条结果**不可信**
+   * ——不是「reviewer 说没过」，而是「reviewer 根本没判成」。与 passed=false 区分开，别把 gate 故障
+   * 当普通未达成掩盖。
+   */
+  gateError?: string;
 }
 
 export interface MakerVerifierOptions {
@@ -55,8 +61,17 @@ export interface MakerVerifierOptions {
   stopCondition: string;
   /** 最多强制返工几次（达上限仍 FAIL 则放行停止，绝不无限转）。默认 3。 */
   maxReworks?: number;
-  /** maker session 总 token 预算（硬保险丝）。默认 50_000。 */
+  /**
+   * **每一方** session 的 token 预算（硬保险丝）。默认 50_000。注意 reviewer 是独立 session，
+   * 其用量不计入 maker 的预算——故对 maker、对**每次** review 各挂一道 budget。聚合上界 ≈
+   * maker 预算 + (maxReworks + 1) × reviewer 单次预算（接真 provider 时据此估算总成本）。
+   */
   budgetTokens?: number;
+  /**
+   * 单次 reviewer LLM 调用的超时（毫秒）。默认 120_000。turnEndGuard 是 event 类 hook，超时会 fail-open
+   * 丢弃续跑结果 → gate 被静默绕过；真 reviewer provider 慢时必须给足，否则验证形同虚设。
+   */
+  reviewerTimeoutMs?: number;
 }
 
 /**
@@ -67,6 +82,7 @@ export async function runMakerVerifierLoop(
 ): Promise<MakerVerifierResult> {
   let lastSolution = "";
   let passed = false;
+  let gateError: string | undefined;
 
   // maker 提交解的 toy 工具（真实场景是 write/edit + 跑测试后提交 diff）。
   const submitTool: HarnessTool = {
@@ -80,6 +96,7 @@ export async function runMakerVerifierLoop(
   };
 
   const maxReworks = opts.maxReworks ?? 3;
+  const budget = opts.budgetTokens ?? 50_000;
   const maker = new AgentSession({
     model: opts.makerModel,
     tools: [submitTool],
@@ -89,12 +106,16 @@ export async function runMakerVerifierLoop(
     maxContinuations: maxReworks + 1,
     hooks: [
       // 停止闸：maker 想停 → 跑独立 reviewer → FAIL 则回灌 gap 强制返工、PASS 则放行。
+      // timeoutMs 必须覆盖真 reviewer provider 的耗时——turnEndGuard 是 event 类、超时 fail-open 会丢弃
+      // 续跑结果让 gate 被静默绕过（默认 30s 对真 LLM 不够）。
       turnEndGuard({
         maxRetries: maxReworks,
-        check: async () => {
-          // 独立 reviewer sub-agent：全新 AgentSession、不同 system prompt、无 tools（不能改代码）。
+        timeoutMs: opts.reviewerTimeoutMs ?? 120_000,
+        check: async (ctx) => {
+          // 独立 reviewer sub-agent：全新 AgentSession、不同 system prompt、无 edit/write 工具（不能改代码）。
           // 复用同一个 reviewerModel 实例 → fake model 的 response 队列在多轮 review 间推进
-          //（真 provider 则是同一模型每次对当前 solution 重新判断）。
+          //（真 provider 则是同一模型每次对当前 solution 重新判断）。挂自己的 tokenBudget 封住单次 review 成本
+          // （reviewer 在独立 session、用量不进 maker 预算）。
           const reviewer = new AgentSession({
             model: opts.reviewerModel,
             tools: [],
@@ -102,10 +123,27 @@ export async function runMakerVerifierLoop(
               `You are a strict, independent reviewer. You cannot edit code. ` +
               `Stop condition: ${opts.stopCondition}. ` +
               `Reply with exactly "PASS" or "FAIL: <one-line gap>".`,
+            hooks: [tokenBudget({ budget, diminishingThreshold: 0 })],
           });
-          const summary = await reviewer.run(
-            `Review this submitted solution:\n${lastSolution || "(nothing submitted yet)"}`,
-          );
+          // reviewer 基础设施失败（provider 抛错 / 非正常终态）→ 验证闸本身坏了。**别**把空/陈旧 verdict
+          // 当普通 FAIL 掩盖（那会让外层以 done+passed=false 收场、看不出 gate 失效）。两种失败都接住：
+          // ① reviewer.run 抛（stream 同步抛被内核 fail-open 后仍可能冒泡）；② 返回非 done 终态。
+          // 经 gateError 显式 surface（ctx.abort 尽力而为，但从 continuation-check 内未必改写终态）。
+          let summary;
+          try {
+            summary = await reviewer.run(
+              `Review this submitted solution:\n${lastSolution || "(nothing submitted yet)"}`,
+            );
+          } catch (err) {
+            gateError = `reviewer threw: ${err instanceof Error ? err.message : String(err)}`;
+            ctx.abort(gateError);
+            return { ok: true };
+          }
+          if (summary.reason !== "done") {
+            gateError = `reviewer failed to produce a verdict (reviewer reason=${summary.reason})`;
+            ctx.abort(gateError);
+            return { ok: true };
+          }
           const verdict = assistantText(summary.lastMessage);
           if (/^\s*PASS\b/i.test(verdict)) {
             passed = true;
@@ -120,7 +158,7 @@ export async function runMakerVerifierLoop(
       // 「无进展」，但 maker-verifier loop 的实际进展发生在**回合外的 reviewer**、不计入 maker delta，简洁
       // 回合会被误判为摆烂、在 reviewer 评判前就 abort。这里只保留**显式预算上限**这一条硬闸。
       // repeatedCallGuard 不内置 abort，在 onRepeat 里 ctx.abort 当熔断（domain-free 设计，由调用方组合）。
-      tokenBudget({ budget: opts.budgetTokens ?? 50_000, diminishingThreshold: 0 }),
+      tokenBudget({ budget, diminishingThreshold: 0 }),
       repeatedCallGuard({
         threshold: 4,
         onRepeat: (ctx, p) =>
@@ -132,5 +170,12 @@ export async function runMakerVerifierLoop(
   const summary = await maker.run(opts.task);
   // reworks = 内核记录的强制续跑次数（turnEndGuard FAIL→force）。比手数 check-FAIL 更准：
   // 达 maxRetries 上限那次「放行停止」的 FAIL 不算返工，continuations 自然不计它。
-  return { reason: summary.reason, reworks: summary.continuations, passed, finalSolution: lastSolution };
+  const result: MakerVerifierResult = {
+    reason: summary.reason,
+    reworks: summary.continuations,
+    passed,
+    finalSolution: lastSolution,
+  };
+  if (gateError !== undefined) result.gateError = gateError;
+  return result;
 }

--- a/examples/05-maker-verifier-loop/src/maker-verifier.ts
+++ b/examples/05-maker-verifier-loop/src/maker-verifier.ts
@@ -1,0 +1,128 @@
+/**
+ * maker-verifier loop —— 用 harness-pi **现成 hook** 拼出的「生成者 / 验证者分离」循环。
+ *
+ * 这不是一条内置 `/goal` 命令，而是从零件装出来的循环——#111「Loop Engineering substrate
+ * （卖 hook 零件库，不卖命令）」的活样本。一条防摆烂的 loop 真正值钱的零件是 **maker-verifier
+ * 分离**（"让作者别批改自己的作业"，reviewer 只回 PASS/FAIL 逼返工），而它全部能用现成件拼出来：
+ *
+ *   - **maker**：一个干活的 `AgentSession`（这里用 toy `submit` 工具代表「产出解」；真实场景是
+ *     write/edit + 跑测试）。
+ *   - **停止闸 = `turnEndGuard`**：maker 想停时，跑一个**独立 reviewer**判 PASS/FAIL；FAIL 就把
+ *     gap 作为阻断消息回灌、强制 maker 返工。验证发生在**回合之外**，结构上绕开了「in-loop judge
+ *     打断生产性回合」的老问题（#100 移除 progressVerifier 的根因）。
+ *   - **reviewer**：一个**全新 `AgentSession`**——不同 system prompt、**无任何 tools**（不能改代码），
+ *     只读 maker 提交的 solution，回 `"PASS"` / `"FAIL: <gap>"`。
+ *   - **硬保险丝**：`tokenBudget`（总预算）+ `repeatedCallGuard`（无进展熔断）——loop 不会无限空转。
+ *
+ * ⚠️ 设计要点（修正一个常见误解）：强制验证闸应放在 `turnEndGuard.check` 里跑 reviewer，**不是**把
+ * `subAgentTool` 丢给 maker 让它「自觉」调——后者是 maker **主动**委派子任务的工具，验证会变成可选、
+ * 称职模型也可能跳过。要把验证做成**强制 gate**，就得挂在 maker 想停的那一刻（turnEndGuard）。
+ *
+ * 全部用 fake model 离线确定性演示；真实接入只需把 makerModel / reviewerModel 换成真 provider。
+ */
+import { AgentSession, Type, type HarnessTool, type Message } from "@harness-pi/core";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { turnEndGuard, tokenBudget, repeatedCallGuard } from "@harness-pi/plugins";
+
+/** 取 assistant 消息纯文本（reviewer 的 verdict 是纯文本）。 */
+function assistantText(m: Message | undefined): string {
+  if (!m) return "";
+  if (typeof m.content === "string") return m.content;
+  return m.content
+    .map((b) => ("text" in b && typeof b.text === "string" ? b.text : ""))
+    .join("");
+}
+
+export interface MakerVerifierResult {
+  /** maker session 终态（reviewer 放行 / 达返工上限 / 预算耗尽 等）。 */
+  reason: string;
+  /** 被 reviewer FAIL 强制返工的次数。 */
+  reworks: number;
+  /** reviewer 最终是否放行（false = 达返工上限仍未过、放行停止）。 */
+  passed: boolean;
+  /** maker 最后提交的解。 */
+  finalSolution: string;
+}
+
+export interface MakerVerifierOptions {
+  /** maker（干活方）的 model。 */
+  makerModel: Model<Api>;
+  /** reviewer（独立验证方）的 model——与 maker 不同实例、不同 system prompt。 */
+  reviewerModel: Model<Api>;
+  /** maker 要完成的任务。 */
+  task: string;
+  /** 验收标准（注入 reviewer 的 system prompt，作为 PASS/FAIL 依据）。 */
+  stopCondition: string;
+  /** 最多强制返工几次（达上限仍 FAIL 则放行停止，绝不无限转）。默认 3。 */
+  maxReworks?: number;
+  /** maker session 总 token 预算（硬保险丝）。默认 50_000。 */
+  budgetTokens?: number;
+}
+
+/**
+ * 跑一条 maker-verifier loop，返回循环结果。所有护栏都是 `@harness-pi/plugins` 现成 hook。
+ */
+export async function runMakerVerifierLoop(
+  opts: MakerVerifierOptions,
+): Promise<MakerVerifierResult> {
+  let lastSolution = "";
+  let passed = false;
+
+  // maker 提交解的 toy 工具（真实场景是 write/edit + 跑测试后提交 diff）。
+  const submitTool: HarnessTool = {
+    name: "submit",
+    description: "Submit your current solution for independent review.",
+    parameters: Type.Object({ solution: Type.String({ description: "the solution text" }) }),
+    async execute(args) {
+      lastSolution = String((args as { solution: string }).solution);
+      return { content: [{ type: "text", text: "submitted for review" }] };
+    },
+  };
+
+  const maker = new AgentSession({
+    model: opts.makerModel,
+    tools: [submitTool],
+    hooks: [
+      // 停止闸：maker 想停 → 跑独立 reviewer → FAIL 则回灌 gap 强制返工、PASS 则放行。
+      turnEndGuard({
+        maxRetries: opts.maxReworks ?? 3,
+        check: async () => {
+          // 独立 reviewer sub-agent：全新 AgentSession、不同 system prompt、无 tools（不能改代码）。
+          // 复用同一个 reviewerModel 实例 → fake model 的 response 队列在多轮 review 间推进
+          //（真 provider 则是同一模型每次对当前 solution 重新判断）。
+          const reviewer = new AgentSession({
+            model: opts.reviewerModel,
+            tools: [],
+            systemPrompt:
+              `You are a strict, independent reviewer. You cannot edit code. ` +
+              `Stop condition: ${opts.stopCondition}. ` +
+              `Reply with exactly "PASS" or "FAIL: <one-line gap>".`,
+          });
+          const summary = await reviewer.run(
+            `Review this submitted solution:\n${lastSolution || "(nothing submitted yet)"}`,
+          );
+          const verdict = assistantText(summary.lastMessage);
+          if (/^\s*PASS\b/i.test(verdict)) {
+            passed = true;
+            return { ok: true };
+          }
+          const gap = verdict.replace(/^\s*FAIL:?\s*/i, "").trim() || "stop condition not met";
+          return { ok: false, message: `Reviewer says FAIL: ${gap}. Revise your solution and resubmit.` };
+        },
+      }),
+      // 硬保险丝：总预算 + 无进展（重复同一 tool call）熔断 —— 防摆烂、防空转。
+      // repeatedCallGuard 不内置 abort，在 onRepeat 里 ctx.abort 当熔断（domain-free 设计，由调用方组合）。
+      tokenBudget({ budget: opts.budgetTokens ?? 50_000 }),
+      repeatedCallGuard({
+        threshold: 4,
+        onRepeat: (ctx, p) =>
+          ctx.abort(`repeated-call-guard: ${p.tool} 重复 ${p.count} 次无进展，熔断`),
+      }),
+    ],
+  });
+
+  const summary = await maker.run(opts.task);
+  // reworks = 内核记录的强制续跑次数（turnEndGuard FAIL→force）。比手数 check-FAIL 更准：
+  // 达 maxRetries 上限那次「放行停止」的 FAIL 不算返工，continuations 自然不计它。
+  return { reason: summary.reason, reworks: summary.continuations, passed, finalSolution: lastSolution };
+}

--- a/examples/05-maker-verifier-loop/src/maker-verifier.ts
+++ b/examples/05-maker-verifier-loop/src/maker-verifier.ts
@@ -79,13 +79,18 @@ export async function runMakerVerifierLoop(
     },
   };
 
+  const maxReworks = opts.maxReworks ?? 3;
   const maker = new AgentSession({
     model: opts.makerModel,
     tools: [submitTool],
+    // 内核在 fire onContinuationCheck **前**先查 maxContinuations（默认 5）。turnEndGuard 每次 FAIL→force
+    // 算一次 continuation，所以 maxContinuations 必须 > maxReworks，否则 maxReworks≥5 时内核会先以
+    // max_continuations 退出、reviewer 等不到最后那次 PASS/exhaust。留 +1 给最终评判的那次 check。
+    maxContinuations: maxReworks + 1,
     hooks: [
       // 停止闸：maker 想停 → 跑独立 reviewer → FAIL 则回灌 gap 强制返工、PASS 则放行。
       turnEndGuard({
-        maxRetries: opts.maxReworks ?? 3,
+        maxRetries: maxReworks,
         check: async () => {
           // 独立 reviewer sub-agent：全新 AgentSession、不同 system prompt、无 tools（不能改代码）。
           // 复用同一个 reviewerModel 实例 → fake model 的 response 队列在多轮 review 间推进
@@ -111,8 +116,11 @@ export async function runMakerVerifierLoop(
         },
       }),
       // 硬保险丝：总预算 + 无进展（重复同一 tool call）熔断 —— 防摆烂、防空转。
+      // diminishingThreshold:0 关掉 tokenBudget 的「递减收益」启发式：它按 maker 每 turn 的 token delta 判
+      // 「无进展」，但 maker-verifier loop 的实际进展发生在**回合外的 reviewer**、不计入 maker delta，简洁
+      // 回合会被误判为摆烂、在 reviewer 评判前就 abort。这里只保留**显式预算上限**这一条硬闸。
       // repeatedCallGuard 不内置 abort，在 onRepeat 里 ctx.abort 当熔断（domain-free 设计，由调用方组合）。
-      tokenBudget({ budget: opts.budgetTokens ?? 50_000 }),
+      tokenBudget({ budget: opts.budgetTokens ?? 50_000, diminishingThreshold: 0 }),
       repeatedCallGuard({
         threshold: 4,
         onRepeat: (ctx, p) =>

--- a/examples/05-maker-verifier-loop/tsconfig.json
+++ b/examples/05-maker-verifier-loop/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,31 @@ importers:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@22.19.19)
 
+  examples/05-maker-verifier-loop:
+    dependencies:
+      '@earendil-works/pi-ai':
+        specifier: ^0.74.2
+        version: 0.74.2(ws@8.21.0)(zod@3.25.76)
+      '@harness-pi/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@harness-pi/plugins':
+        specifier: workspace:*
+        version: link:../../packages/plugins
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.19
+      tsx:
+        specifier: ^4.0.0
+        version: 4.22.3
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.19.19)
+
   packages/adapters:
     dependencies:
       '@earendil-works/pi-ai':


### PR DESCRIPTION
#111 三件可执行后续：① README Loop Engineering 定位段（映射表经核验去掉 verify-gate/worktree/review-gate 三处夸大）；② examples/05-maker-verifier-loop 用现成 hook 拼出的 maker-verifier loop（=/goal v2 spike，含测试）；③ docs/10-goal-v2-design.md 设计稿（闸放 turnEndGuard.check 跑独立 reviewer，非 subAgentTool 自觉调）。Refs #111